### PR TITLE
fix(orbit): auto-proceed to evolve after ship regardless of CI

### DIFF
--- a/commands/orbit.md
+++ b/commands/orbit.md
@@ -343,17 +343,33 @@ EOF
 ```bash
 # Check if gh is available and CI is configured
 if command -v gh &>/dev/null && gh pr checks <PR_NUMBER> 2>/dev/null | grep -q .; then
-  gh pr checks <PR_NUMBER> --watch
-  CI_STATUS=$?
+  CI_RETRY=0
+  CI_MAX_RETRIES=2
+  while [ $CI_RETRY -le $CI_MAX_RETRIES ]; do
+    gh pr checks <PR_NUMBER> --watch
+    if [ $? -eq 0 ]; then
+      CI_STATUS="PASS"
+      break
+    fi
+    CI_RETRY=$((CI_RETRY + 1))
+    if [ $CI_RETRY -le $CI_MAX_RETRIES ]; then
+      # Diagnose and fix automatically, then re-check
+      echo "CI failed (attempt $CI_RETRY/$CI_MAX_RETRIES) — diagnosing and fixing..."
+    else
+      CI_STATUS="FAIL"
+    fi
+  done
 else
   # No CI configured (e.g., CodeCommit without gh Actions) — skip
-  CI_STATUS=0
+  CI_STATUS="N/A"
   CI_NOTE="No CI configured — skipped"
 fi
 ```
 
-- CI fails → diagnose and fix automatically. Do NOT block orbit progression.
+- CI fails → diagnose and fix automatically, retry up to 2 times.
+- All retries exhausted → record `CI: FAIL`, proceed to Step 7 (evolve will analyze the failure pattern).
 - CI absent / `gh` not available → set `CI: N/A`, proceed immediately to Step 7.
+- Do NOT block orbit progression regardless of CI outcome.
 
 **Ship Report:**
 ```

--- a/commands/orbit.md
+++ b/commands/orbit.md
@@ -338,18 +338,35 @@ EOF
 )"
 ```
 
-**6d. CI:** `gh pr checks <PR_NUMBER> --watch` — diagnose and fix automatically on failure.
+**6d. CI:** Check CI status — do not block orbit on CI:
+
+```bash
+# Check if gh is available and CI is configured
+if command -v gh &>/dev/null && gh pr checks <PR_NUMBER> 2>/dev/null | grep -q .; then
+  gh pr checks <PR_NUMBER> --watch
+  CI_STATUS=$?
+else
+  # No CI configured (e.g., CodeCommit without gh Actions) — skip
+  CI_STATUS=0
+  CI_NOTE="No CI configured — skipped"
+fi
+```
+
+- CI fails → diagnose and fix automatically. Do NOT block orbit progression.
+- CI absent / `gh` not available → set `CI: N/A`, proceed immediately to Step 7.
 
 **Ship Report:**
 ```
 ## Ship Report
 - Spec: SPEC-{timestamp} ({goal_slug})
 - PR: <URL>
-- CI: PASS/FAIL
+- CI: PASS/FAIL/N/A
 - Ready to merge: YES/NO
 ```
 
 Push `{"phase": "ship", "status": "complete"}` to `phase_history`.
+
+> **Orbit context:** After pushing ship to `phase_history`, **immediately proceed to Step 7 (Orbit Complete + Evolve)**. Do NOT stop here.
 
 ---
 
@@ -384,7 +401,7 @@ Update state: `"phase": "complete"`, `"status": "complete"`.
 
 ### Step 7a: Evolve (Auto)
 
-PR created + CI green → run `/evolve` automatically:
+**Always run** — regardless of CI status (PASS / FAIL / N/A). Evolve on every completed orbit:
 1. Read `$HARNESS_DIR/obs/` session logs
 2. Read `$HARNESS_DIR/metrics.json` + `evolution.jsonl`
 3. Detect failure patterns, weak tools, weak file types

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -89,7 +89,11 @@ If CI fails, diagnose and fix. Do not ask the user to fix CI — handle it.
 - Action needed: <if any>
 ```
 
-After the Ship Report, suggest: **"One loop complete. Run `/evolve` to analyze this session's observations and improve skills for the next cycle."**
+**If running inside `/orbit` pipeline** (a `PIPELINE-*.json` with `"status": "running"` exists):
+- Do NOT stop here. Return control to orbit — it will run Step 7 (Evolve) automatically.
+
+**If running standalone** (no active orbit pipeline):
+- Suggest: **"One loop complete. Run `/evolve` to analyze this session's observations and improve skills for the next cycle."**
 
 ## Red Flags
 - Shipping without a PASS check report


### PR DESCRIPTION
## Summary
orbit 파이프라인이 ship 단계 이후 evolve로 자동 진행되지 않는 문제 수정.

## Root Cause
두 가지 버그가 있었음:
1. `orbit.md` Step 6d — `gh pr checks --watch`가 CI/gh 없는 환경(CodeCommit 등)에서 무한 블로킹
2. `ship.md` Step 5 — orbit 컨텍스트에서도 "suggest /evolve" 로 응답 종료, orbit Step 7로 미복귀

## Changes
- `commands/orbit.md`: CI 체크를 조건부로 변경 — gh/CI 없으면 N/A로 처리 후 즉시 Step 7 진행
- `commands/orbit.md`: Step 6 완료 후 Step 7 즉시 진행 명시 (Do NOT stop here)
- `commands/orbit.md`: Step 7a evolve — "PR+CI green" 조건 제거, 모든 orbit 완료 시 항상 실행
- `commands/ship.md`: orbit 파이프라인 감지 시 evolve 제안 대신 orbit으로 제어 반환

## Acceptance Criteria
- AC1: ✅ CI 없는 환경에서 orbit이 ship → evolve까지 자동 진행됨
- AC2: ✅ ship을 standalone으로 실행 시 기존 동작(suggest /evolve) 유지됨
- AC3: ✅ evolve가 CI 상태와 무관하게 항상 실행됨