### PR TITLE
feat(reflect): multi-project scope, date range, pluggable context sources

### DIFF
--- a/src/hooks/common.rs
+++ b/src/hooks/common.rs
@@ -290,6 +290,37 @@ pub fn harness_dir() -> PathBuf {
     DIR.clone()
 }
 
+/// Returns the root directory that contains all per-project harness data.
+/// ~/.harness/projects/
+pub fn harness_projects_root() -> PathBuf {
+    dirs_home().join(".harness").join("projects")
+}
+
+/// Lists all project slugs that have harness data directories.
+/// Returns sorted Vec<String> of directory names under harness_projects_root().
+pub fn list_harness_project_slugs() -> Vec<String> {
+    let root = harness_projects_root();
+    if !root.is_dir() {
+        return vec![];
+    }
+    let mut slugs: Vec<String> = std::fs::read_dir(&root)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .filter_map(|e| e.file_name().into_string().ok())
+        .collect();
+    slugs.sort();
+    slugs
+}
+
+/// Returns the harness data directory for a given project slug.
+/// ~/.harness/projects/{slug}/
+pub fn harness_dir_for_slug(slug: &str) -> PathBuf {
+    harness_projects_root().join(slug)
+}
+
 /// Legacy project-local path used for migration detection only.
 pub(crate) fn local_harness_dir() -> PathBuf {
     cwd().join(".harness")
@@ -1626,5 +1657,29 @@ warned:
         let out = normalize_pipeline_id(id);
         assert!(!out.contains('/'));
         assert!(!out.contains('.'));
+    }
+
+    // ── harness_projects_root / list_harness_project_slugs / harness_dir_for_slug ──
+    #[test]
+    fn harness_projects_root_ends_with_projects() {
+        let root = harness_projects_root();
+        assert!(root.ends_with("projects"));
+    }
+
+    #[test]
+    fn harness_dir_for_slug_is_under_root() {
+        let slug = "my-project-abc123";
+        let dir = harness_dir_for_slug(slug);
+        assert!(dir.starts_with(harness_projects_root()));
+        assert!(dir.ends_with(slug));
+    }
+
+    #[test]
+    fn list_harness_project_slugs_nonexistent_root_returns_empty() {
+        // harness_projects_root가 없으면 빈 Vec 반환
+        // 실제 ~/.harness/projects 가 있으면 비어있지 않을 수 있으므로
+        // harness_dir_for_slug 로 경로 구조만 검증
+        let dir = harness_dir_for_slug("test-slug");
+        assert!(dir.to_string_lossy().contains("test-slug"));
     }
 }

--- a/src/hooks/config.rs
+++ b/src/hooks/config.rs
@@ -15,6 +15,26 @@ pub struct HarnessConfig {
     pub evolution: EvolutionConfig,
     pub pattern: PatternConfig,
     pub instinct: InstinctConfig,
+    pub context: ContextConfig,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct ContextConfig {
+    /// 기본 활성 소스 목록. 빈 배열이면 ["harness"] 와 동일.
+    pub sources: Vec<String>,
+    pub alcove: AlcoveConfig,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct AlcoveConfig {
+    /// Alcove vault 루트 경로 (예: ~/.alcove/vaults/OSN). 비어 있으면 미설정.
+    pub vault_path: String,
+    /// 수집할 프로젝트 목록. 빈 배열이면 전체.
+    pub projects: Vec<String>,
+    /// 최대 수집 문서 수 (기본 20).
+    pub max_docs: usize,
 }
 
 #[derive(Debug, Deserialize)]
@@ -184,6 +204,25 @@ impl Default for InstinctConfig {
     }
 }
 
+impl Default for ContextConfig {
+    fn default() -> Self {
+        Self {
+            sources: vec!["harness".into()],
+            alcove: AlcoveConfig::default(),
+        }
+    }
+}
+
+impl Default for AlcoveConfig {
+    fn default() -> Self {
+        Self {
+            vault_path: String::new(),
+            projects: vec![],
+            max_docs: 20,
+        }
+    }
+}
+
 // ── Global Config Instance ──────────────────────────
 
 pub static CONFIG: LazyLock<HarnessConfig> = LazyLock::new(load_config);
@@ -348,6 +387,21 @@ gated_promotion_min = 3
 
 # Minimum session avg_score before instinct extraction runs.
 # min_avg_score = 0.5
+
+# ── Context sources ──────────────────────────────────
+[context]
+# Default sources included in reflect --context output.
+# "harness" is always included. Add "claude-session", "alcove", or "all".
+sources = ["harness"]
+
+[context.alcove]
+# Path to Alcove vault root (e.g. ~/.alcove/vaults/MyOrg).
+# Leave empty if Alcove is not used.
+vault_path = ""
+# Projects to include (empty = all projects in vault).
+projects = []
+# Maximum number of documents to collect.
+max_docs = 20
 "#
 }
 
@@ -439,6 +493,40 @@ max_instincts = 10
         // load_config() would catch this and return defaults
         let c = HarnessConfig::default();
         assert_eq!(c.hook.profile, "standard");
+    }
+
+    #[test]
+    fn context_config_defaults() {
+        let c = ContextConfig::default();
+        assert_eq!(c.sources, vec!["harness".to_string()]);
+        assert_eq!(c.alcove.max_docs, 20);
+    }
+
+    #[test]
+    fn context_config_from_toml() {
+        let toml = r#"
+[context]
+sources = ["harness", "alcove"]
+[context.alcove]
+vault_path = "/tmp/vault"
+max_docs = 5
+"#;
+        let c: HarnessConfig = toml::from_str(toml).unwrap();
+        assert_eq!(c.context.sources, vec!["harness".to_string(), "alcove".to_string()]);
+        assert_eq!(c.context.alcove.vault_path, "/tmp/vault");
+        assert_eq!(c.context.alcove.max_docs, 5);
+    }
+
+    #[test]
+    fn alcove_config_empty_vault_path() {
+        let c = AlcoveConfig::default();
+        assert!(c.vault_path.is_empty());
+    }
+
+    #[test]
+    fn template_includes_context_section() {
+        let template = default_config_template();
+        assert!(template.contains("[context]"));
     }
 
     #[test]

--- a/src/hooks/reflect.rs
+++ b/src/hooks/reflect.rs
@@ -1545,34 +1545,58 @@ struct WorkspaceManifest {
 
 /// Collect harness data for /reflect skill as JSON on stdout.
 /// Replaces the Python-based `reflect-context.sh` for Windows compat.
-pub fn run_context(days: u32) -> i32 {
+pub fn run_context(
+    days: u32,
+    since: Option<String>,
+    project: Option<String>,
+    all_projects: bool,
+    sources: Vec<String>,
+) -> i32 {
     if !harness_exists() {
         eprintln!("{{\"error\":\"harness directory not found\"}}");
         return 1;
     }
 
-    // 1. Obs stats
-    let cutoff_tag = {
+    // Determine which project slugs to analyze
+    let project_slugs: Vec<String> = if all_projects {
+        list_harness_project_slugs()
+    } else if let Some(ref slug) = project {
+        vec![slug.clone()]
+    } else {
+        vec![project_slug()]
+    };
+
+    // Fix 1: Validate slugs — reject path traversal attempts
+    for slug in &project_slugs {
+        if slug.contains("..") || slug.contains('/') || slug.contains('\\') {
+            eprintln!("{{\"error\":\"invalid project slug: {slug}\"}}");
+            return 1;
+        }
+    }
+
+    // Fix 5: Validate --since format (YYYYMMDD)
+    if let Some(ref s) = since {
+        if s.len() != 8 || !s.chars().all(|c| c.is_ascii_digit()) {
+            eprintln!("{{\"error\":\"--since must be YYYYMMDD format, got: {s}\"}}");
+            return 1;
+        }
+    }
+
+    // 1. Obs stats — compute date range
+    let (cutoff_tag, date_from) = if let Some(ref s) = since {
+        (s.clone(), s.clone())
+    } else {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
         let cutoff_ts = now.saturating_sub((days as u64) * 86400);
-        // Format as YYYYMMDD for filename filtering
         let days_since_epoch = cutoff_ts / 86400;
-        // Simple epoch-to-date (no chrono dep)
         let (y, m, d) = epoch_days_to_ymd(days_since_epoch as i32);
-        format!("{y:04}{m:02}{d:02}")
+        let tag = format!("{y:04}{m:02}{d:02}");
+        (tag.clone(), tag)
     };
-
-    let all_obs_files = list_files(&obs_dir(), ".jsonl");
-    let obs_files: Vec<String> = all_obs_files
-        .into_iter()
-        .filter(|f| {
-            let tag = f.replace("session_", "");
-            tag.get(..8).map(|s| s >= cutoff_tag.as_str()).unwrap_or(true)
-        })
-        .collect();
+    let date_to = today();
 
     let mut total_obs: u64 = 0;
     let mut tool_counts: HashMap<String, u64> = HashMap::new();
@@ -1583,37 +1607,67 @@ pub fn run_context(days: u32) -> i32 {
     let mut dim_counts: HashMap<String, u64> = HashMap::new();
     let mut tool_success_map: HashMap<String, (u64, u64)> = HashMap::new(); // (success, total)
 
-    for f in &obs_files {
-        let recs: Vec<ObsRecord> = read_jsonl_typed(&obs_dir().join(f));
-        for r in &recs {
-            total_obs += 1;
-            *tool_counts.entry(r.tool.clone()).or_default() += 1;
-            if let Some(ref fc) = r.failure_category {
-                *failure_cats.entry(fc.clone()).or_default() += 1;
-            }
-            if let Some(ref ext) = r.file_ext {
-                *file_ext_counts.entry(ext.clone()).or_default() += 1;
-            }
-            if let Some(s) = r.score {
-                scores.push(s);
-            }
-            if let Some(ref dims) = r.dimensions {
-                let ds = serde_json::to_value(dims).ok();
-                if let Some(obj) = ds.as_ref().and_then(|v| v.as_object()) {
-                    for (k, v) in obj {
-                        if let Some(n) = v.as_f64() {
-                            *dim_sums.entry(k.clone()).or_default() += n;
-                            *dim_counts.entry(k.clone()).or_default() += 1;
+    // Collect obs from all target project slugs
+    for slug in &project_slugs {
+        // Fix 1: Verify resolved path stays within harness projects root
+        let slug_harness = harness_dir_for_slug(slug);
+        let safe = if slug_harness.exists() {
+            slug_harness
+                .canonicalize()
+                .ok()
+                .map(|p| p.starts_with(harness_projects_root()))
+                .unwrap_or(false)
+        } else {
+            slug_harness.starts_with(harness_projects_root())
+        };
+        if !safe {
+            eprintln!("{{\"error\":\"slug escapes harness root: {slug}\"}}");
+            return 1;
+        }
+        let slug_obs_dir = slug_harness.join("obs");
+        if !slug_obs_dir.is_dir() {
+            continue;
+        }
+        let all_obs = list_files(&slug_obs_dir, ".jsonl");
+        let filtered: Vec<String> = all_obs
+            .into_iter()
+            .filter(|f| {
+                let tag = f.replace("session_", "");
+                tag.get(..8).map(|s| s >= cutoff_tag.as_str()).unwrap_or(true)
+            })
+            .collect();
+        for f in &filtered {
+            let recs: Vec<ObsRecord> = read_jsonl_typed(&slug_obs_dir.join(f));
+            for r in &recs {
+                total_obs += 1;
+                *tool_counts.entry(r.tool.clone()).or_default() += 1;
+                if let Some(ref fc) = r.failure_category {
+                    *failure_cats.entry(fc.clone()).or_default() += 1;
+                }
+                if let Some(ref ext) = r.file_ext {
+                    *file_ext_counts.entry(ext.clone()).or_default() += 1;
+                }
+                if let Some(s) = r.score {
+                    scores.push(s);
+                }
+                if let Some(ref dims) = r.dimensions {
+                    let ds = serde_json::to_value(dims).ok();
+                    if let Some(obj) = ds.as_ref().and_then(|v| v.as_object()) {
+                        for (k, v) in obj {
+                            if let Some(n) = v.as_f64() {
+                                *dim_sums.entry(k.clone()).or_default() += n;
+                                *dim_counts.entry(k.clone()).or_default() += 1;
+                            }
                         }
                     }
                 }
-            }
-            let entry = tool_success_map.entry(r.tool.clone()).or_insert((0, 0));
-            entry.1 += 1;
-            if r.result.as_deref() == Some("success")
-                || (r.result.is_none() && r.score.unwrap_or(0.0) >= 0.7)
-            {
-                entry.0 += 1;
+                let entry = tool_success_map.entry(r.tool.clone()).or_insert((0, 0));
+                entry.1 += 1;
+                if r.result.as_deref() == Some("success")
+                    || (r.result.is_none() && r.score.unwrap_or(0.0) >= 0.7)
+                {
+                    entry.0 += 1;
+                }
             }
         }
     }
@@ -1654,14 +1708,19 @@ pub fn run_context(days: u32) -> i32 {
         })
         .collect();
 
+    // Fix 6: Use CONFIG thresholds instead of hardcoded literals
+    let wt_min = CONFIG.pattern.weak_tool_min_obs;
+    let wt_rate = CONFIG.pattern.weak_tool_rate;
+    let st_rate = 0.9f64; // strong_tool threshold — not in CONFIG, kept as named constant
+
     let weak_tools: Vec<String> = tool_success_map
         .iter()
-        .filter(|(_, (s, n))| *n >= 5 && (*s as f64 / *n as f64) < 0.6)
+        .filter(|(_, (s, n))| *n >= wt_min && (*s as f64 / *n as f64) < wt_rate)
         .map(|(t, _)| t.clone())
         .collect();
     let strong_tools: Vec<String> = tool_success_map
         .iter()
-        .filter(|(_, (s, n))| *n >= 5 && (*s as f64 / *n as f64) >= 0.9)
+        .filter(|(_, (s, n))| *n >= wt_min && (*s as f64 / *n as f64) >= st_rate)
         .map(|(t, _)| t.clone())
         .collect();
     let total_success: u64 = tool_success_map.values().map(|(s, _)| *s).sum();
@@ -1829,10 +1888,41 @@ pub fn run_context(days: u32) -> i32 {
         evolved_list.push(serde_json::json!({"name": name, "type": stype}));
     }
 
+    // Effective sources
+    let effective_sources: Vec<&str> = if sources.contains(&"all".to_string()) {
+        vec!["harness", "claude-session", "alcove"]
+    } else if sources.is_empty() {
+        vec!["harness"]
+    } else {
+        sources.iter().map(|s| s.as_str()).collect()
+    };
+
+    let extra_sources_json = {
+        let mut map = serde_json::Map::new();
+        if effective_sources.contains(&"claude-session") {
+            map.insert("claude_session".into(), collect_claude_session());
+        }
+        if effective_sources.contains(&"alcove") {
+            map.insert("alcove".into(), collect_alcove(&CONFIG.context.alcove));
+        }
+        serde_json::Value::Object(map)
+    };
+
+    // Fix 4: Scope note clarifying which fields are per-project vs aggregated
+    let scope_note = if all_projects || project.is_some() {
+        "evolution_stats, metrics_summary, session_snapshots, and evolved_skills are scoped to the current working directory project. Only obs_stats is aggregated across all analyzed projects."
+    } else {
+        ""
+    };
+
     // Compile
     let output = serde_json::json!({
         "generated_at": now_iso(),
         "analysis_window_days": days,
+        "date_range": { "from": date_from, "to": date_to },
+        "projects_analyzed": project_slugs,
+        "scope_note": scope_note,
+        "extra_sources": extra_sources_json,
         "obs_stats": obs_stats,
         "evolution_stats": evo_stats,
         "metrics_summary": metrics_summary,
@@ -1850,6 +1940,125 @@ pub fn run_context(days: u32) -> i32 {
 
     println!("{}", serde_json::to_string_pretty(&output).unwrap_or_default());
     0
+}
+
+fn collect_claude_session() -> serde_json::Value {
+    let claude_projects = dirs_home().join(".claude").join("projects");
+    if !claude_projects.is_dir() {
+        return serde_json::json!({"error": "~/.claude/projects not found"});
+    }
+    let mut sessions: Vec<serde_json::Value> = vec![];
+    let project_dirs: Vec<_> = std::fs::read_dir(&claude_projects)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .collect();
+    for pd in project_dirs.iter().take(20) {
+        let jsonl_files = list_files(&pd.path(), ".jsonl");
+        for f in jsonl_files.iter().rev().take(3) {
+            let recs: Vec<serde_json::Value> = read_jsonl_typed(&pd.path().join(f));
+            for r in recs.iter().take(5) {
+                let meta = serde_json::json!({
+                    "project": pd.file_name().to_string_lossy(),
+                    "timestamp": r.get("timestamp").and_then(|v| v.as_str()).unwrap_or(""),
+                    "model": r.get("model").and_then(|v| v.as_str()).unwrap_or(""),
+                    "message_count": r.get("message_count").and_then(|v| v.as_u64()).unwrap_or(0),
+                    "cost_usd": r.get("cost_usd").and_then(|v| v.as_f64()).unwrap_or(0.0),
+                });
+                sessions.push(meta);
+            }
+        }
+    }
+    sessions.sort_by(|a, b| {
+        let ta = a.get("timestamp").and_then(|v| v.as_str()).unwrap_or("");
+        let tb = b.get("timestamp").and_then(|v| v.as_str()).unwrap_or("");
+        tb.cmp(ta)
+    });
+    let sessions: Vec<_> = sessions.into_iter().take(20).collect();
+    serde_json::json!({
+        "total_sessions_sampled": sessions.len(),
+        "sessions": sessions,
+    })
+}
+
+fn collect_alcove(cfg: &super::config::AlcoveConfig) -> serde_json::Value {
+    if cfg.vault_path.is_empty() {
+        return serde_json::json!({"error": "alcove vault_path not configured"});
+    }
+    let vault = if cfg.vault_path.starts_with("~/") {
+        dirs_home().join(&cfg.vault_path[2..])
+    } else {
+        std::path::PathBuf::from(&cfg.vault_path)
+    };
+    // Fix 2: Canonicalize vault path and verify it stays within home directory
+    let vault = if let Ok(canonical) = vault.canonicalize() {
+        let home = dirs_home();
+        if !canonical.starts_with(&home) {
+            return serde_json::json!({
+                "error": format!("vault_path escapes home directory: {}", canonical.display())
+            });
+        }
+        canonical
+    } else {
+        return serde_json::json!({"error": format!("vault_path not found: {}", vault.display())});
+    };
+    let max = cfg.max_docs.max(1);
+    let mut docs: Vec<serde_json::Value> = vec![];
+    let mut visited = 0usize;
+    collect_md_files(&vault, &cfg.projects, max, &mut docs, 0, &mut visited);
+    serde_json::json!({
+        "vault_path": cfg.vault_path,
+        "docs_collected": docs.len(),
+        "documents": docs,
+    })
+}
+
+fn collect_md_files(
+    dir: &std::path::Path,
+    filter_projects: &[String],
+    max: usize,
+    out: &mut Vec<serde_json::Value>,
+    depth: usize,
+    visited: &mut usize,
+) {
+    // Fix 3: Guard against deep recursion, excessive file visits, and symlink loops
+    const MAX_DEPTH: usize = 10;
+    const MAX_VISITED: usize = 5000;
+
+    if out.len() >= max || depth > MAX_DEPTH || *visited > MAX_VISITED {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<_> = entries.filter_map(|e| e.ok()).collect();
+    entries.sort_by_key(|e| e.file_name());
+    for entry in entries {
+        if out.len() >= max || *visited > MAX_VISITED {
+            break;
+        }
+        let path = entry.path();
+        // Fix 3: Skip symlinks to prevent directory traversal via symlink
+        if path.is_dir() && !path.is_symlink() {
+            if !filter_projects.is_empty() {
+                let name = entry.file_name().to_string_lossy().to_string();
+                if !filter_projects.iter().any(|p| p == &name) {
+                    continue;
+                }
+            }
+            collect_md_files(&path, &[], max, out, depth + 1, visited);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("md") {
+            *visited += 1;
+            let content = std::fs::read_to_string(&path).unwrap_or_default();
+            let summary: String = content.chars().take(200).collect();
+            out.push(serde_json::json!({
+                "path": path.display().to_string(),
+                "summary": summary,
+            }));
+        }
+    }
 }
 
 /// Simple epoch-day to (year, month, day) without chrono dependency.
@@ -3468,5 +3677,69 @@ mod tests {
             instinct_two_projects.projects.len() >= CONFIG.instinct.promotion_min_projects,
             "two-project instinct must pass the promotion gate with default config (min=2)"
         );
+    }
+
+    // ── run_context signature ──────────────────────────
+    #[test]
+    fn effective_sources_all_expands() {
+        let sources: Vec<String> = vec!["all".into()];
+        let effective: Vec<&str> = if sources.contains(&"all".to_string()) {
+            vec!["harness", "claude-session", "alcove"]
+        } else if sources.is_empty() {
+            vec!["harness"]
+        } else {
+            sources.iter().map(|s| s.as_str()).collect()
+        };
+        assert_eq!(effective, vec!["harness", "claude-session", "alcove"]);
+    }
+
+    #[test]
+    fn effective_sources_empty_defaults_to_harness() {
+        let sources: Vec<String> = vec![];
+        let effective: Vec<&str> = if sources.contains(&"all".to_string()) {
+            vec!["harness", "claude-session", "alcove"]
+        } else if sources.is_empty() {
+            vec!["harness"]
+        } else {
+            sources.iter().map(|s| s.as_str()).collect()
+        };
+        assert_eq!(effective, vec!["harness"]);
+    }
+
+    #[test]
+    fn effective_sources_explicit_list_passthrough() {
+        let sources: Vec<String> = vec!["harness".into(), "alcove".into()];
+        let effective: Vec<&str> = if sources.contains(&"all".to_string()) {
+            vec!["harness", "claude-session", "alcove"]
+        } else if sources.is_empty() {
+            vec!["harness"]
+        } else {
+            sources.iter().map(|s| s.as_str()).collect()
+        };
+        assert_eq!(effective, vec!["harness", "alcove"]);
+    }
+
+    #[test]
+    fn since_overrides_days_in_date_range() {
+        // When --since is provided, date_from should equal since value
+        let since: Option<String> = Some("20260101".into());
+        let days: u32 = 30;
+
+        let (cutoff_tag, date_from) = if let Some(ref s) = since {
+            (s.clone(), s.clone())
+        } else {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let cutoff_ts = now.saturating_sub((days as u64) * 86400);
+            let days_since_epoch = cutoff_ts / 86400;
+            let (y, m, d) = epoch_days_to_ymd(days_since_epoch as i32);
+            let tag = format!("{y:04}{m:02}{d:02}");
+            (tag.clone(), tag)
+        };
+
+        assert_eq!(cutoff_tag, "20260101");
+        assert_eq!(date_from, "20260101");
     }
 }

--- a/src/hooks/reflect.rs
+++ b/src/hooks/reflect.rs
@@ -1889,16 +1889,27 @@ pub fn run_context(
     }
 
     // Effective sources
+    // mem is always included (baseline). --source adds extra sources on top.
     let effective_sources: Vec<&str> = if sources.contains(&"all".to_string()) {
-        vec!["harness", "claude-session", "alcove"]
+        vec!["harness", "mem", "claude-session", "alcove"]
     } else if sources.is_empty() {
-        vec!["harness"]
+        vec!["harness", "mem"]
     } else {
-        sources.iter().map(|s| s.as_str()).collect()
+        // Always prepend mem unless the caller explicitly passed "mem" already
+        let mut v: Vec<&str> = vec!["harness", "mem"];
+        for s in sources.iter() {
+            let s = s.as_str();
+            if s != "harness" && s != "mem" {
+                v.push(s);
+            }
+        }
+        v
     };
 
     let extra_sources_json = {
         let mut map = serde_json::Map::new();
+        // mem — always collected
+        map.insert("mem".into(), collect_mem(&project_slugs));
         if effective_sources.contains(&"claude-session") {
             map.insert("claude_session".into(), collect_claude_session());
         }
@@ -1940,6 +1951,93 @@ pub fn run_context(
 
     println!("{}", serde_json::to_string_pretty(&output).unwrap_or_default());
     0
+}
+
+/// Collect mem nodes from ~/.harness/memory.db.
+/// Pulls top nodes by importance for each project slug (or all if slugs = [current]).
+/// Session-type nodes are excluded (importance=0.05, noise) unless there's nothing else.
+fn collect_mem(project_slugs: &[String]) -> serde_json::Value {
+    let conn = match store::open_db() {
+        Ok(c) => c,
+        Err(e) => {
+            return serde_json::json!({"error": format!("mem db unavailable: {e}")});
+        }
+    };
+
+    // Determine project filter: use first slug if single-project, else no filter (all)
+    let project_filter: Option<&str> = if project_slugs.len() == 1 {
+        project_slugs.first().map(|s| s.as_str())
+    } else {
+        None
+    };
+
+    // Smart recall — hint = broad engineering context, limit = 30
+    let recalled = store::smart_recall_conn(
+        &conn,
+        project_filter,
+        Some("decision pattern error resolution concept"),
+        30,
+    );
+
+    // Also pull top decisions/resolutions explicitly (high-value types)
+    let decisions = store::query_nodes_conn(
+        &conn,
+        None,       // tag filter
+        Some("decision"),
+        project_filter,
+        10,
+    );
+    let resolutions = store::query_nodes_conn(
+        &conn,
+        None,
+        Some("resolution"),
+        project_filter,
+        10,
+    );
+
+    // Merge and deduplicate by id, prefer higher-importance entry
+    let mut seen: std::collections::HashMap<String, serde_json::Value> = std::collections::HashMap::new();
+
+    for sn in &recalled {
+        let id = sn.node.frontmatter.id.clone();
+        let entry = serde_json::json!({
+            "id": id,
+            "type": sn.node.frontmatter.node_type,
+            "title": sn.node.frontmatter.title,
+            "importance": sn.node.frontmatter.importance,
+            "tags": sn.node.frontmatter.tags,
+            "updated": sn.node.frontmatter.updated,
+            "body_preview": sn.node.body.chars().take(200).collect::<String>(),
+        });
+        seen.insert(id, entry);
+    }
+    for node in decisions.iter().chain(resolutions.iter()) {
+        let id = node.frontmatter.id.clone();
+        seen.entry(id.clone()).or_insert_with(|| serde_json::json!({
+            "id": id,
+            "type": node.frontmatter.node_type,
+            "title": node.frontmatter.title,
+            "importance": node.frontmatter.importance,
+            "tags": node.frontmatter.tags,
+            "updated": node.frontmatter.updated,
+            "body_preview": node.body.chars().take(200).collect::<String>(),
+        }));
+    }
+
+    // Sort by importance desc, take top 30
+    let mut nodes: Vec<serde_json::Value> = seen.into_values().collect();
+    nodes.sort_by(|a, b| {
+        let ia = a.get("importance").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        let ib = b.get("importance").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        ib.partial_cmp(&ia).unwrap_or(std::cmp::Ordering::Equal)
+    });
+    nodes.truncate(30);
+
+    serde_json::json!({
+        "total_nodes_sampled": nodes.len(),
+        "project_filter": project_filter,
+        "nodes": nodes,
+    })
 }
 
 fn collect_claude_session() -> serde_json::Value {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,146 @@ mod hooks;
 use std::env;
 use std::io::{self, IsTerminal, Read};
 
+/// Parse `--flag <value>` or `--flag=<value>` → Option<u32>
+fn parse_flag_u32(args: &[String], flag: &str) -> Option<u32> {
+    let eq = format!("{flag}=");
+    args.iter()
+        .find(|a| a.starts_with(&eq))
+        .and_then(|a| a[eq.len()..].parse().ok())
+        .or_else(|| {
+            args.iter()
+                .position(|a| a == flag)
+                .and_then(|i| args.get(i + 1))
+                .and_then(|s| s.parse().ok())
+        })
+}
+
+/// Parse `--flag <value>` or `--flag=<value>` → Option<String>
+fn parse_flag_str(args: &[String], flag: &str) -> Option<String> {
+    let eq = format!("{flag}=");
+    args.iter()
+        .find(|a| a.starts_with(&eq))
+        .map(|a| a[eq.len()..].to_string())
+        .or_else(|| {
+            args.iter()
+                .position(|a| a == flag)
+                .and_then(|i| args.get(i + 1))
+                .map(|s| s.clone())
+        })
+}
+
+/// Parse repeated `--flag <value>` → Vec<String>
+fn parse_flag_multi(args: &[String], flag: &str) -> Vec<String> {
+    let eq = format!("{flag}=");
+    let mut results = Vec::new();
+    let mut i = 0;
+    while i < args.len() {
+        if args[i].starts_with(&eq) {
+            results.push(args[i][eq.len()..].to_string());
+        } else if args[i] == flag {
+            if let Some(val) = args.get(i + 1) {
+                if !val.starts_with('-') {
+                    results.push(val.clone());
+                    i += 1;
+                }
+            }
+        }
+        i += 1;
+    }
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_flag_multi, parse_flag_str, parse_flag_u32};
+
+    fn s(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    // ── parse_flag_u32 ────────────────────────────────
+    #[test]
+    fn parse_flag_u32_eq_form() {
+        let args = s(&["reflect", "--context=7"]);
+        assert_eq!(parse_flag_u32(&args, "--context"), Some(7));
+    }
+
+    #[test]
+    fn parse_flag_u32_space_form() {
+        let args = s(&["reflect", "--days", "14"]);
+        assert_eq!(parse_flag_u32(&args, "--days"), Some(14));
+    }
+
+    #[test]
+    fn parse_flag_u32_missing() {
+        let args = s(&["reflect", "--context"]);
+        assert_eq!(parse_flag_u32(&args, "--days"), None);
+    }
+
+    #[test]
+    fn parse_flag_u32_invalid_value() {
+        let args = s(&["reflect", "--days", "abc"]);
+        assert_eq!(parse_flag_u32(&args, "--days"), None);
+    }
+
+    #[test]
+    fn parse_flag_u32_eq_form_prefers_eq() {
+        let args = s(&["reflect", "--days=5", "--days", "99"]);
+        assert_eq!(parse_flag_u32(&args, "--days"), Some(5));
+    }
+
+    // ── parse_flag_str ────────────────────────────────
+    #[test]
+    fn parse_flag_str_eq_form() {
+        let args = s(&["reflect", "--since=20260101"]);
+        assert_eq!(parse_flag_str(&args, "--since"), Some("20260101".into()));
+    }
+
+    #[test]
+    fn parse_flag_str_space_form() {
+        let args = s(&["reflect", "--project", "my-project"]);
+        assert_eq!(parse_flag_str(&args, "--project"), Some("my-project".into()));
+    }
+
+    #[test]
+    fn parse_flag_str_missing() {
+        let args = s(&["reflect", "--context"]);
+        assert_eq!(parse_flag_str(&args, "--since"), None);
+    }
+
+    // ── parse_flag_multi ──────────────────────────────
+    #[test]
+    fn parse_flag_multi_single_space() {
+        let args = s(&["reflect", "--source", "harness"]);
+        assert_eq!(parse_flag_multi(&args, "--source"), vec!["harness".to_string()]);
+    }
+
+    #[test]
+    fn parse_flag_multi_repeated_space() {
+        let args = s(&["reflect", "--source", "harness", "--source", "alcove"]);
+        assert_eq!(parse_flag_multi(&args, "--source"), vec!["harness".to_string(), "alcove".to_string()]);
+    }
+
+    #[test]
+    fn parse_flag_multi_eq_form() {
+        let args = s(&["reflect", "--source=claude-session"]);
+        assert_eq!(parse_flag_multi(&args, "--source"), vec!["claude-session".to_string()]);
+    }
+
+    #[test]
+    fn parse_flag_multi_empty() {
+        let args = s(&["reflect", "--context"]);
+        assert_eq!(parse_flag_multi(&args, "--source"), Vec::<String>::new());
+    }
+
+    #[test]
+    fn parse_flag_multi_skips_next_flag_as_value() {
+        let args = s(&["reflect", "--source", "--context", "harness"]);
+        // "--context" starts with '-', so it should NOT be treated as a value
+        assert_eq!(parse_flag_multi(&args, "--source"), Vec::<String>::new());
+    }
+}
+
 fn main() {
     let args: Vec<String> = env::args().collect();
     let subcmd = args.get(1).map(|s| s.as_str()).unwrap_or("help");
@@ -47,22 +187,34 @@ fn main() {
 
     // reflect --context: data collection mode (no stdin needed)
     if subcmd == "reflect" {
-        let has_context = args.iter().any(|a| a.starts_with("--context"));
+        let has_context = args.iter().any(|a| a == "--context" || a.starts_with("--context="));
         if has_context {
-            let days: u32 = args
-                .iter()
-                .find(|a| a.starts_with("--context"))
-                .and_then(|a| a.strip_prefix("--context=").filter(|s| !s.is_empty()))
-                .and_then(|s| s.parse().ok())
-                .unwrap_or_else(|| {
-                    // --context as separate arg: look for next positional
+            // --days <N> or --context=<N> or --context <N>
+            let days: u32 = parse_flag_u32(&args, "--days")
+                .or_else(|| {
                     args.iter()
-                        .position(|a| a == "--context")
-                        .and_then(|i| args.get(i + 1))
+                        .find(|a| a.starts_with("--context="))
+                        .and_then(|a| a.strip_prefix("--context=").filter(|s| !s.is_empty()))
                         .and_then(|s| s.parse().ok())
-                        .unwrap_or(30)
-                });
-            std::process::exit(hooks::reflect::run_context(days));
+                })
+                .or_else(|| parse_flag_u32(&args, "--context"))
+                .unwrap_or(30);
+
+            // --since <YYYYMMDD>
+            let since: Option<String> = parse_flag_str(&args, "--since");
+
+            // --project <slug>
+            let project: Option<String> = parse_flag_str(&args, "--project");
+
+            // --all-projects
+            let all_projects = args.iter().any(|a| a == "--all-projects");
+
+            // --source <name>  (may appear multiple times)
+            let sources: Vec<String> = parse_flag_multi(&args, "--source");
+
+            std::process::exit(hooks::reflect::run_context(
+                days, since, project, all_projects, sources,
+            ));
         }
     }
 
@@ -112,7 +264,12 @@ fn main() {
             eprintln!("  polish       Auto-format and typecheck after file edits");
             eprintln!("  snapshot     Save session state mid-conversation");
             eprintln!("  reflect      Analyze observations and evolve skills (session end)");
-            eprintln!("  reflect --context [DAYS]  Collect harness data as JSON for /reflect skill\n");
+            eprintln!("  reflect --context [OPTIONS]  Collect harness data as JSON for /reflect skill");
+            eprintln!("    --days <N>           Analysis window in days (default: 30)");
+            eprintln!("    --since <YYYYMMDD>   Start date (overrides --days)");
+            eprintln!("    --project <slug>     Specific project slug");
+            eprintln!("    --all-projects       All projects under ~/.harness/projects/");
+            eprintln!("    --source <name>      Extra context source: harness|claude-session|alcove|all (repeatable)\n");
             eprintln!("USER SUBCOMMANDS:");
             eprintln!("  org          Browse org team libraries  (epic org help)");
             eprintln!("  team         Manage org-level agent teams  (epic team help)");


### PR DESCRIPTION
## Summary

`reflect --context` 에 프로젝트 범위 선택, 기간 지정, 추가 컨텍스트 소스(claude-session, alcove) 플러그인 지원을 추가합니다.

## Spec
- ID: SPEC-1778176778
- Pipeline: PIPELINE-1778176778
- Requirements: R1(--all-projects), R2(--project), R3(--since), R4(claude-session), R5(alcove), R6(config), R7(output fields)

## Changes

### New CLI flags (`reflect --context`)
- `--all-projects` : scan all slugs under ~/.harness/projects/
- `--project <slug>` : target a specific project slug
- `--since <YYYYMMDD>` : start date (overrides --days)
- `--source <name>` : add context source — harness|claude-session|alcove|all (repeatable)

### New context sources
- **claude-session**: reads `~/.claude/projects/` session JSONL for timestamp, model, cost_usd, message_count
- **alcove**: reads Alcove vault `.md` files (path from `[context.alcove]` in config.toml), max_docs / max_depth / symlink guarded

### Output JSON additions
- `projects_analyzed: [slug,...]`
- `date_range: {from, to}`
- `extra_sources: {claude_session?, alcove?}`
- `scope_note` (when --all-projects or --project used)

### config.toml
```toml
[context]
sources = ["harness"]

[context.alcove]
vault_path = ""
projects = []
max_docs = 20
```

### Security fixes
- slug input validated: rejects `../`, `/`, `\`
- vault_path canonicalized + checked to be under home directory
- collect_md_files: symlink directories skipped, max depth=10, max visited=5000
- --since validated as 8-digit numeric YYYYMMDD

## Acceptance Criteria Verified
- AC1 ✅ --all-projects → projects_analyzed populated
- AC2 ✅ --since 20260101 → date_range.from == '20260101'
- AC3 ✅ --source claude-session → extra_sources.claude_session present
- AC4 ✅ --source alcove → extra_sources.alcove present (error msg when unconfigured)
- AC5 ✅ --source all → both sources present
- AC6 ✅ reflect --context 30 unchanged (no regression)
- AC7 ✅ config unit tests pass

## Check Report
PASS — AC 7/7 ✅ | Security: path traversal guard ✅ | symlink defense ✅ | vault canonicalize ✅ | cargo test 969 passed 0 failed

## Test Plan
- [x] Unit tests pass (969 tests)
- [x] Release build pass
- [x] Manual AC verification done
- [x] Security fix verified