### PR TITLE
feat(store): migrate all callers from rusqlite to sqlx pool

### DIFF
--- a/src/evolve/ingest.rs
+++ b/src/evolve/ingest.rs
@@ -1,33 +1,36 @@
 use crate::mem::store;
 use crate::shared::{evolution::*, helpers::*, paths::*};
+use crate::store::runtime::block_on;
+use sqlx::SqlitePool;
 
 use super::analysis::build_summary;
 
 /// Query pattern types detected in the previous session (the session that the
 /// current session "follows"). Extracts non-generic tags from CSV tag strings.
-pub fn query_prev_pattern_types(conn: &rusqlite::Connection, session_node_id: &str) -> Vec<String> {
-    let mut results = Vec::new();
+pub async fn query_prev_pattern_types_async(
+    pool: &SqlitePool,
+    session_node_id: &str,
+) -> Vec<String> {
     let sql = "SELECT n.tags FROM nodes n
          JOIN edges e ON e.source = n.id
          WHERE n.type = 'pattern'
          AND e.relation = 'detected_in'
          AND e.target IN (
             SELECT e2.source FROM edges e2
-            WHERE e2.target = ?1 AND e2.relation = 'follows'
+            WHERE e2.target = ? AND e2.relation = 'follows'
          )";
-    if let Ok(mut stmt) = conn.prepare(sql) {
-        let rows = stmt.query_map(rusqlite::params![session_node_id], |row| {
-            let tags_str: String = row.get(0)?;
-            Ok(tags_str)
-        });
-        if let Ok(iter) = rows {
-            for r in iter.flatten() {
-                for tag in r.split(',') {
-                    let tag = tag.trim().trim_matches('"');
-                    if !tag.is_empty() && tag != "auto" && tag != "pattern" {
-                        results.push(tag.to_string());
-                    }
-                }
+    let tags_rows: Vec<String> = sqlx::query_scalar::<_, String>(sql)
+        .bind(session_node_id)
+        .fetch_all(pool)
+        .await
+        .unwrap_or_default();
+
+    let mut results = Vec::new();
+    for tags_str in tags_rows {
+        for tag in tags_str.split(',') {
+            let tag = tag.trim().trim_matches('"');
+            if !tag.is_empty() && tag != "auto" && tag != "pattern" {
+                results.push(tag.to_string());
             }
         }
     }
@@ -35,15 +38,15 @@ pub fn query_prev_pattern_types(conn: &rusqlite::Connection, session_node_id: &s
 }
 
 /// Find or create a project hub node. Returns the hub node's ID.
-pub fn ensure_project_hub(conn: &rusqlite::Connection, slug: &str) -> std::io::Result<String> {
-    // Check if hub already exists
-    let existing: Option<String> = conn
-        .query_row(
-            "SELECT id FROM nodes WHERE type = 'project' AND title = ?1 LIMIT 1",
-            rusqlite::params![format!("project: {}", slug)],
-            |row| row.get(0),
-        )
-        .ok();
+pub async fn ensure_project_hub_async(pool: &SqlitePool, slug: &str) -> std::io::Result<String> {
+    let title = format!("project: {}", slug);
+    let existing: Option<String> = sqlx::query_scalar::<_, String>(
+        "SELECT id FROM nodes WHERE type = 'project' AND title = ? LIMIT 1",
+    )
+    .bind(&title)
+    .fetch_optional(pool)
+    .await
+    .unwrap_or(None);
 
     if let Some(id) = existing {
         return Ok(id);
@@ -56,7 +59,7 @@ pub fn ensure_project_hub(conn: &rusqlite::Connection, slug: &str) -> std::io::R
         frontmatter: store::NodeFrontmatter {
             id: id.clone(),
             node_type: "project".to_string(),
-            title: format!("project: {}", slug),
+            title,
             tags: vec!["hub".to_string()],
             projects: vec![slug.to_string()],
             agents: vec![],
@@ -68,35 +71,32 @@ pub fn ensure_project_hub(conn: &rusqlite::Connection, slug: &str) -> std::io::R
         },
         body: format!("Project hub node for {}", slug),
     };
-    store::write_node_conn(conn, &node)?;
+    store::write_node_pool(pool, &node).await?;
     Ok(id)
 }
 
 /// Ingest session analysis results into the knowledge graph.
 /// Returns (nodes_created, edges_created).
 pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]) -> (u64, u64) {
-    let conn = match store::open_db() {
-        Ok(c) => c,
+    let pool = match block_on(crate::store::pool::memory_pool()) {
+        Ok(p) => p,
         Err(e) => {
             eprintln!("[ingest] failed to open memory DB: {e}");
             return (0, 0);
         }
     };
 
+    block_on(ingest_to_memory_async(&pool, analysis, patterns))
+}
+
+async fn ingest_to_memory_async(
+    pool: &SqlitePool,
+    analysis: &SessionAnalysis,
+    patterns: &[DetectedPattern],
+) -> (u64, u64) {
     let slug = project_slug();
     let ts = now_iso();
     let dedup_hours = 24u64;
-    // `unchecked_transaction()` is used here because `open_db()` always returns
-    // a fresh connection in autocommit mode (no prior transaction active). Using
-    // the checked variant would be equivalent but adds unnecessary overhead for
-    // this single-writer, fresh-connection pattern.
-    let tx = match conn.unchecked_transaction() {
-        Ok(t) => t,
-        Err(e) => {
-            eprintln!("[ingest] failed to begin transaction: {e}");
-            return (0, 0);
-        }
-    };
 
     let mut nodes_created = 0u64;
     let mut edges_created = 0u64;
@@ -127,7 +127,7 @@ pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]
             },
             body,
         };
-        match store::write_node_dedup_conn(&tx, &node, dedup_hours) {
+        match store::write_node_dedup_pool(pool, &node, dedup_hours).await {
             Ok((id, false)) => {
                 session_node_id = id;
                 nodes_created += 1;
@@ -170,7 +170,7 @@ pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]
             },
             body,
         };
-        if let Ok((id, deduped)) = store::write_node_dedup_conn(&tx, &node, dedup_hours) {
+        if let Ok((id, deduped)) = store::write_node_dedup_pool(pool, &node, dedup_hours).await {
             let files = pattern.involved_files.clone();
             pattern_node_ids.push((id.clone(), files));
             if !deduped {
@@ -186,7 +186,7 @@ pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]
                     weight: 1.0,
                     ts: ts.clone(),
                 };
-                if store::append_edge_conn(&tx, &edge).is_ok() {
+                if store::append_edge_pool(pool, &edge).await.is_ok() {
                     edges_created += 1;
                 }
             }
@@ -195,7 +195,7 @@ pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]
 
     // 8b-2. Resolution nodes: patterns resolved since last session
     if !session_node_id.is_empty() {
-        let prev_pattern_types = query_prev_pattern_types(&tx, &session_node_id);
+        let prev_pattern_types = query_prev_pattern_types_async(pool, &session_node_id).await;
 
         // Get current pattern types for comparison
         let current_pattern_types: Vec<&str> =
@@ -226,7 +226,9 @@ pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]
                     },
                     body,
                 };
-                if let Ok((id, false)) = store::write_node_dedup_conn(&tx, &node, dedup_hours) {
+                if let Ok((id, false)) =
+                    store::write_node_dedup_pool(pool, &node, dedup_hours).await
+                {
                     nodes_created += 1;
                     // Edge: resolution -> session (resolved_in)
                     let edge = store::Edge {
@@ -237,13 +239,13 @@ pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]
                         weight: 1.0,
                         ts: ts.clone(),
                     };
-                    if store::append_edge_conn(&tx, &edge).is_ok() {
+                    if store::append_edge_pool(pool, &edge).await.is_ok() {
                         edges_created += 1;
                     }
                     // Link resolution to project hub
-                    if let Ok(ref hub_id) = ensure_project_hub(&tx, &slug) {
-                        let _ = store::append_edge_conn(
-                            &tx,
+                    if let Ok(ref hub_id) = ensure_project_hub_async(pool, &slug).await {
+                        let _ = store::append_edge_pool(
+                            pool,
                             &store::Edge {
                                 id: store::new_uuid(),
                                 source: id,
@@ -253,6 +255,7 @@ pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]
                                 ts: ts.clone(),
                             },
                         )
+                        .await
                         .map(|_| edges_created += 1);
                     }
                 }
@@ -298,7 +301,7 @@ pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]
             },
             body,
         };
-        if let Ok((id, false)) = store::write_node_dedup_conn(&tx, &node, dedup_hours) {
+        if let Ok((id, false)) = store::write_node_dedup_pool(pool, &node, dedup_hours).await {
             error_node_ids.push(id);
             nodes_created += 1;
         }
@@ -330,7 +333,7 @@ pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]
             },
             body,
         };
-        if let Ok((id, false)) = store::write_node_dedup_conn(&tx, &node, dedup_hours) {
+        if let Ok((id, false)) = store::write_node_dedup_pool(pool, &node, dedup_hours).await {
             error_node_ids.push(id);
             nodes_created += 1;
         }
@@ -351,7 +354,7 @@ pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]
                     weight: shared.len() as f64,
                     ts: ts.clone(),
                 };
-                if store::append_edge_conn(&tx, &edge).is_ok() {
+                if store::append_edge_pool(pool, &edge).await.is_ok() {
                     edges_created += 1;
                 }
             }
@@ -359,11 +362,11 @@ pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]
     }
 
     // 8f. Project hub nodes + belongs_to edges
-    if let Ok(hub_id) = ensure_project_hub(&tx, &slug) {
+    if let Ok(hub_id) = ensure_project_hub_async(pool, &slug).await {
         // Link session node to project hub
         if !session_node_id.is_empty() {
-            let _ = store::append_edge_conn(
-                &tx,
+            let _ = store::append_edge_pool(
+                pool,
                 &store::Edge {
                     id: store::new_uuid(),
                     source: session_node_id.clone(),
@@ -373,12 +376,13 @@ pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]
                     ts: ts.clone(),
                 },
             )
+            .await
             .map(|_| edges_created += 1);
         }
         // Link pattern nodes to project hub
         for (pid, _) in &pattern_node_ids {
-            let _ = store::append_edge_conn(
-                &tx,
+            let _ = store::append_edge_pool(
+                pool,
                 &store::Edge {
                     id: store::new_uuid(),
                     source: pid.clone(),
@@ -388,12 +392,13 @@ pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]
                     ts: ts.clone(),
                 },
             )
+            .await
             .map(|_| edges_created += 1);
         }
         // Link error nodes to project hub
         for eid in &error_node_ids {
-            let _ = store::append_edge_conn(
-                &tx,
+            let _ = store::append_edge_pool(
+                pool,
                 &store::Edge {
                     id: store::new_uuid(),
                     source: eid.clone(),
@@ -403,25 +408,27 @@ pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]
                     ts: ts.clone(),
                 },
             )
+            .await
             .map(|_| edges_created += 1);
         }
     }
 
     // 8g. Session chain: link to previous session in same project
     if !session_node_id.is_empty() {
-        let prev_session: Option<String> = tx
-            .query_row(
-                "SELECT id FROM nodes WHERE type = 'session' AND id != ?1
-             AND (',' || projects || ',' LIKE '%,' || ?2 || ',%')
+        let prev_session: Option<String> = sqlx::query_scalar::<_, String>(
+            "SELECT id FROM nodes WHERE type = 'session' AND id != ?
+             AND (',' || projects || ',' LIKE '%,' || ? || ',%')
              ORDER BY updated DESC LIMIT 1",
-                rusqlite::params![session_node_id, slug],
-                |row| row.get(0),
-            )
-            .ok();
+        )
+        .bind(&session_node_id)
+        .bind(&slug)
+        .fetch_optional(pool)
+        .await
+        .unwrap_or(None);
 
         if let Some(prev_id) = prev_session {
-            let _ = store::append_edge_conn(
-                &tx,
+            let _ = store::append_edge_pool(
+                pool,
                 &store::Edge {
                     id: store::new_uuid(),
                     source: prev_id,
@@ -431,6 +438,7 @@ pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]
                     ts: ts.clone(),
                 },
             )
+            .await
             .map(|_| edges_created += 1);
         }
     }
@@ -444,7 +452,9 @@ pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]
         .collect();
 
     if all_new_ids.len() >= 2 {
-        let new_nodes = store::read_nodes_conn(&tx, &all_new_ids).unwrap_or_default();
+        let new_nodes = store::read_nodes_pool(pool, &all_new_ids)
+            .await
+            .unwrap_or_default();
         for i in 0..new_nodes.len() {
             for j in (i + 1)..new_nodes.len() {
                 let shared: Vec<String> = new_nodes[i]
@@ -455,8 +465,8 @@ pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]
                     .cloned()
                     .collect();
                 if !shared.is_empty() {
-                    let _ = store::append_edge_conn(
-                        &tx,
+                    let _ = store::append_edge_pool(
+                        pool,
                         &store::Edge {
                             id: store::new_uuid(),
                             source: new_nodes[i].frontmatter.id.clone(),
@@ -466,13 +476,13 @@ pub fn ingest_to_memory(analysis: &SessionAnalysis, patterns: &[DetectedPattern]
                             ts: ts.clone(),
                         },
                     )
+                    .await
                     .map(|_| edges_created += 1);
                 }
             }
         }
     }
 
-    let _ = tx.commit();
     (nodes_created, edges_created)
 }
 
@@ -481,19 +491,21 @@ mod tests {
     use super::*;
     use crate::mem::store;
 
-    fn open_test_mem_db() -> rusqlite::Connection {
-        let conn = rusqlite::Connection::open_in_memory().expect("in-memory db");
-        store::init_schema(&conn).expect("schema");
-        conn
+    async fn open_test_mem_pool() -> SqlitePool {
+        let pool = crate::store::pool::test_memory_pool().await;
+        store::init_schema_pool(&pool).await.expect("schema");
+        pool
     }
 
-    #[test]
-    fn ensure_project_hub_creates_new_hub_node() {
-        let conn = open_test_mem_db();
-        let hub_id = ensure_project_hub(&conn, "test-project").unwrap();
+    #[tokio::test]
+    async fn ensure_project_hub_creates_new_hub_node() {
+        let pool = open_test_mem_pool().await;
+        let hub_id = ensure_project_hub_async(&pool, "test-project")
+            .await
+            .unwrap();
         assert!(!hub_id.is_empty(), "hub ID must not be empty");
 
-        let node = store::read_node_conn(&conn, &hub_id).unwrap();
+        let node = store::read_node_pool(&pool, &hub_id).await.unwrap();
         assert_eq!(node.frontmatter.node_type, "project");
         assert_eq!(node.frontmatter.title, "project: test-project");
         assert!(node.frontmatter.tags.contains(&"hub".to_string()));
@@ -504,27 +516,29 @@ mod tests {
         );
     }
 
-    #[test]
-    fn ensure_project_hub_returns_existing_hub() {
-        let conn = open_test_mem_db();
-        let id1 = ensure_project_hub(&conn, "my-proj").unwrap();
-        let id2 = ensure_project_hub(&conn, "my-proj").unwrap();
+    #[tokio::test]
+    async fn ensure_project_hub_returns_existing_hub() {
+        let pool = open_test_mem_pool().await;
+        let id1 = ensure_project_hub_async(&pool, "my-proj").await.unwrap();
+        let id2 = ensure_project_hub_async(&pool, "my-proj").await.unwrap();
         assert_eq!(id1, id2, "second call must return same hub ID");
     }
 
-    #[test]
-    fn ensure_project_hub_different_projects_get_different_ids() {
-        let conn = open_test_mem_db();
-        let id_a = ensure_project_hub(&conn, "proj-a").unwrap();
-        let id_b = ensure_project_hub(&conn, "proj-b").unwrap();
+    #[tokio::test]
+    async fn ensure_project_hub_different_projects_get_different_ids() {
+        let pool = open_test_mem_pool().await;
+        let id_a = ensure_project_hub_async(&pool, "proj-a").await.unwrap();
+        let id_b = ensure_project_hub_async(&pool, "proj-b").await.unwrap();
         assert_ne!(id_a, id_b, "different projects must get different hub IDs");
     }
 
-    #[test]
-    fn auto_edge_belongs_to_links_session_to_project_hub() {
-        let conn = open_test_mem_db();
+    #[tokio::test]
+    async fn auto_edge_belongs_to_links_session_to_project_hub() {
+        let pool = open_test_mem_pool().await;
 
-        let hub_id = ensure_project_hub(&conn, "edge-test-proj").unwrap();
+        let hub_id = ensure_project_hub_async(&pool, "edge-test-proj")
+            .await
+            .unwrap();
 
         let session_id = store::new_uuid();
         let session_node = store::Node {
@@ -541,7 +555,7 @@ mod tests {
             },
             body: "test session".into(),
         };
-        store::write_node_conn(&conn, &session_node).unwrap();
+        store::write_node_pool(&pool, &session_node).await.unwrap();
 
         let edge = store::Edge {
             id: store::new_uuid(),
@@ -551,18 +565,20 @@ mod tests {
             weight: 0.5,
             ts: store::now_iso(),
         };
-        store::append_edge_conn(&conn, &edge).unwrap();
+        store::append_edge_pool(&pool, &edge).await.unwrap();
 
-        let edges = store::read_edges_conn(&conn, 5000).unwrap_or_default();
+        let edges = store::read_edges_pool(&pool, 5000)
+            .await
+            .unwrap_or_default();
         let found = edges
             .iter()
             .any(|e| e.source == session_id && e.target == hub_id && e.relation == "belongs_to");
         assert!(found, "belongs_to edge from session to hub must exist");
     }
 
-    #[test]
-    fn auto_edge_follows_links_previous_session() {
-        let conn = open_test_mem_db();
+    #[tokio::test]
+    async fn auto_edge_follows_links_previous_session() {
+        let pool = open_test_mem_pool().await;
 
         let prev_id = store::new_uuid();
         let prev_node = store::Node {
@@ -578,7 +594,7 @@ mod tests {
             },
             body: "prev session".into(),
         };
-        store::write_node_conn(&conn, &prev_node).unwrap();
+        store::write_node_pool(&pool, &prev_node).await.unwrap();
 
         let curr_id = store::new_uuid();
         let curr_node = store::Node {
@@ -594,17 +610,18 @@ mod tests {
             },
             body: "curr session".into(),
         };
-        store::write_node_conn(&conn, &curr_node).unwrap();
+        store::write_node_pool(&pool, &curr_node).await.unwrap();
 
-        let prev_session: Option<String> = conn
-            .query_row(
-                "SELECT id FROM nodes WHERE type = 'session' AND id != ?1
-             AND (',' || projects || ',' LIKE '%,' || ?2 || ',%')
+        let prev_session: Option<String> = sqlx::query_scalar::<_, String>(
+            "SELECT id FROM nodes WHERE type = 'session' AND id != ?
+             AND (',' || projects || ',' LIKE '%,' || ? || ',%')
              ORDER BY updated DESC LIMIT 1",
-                rusqlite::params![curr_id, "chain-proj"],
-                |row| row.get(0),
-            )
-            .ok();
+        )
+        .bind(&curr_id)
+        .bind("chain-proj")
+        .fetch_optional(&pool)
+        .await
+        .unwrap();
 
         assert!(prev_session.is_some(), "should find a previous session");
         assert_eq!(prev_session.unwrap(), prev_id);
@@ -617,9 +634,11 @@ mod tests {
             weight: 0.3,
             ts: store::now_iso(),
         };
-        store::append_edge_conn(&conn, &edge).unwrap();
+        store::append_edge_pool(&pool, &edge).await.unwrap();
 
-        let edges = store::read_edges_conn(&conn, 5000).unwrap_or_default();
+        let edges = store::read_edges_pool(&pool, 5000)
+            .await
+            .unwrap_or_default();
         let found = edges
             .iter()
             .any(|e| e.source == prev_id && e.target == curr_id && e.relation == "follows");
@@ -629,9 +648,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn auto_edge_shares_context_links_same_tag_nodes() {
-        let conn = open_test_mem_db();
+    #[tokio::test]
+    async fn auto_edge_shares_context_links_same_tag_nodes() {
+        let pool = open_test_mem_pool().await;
 
         let id_a = store::new_uuid();
         let node_a = store::Node {
@@ -646,7 +665,7 @@ mod tests {
             },
             body: "error A body".into(),
         };
-        store::write_node_conn(&conn, &node_a).unwrap();
+        store::write_node_pool(&pool, &node_a).await.unwrap();
 
         let id_b = store::new_uuid();
         let node_b = store::Node {
@@ -661,10 +680,10 @@ mod tests {
             },
             body: "error B body".into(),
         };
-        store::write_node_conn(&conn, &node_b).unwrap();
+        store::write_node_pool(&pool, &node_b).await.unwrap();
 
         let all_new_ids: Vec<&str> = vec![&id_a, &id_b];
-        let new_nodes = store::read_nodes_conn(&conn, &all_new_ids).unwrap();
+        let new_nodes = store::read_nodes_pool(&pool, &all_new_ids).await.unwrap();
         assert_eq!(new_nodes.len(), 2);
 
         let shared: Vec<String> = new_nodes[0]
@@ -687,9 +706,11 @@ mod tests {
             weight: shared.len() as f64,
             ts: store::now_iso(),
         };
-        store::append_edge_conn(&conn, &edge).unwrap();
+        store::append_edge_pool(&pool, &edge).await.unwrap();
 
-        let edges = store::read_edges_conn(&conn, 5000).unwrap_or_default();
+        let edges = store::read_edges_pool(&pool, 5000)
+            .await
+            .unwrap_or_default();
         let found = edges
             .iter()
             .any(|e| e.source == id_a && e.target == id_b && e.relation == "shares_context");
@@ -699,9 +720,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn auto_edge_shares_context_ignores_auto_tag() {
-        let conn = open_test_mem_db();
+    #[tokio::test]
+    async fn auto_edge_shares_context_ignores_auto_tag() {
+        let pool = open_test_mem_pool().await;
 
         let id_a = store::new_uuid();
         let node_a = store::Node {
@@ -716,7 +737,7 @@ mod tests {
             },
             body: "error C body".into(),
         };
-        store::write_node_conn(&conn, &node_a).unwrap();
+        store::write_node_pool(&pool, &node_a).await.unwrap();
 
         let id_b = store::new_uuid();
         let node_b = store::Node {
@@ -731,10 +752,10 @@ mod tests {
             },
             body: "error D body".into(),
         };
-        store::write_node_conn(&conn, &node_b).unwrap();
+        store::write_node_pool(&pool, &node_b).await.unwrap();
 
         let all_new_ids: Vec<&str> = vec![&id_a, &id_b];
-        let new_nodes = store::read_nodes_conn(&conn, &all_new_ids).unwrap();
+        let new_nodes = store::read_nodes_pool(&pool, &all_new_ids).await.unwrap();
 
         let shared: Vec<String> = new_nodes[0]
             .frontmatter
@@ -749,13 +770,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn resolution_node_created_when_pattern_absent_in_current_session() {
-        let conn = open_test_mem_db();
+    #[tokio::test]
+    async fn resolution_node_created_when_pattern_absent_in_current_session() {
+        let pool = open_test_mem_pool().await;
         let slug = "res-test-proj";
 
         // 1. Create project hub
-        let hub_id = ensure_project_hub(&conn, slug).unwrap();
+        let hub_id = ensure_project_hub_async(&pool, slug).await.unwrap();
 
         // 2. Create previous session node
         let prev_session_id = store::new_uuid();
@@ -772,7 +793,7 @@ mod tests {
             },
             body: "previous session".into(),
         };
-        store::write_node_conn(&conn, &prev_session).unwrap();
+        store::write_node_pool(&pool, &prev_session).await.unwrap();
 
         // 3. Create a pattern node from the previous session
         let pattern_id = store::new_uuid();
@@ -789,11 +810,11 @@ mod tests {
             },
             body: "pattern body".into(),
         };
-        store::write_node_conn(&conn, &pattern_node).unwrap();
+        store::write_node_pool(&pool, &pattern_node).await.unwrap();
 
         // 4. Edge: pattern -> prev_session (detected_in)
-        store::append_edge_conn(
-            &conn,
+        store::append_edge_pool(
+            &pool,
             &store::Edge {
                 id: store::new_uuid(),
                 source: pattern_id.clone(),
@@ -803,6 +824,7 @@ mod tests {
                 ts: "2026-01-01T00:00:00Z".into(),
             },
         )
+        .await
         .unwrap();
 
         // 5. Create current session node (simulates what ingest_to_memory does)
@@ -820,11 +842,11 @@ mod tests {
             },
             body: "current session".into(),
         };
-        store::write_node_conn(&conn, &curr_session).unwrap();
+        store::write_node_pool(&pool, &curr_session).await.unwrap();
 
         // 6. Edge: prev_session -> curr_session (follows)
-        store::append_edge_conn(
-            &conn,
+        store::append_edge_pool(
+            &pool,
             &store::Edge {
                 id: store::new_uuid(),
                 source: prev_session_id,
@@ -834,10 +856,11 @@ mod tests {
                 ts: "2026-01-02T00:00:00Z".into(),
             },
         )
+        .await
         .unwrap();
 
         // 7. Query prev pattern types via shared helper
-        let prev_pattern_types = query_prev_pattern_types(&conn, &curr_session_id);
+        let prev_pattern_types = query_prev_pattern_types_async(&pool, &curr_session_id).await;
 
         // Should find exactly the one pattern type from prev session
         assert_eq!(
@@ -875,11 +898,13 @@ mod tests {
                     pattern_type,
                 ),
             };
-            store::write_node_conn(&conn, &resolution_node).unwrap();
+            store::write_node_pool(&pool, &resolution_node)
+                .await
+                .unwrap();
 
             // Edge: resolution -> session (resolved_in)
-            store::append_edge_conn(
-                &conn,
+            store::append_edge_pool(
+                &pool,
                 &store::Edge {
                     id: store::new_uuid(),
                     source: resolution_id.clone(),
@@ -889,11 +914,12 @@ mod tests {
                     ts: "2026-01-02T00:00:00Z".into(),
                 },
             )
+            .await
             .unwrap();
 
             // Edge: resolution -> hub (belongs_to)
-            store::append_edge_conn(
-                &conn,
+            store::append_edge_pool(
+                &pool,
                 &store::Edge {
                     id: store::new_uuid(),
                     source: resolution_id.clone(),
@@ -903,11 +929,12 @@ mod tests {
                     ts: "2026-01-02T00:00:00Z".into(),
                 },
             )
+            .await
             .unwrap();
         }
 
         // 9. Verify the resolution node and edges exist
-        let edges = store::read_edges_conn(&conn, 5000).unwrap();
+        let edges = store::read_edges_pool(&pool, 5000).await.unwrap();
         let resolved_in: Vec<_> = edges
             .iter()
             .filter(|e| e.relation == "resolved_in" && e.target == curr_session_id)
@@ -934,9 +961,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn no_resolution_node_when_pattern_still_present() {
-        let conn = open_test_mem_db();
+    #[tokio::test]
+    async fn no_resolution_node_when_pattern_still_present() {
+        let pool = open_test_mem_pool().await;
         let slug = "res-still-present";
 
         // 1. Create previous session with a pattern
@@ -954,7 +981,7 @@ mod tests {
             },
             body: "prev session".into(),
         };
-        store::write_node_conn(&conn, &prev_session).unwrap();
+        store::write_node_pool(&pool, &prev_session).await.unwrap();
 
         let pattern_id = store::new_uuid();
         let pattern_node = store::Node {
@@ -970,10 +997,10 @@ mod tests {
             },
             body: "pattern body".into(),
         };
-        store::write_node_conn(&conn, &pattern_node).unwrap();
+        store::write_node_pool(&pool, &pattern_node).await.unwrap();
 
-        store::append_edge_conn(
-            &conn,
+        store::append_edge_pool(
+            &pool,
             &store::Edge {
                 id: store::new_uuid(),
                 source: pattern_id,
@@ -983,6 +1010,7 @@ mod tests {
                 ts: "2026-01-01T00:00:00Z".into(),
             },
         )
+        .await
         .unwrap();
 
         // 2. Create current session
@@ -1000,10 +1028,10 @@ mod tests {
             },
             body: "curr session".into(),
         };
-        store::write_node_conn(&conn, &curr_session).unwrap();
+        store::write_node_pool(&pool, &curr_session).await.unwrap();
 
-        store::append_edge_conn(
-            &conn,
+        store::append_edge_pool(
+            &pool,
             &store::Edge {
                 id: store::new_uuid(),
                 source: prev_session_id,
@@ -1013,10 +1041,11 @@ mod tests {
                 ts: "2026-01-02T00:00:00Z".into(),
             },
         )
+        .await
         .unwrap();
 
         // 3. Query prev pattern types via shared helper
-        let prev_pattern_types = query_prev_pattern_types(&conn, &curr_session_id);
+        let prev_pattern_types = query_prev_pattern_types_async(&pool, &curr_session_id).await;
 
         assert_eq!(prev_pattern_types.len(), 1);
         assert_eq!(prev_pattern_types[0], "thrashing");
@@ -1030,7 +1059,7 @@ mod tests {
         }
 
         // 5. Verify no resolution nodes exist
-        let all_edges = store::read_edges_conn(&conn, 5000).unwrap();
+        let all_edges = store::read_edges_pool(&pool, 5000).await.unwrap();
         let resolved_edges: Vec<_> = all_edges
             .iter()
             .filter(|e| e.relation == "resolved_in")

--- a/src/evolve/instincts.rs
+++ b/src/evolve/instincts.rs
@@ -69,12 +69,8 @@ pub fn extract_instincts(
 }
 
 pub fn promote_instincts_to_global(instincts: &[Instinct]) -> u64 {
-    let conn = match store::open_db() {
-        Ok(c) => c,
-        Err(_) => return 0,
-    };
-    let tx = match conn.unchecked_transaction() {
-        Ok(t) => t,
+    let pool = match crate::store::runtime::block_on(crate::store::pool::memory_pool()) {
+        Ok(p) => p,
         Err(_) => return 0,
     };
 
@@ -120,14 +116,15 @@ pub fn promote_instincts_to_global(instincts: &[Instinct]) -> u64 {
         };
 
         // Use dedup to avoid duplicate instincts (7-day window)
-        if let Ok((_, is_new)) = store::write_node_dedup_conn(&tx, &node, 168)
+        // write_node_dedup_pool returns (id, is_new): true = newly written, false = duplicate
+        if let Ok((_, is_new)) =
+            crate::store::runtime::block_on(store::write_node_dedup_pool(&pool, &node, 168))
             && is_new
         {
             promoted += 1;
         }
     }
 
-    let _ = tx.commit();
     promoted
 }
 

--- a/src/hooks/reflect.rs
+++ b/src/hooks/reflect.rs
@@ -528,8 +528,8 @@ pub fn run_context(
 /// Pulls top nodes by importance for each project slug (or all if slugs = [current]).
 /// Session-type nodes are excluded (importance=0.05, noise) unless there's nothing else.
 fn collect_mem(project_slugs: &[String]) -> serde_json::Value {
-    let conn = match store::open_db() {
-        Ok(c) => c,
+    let pool = match crate::store::runtime::block_on(crate::store::pool::memory_pool()) {
+        Ok(p) => p,
         Err(e) => {
             return serde_json::json!({"error": format!("mem db unavailable: {e}")});
         }
@@ -543,27 +543,33 @@ fn collect_mem(project_slugs: &[String]) -> serde_json::Value {
     };
 
     // Smart recall — hint = broad engineering context, limit = 30
-    let recalled = match store::smart_recall_conn(
-        &conn,
+    let recalled = match crate::store::runtime::block_on(store::smart_recall_pool(
+        &pool,
         project_filter,
         Some("decision pattern error resolution concept"),
         30,
-    ) {
+    )) {
         Ok(s) => s,
         Err(e) => return serde_json::json!({"error": format!("recall failed: {e}")}),
     };
 
     // Also pull top decisions/resolutions explicitly (high-value types)
-    let decisions = store::query_nodes_conn(
-        &conn,
+    let decisions = crate::store::runtime::block_on(store::query_nodes_pool(
+        &pool,
         None, // tag filter
         Some("decision"),
         project_filter,
         10,
-    )
+    ))
     .unwrap_or_default();
-    let resolutions = store::query_nodes_conn(&conn, None, Some("resolution"), project_filter, 10)
-        .unwrap_or_default();
+    let resolutions = crate::store::runtime::block_on(store::query_nodes_pool(
+        &pool,
+        None,
+        Some("resolution"),
+        project_filter,
+        10,
+    ))
+    .unwrap_or_default();
 
     // Merge and deduplicate by id, prefer higher-importance entry
     let mut seen: std::collections::HashMap<String, serde_json::Value> =

--- a/src/mem/axum_server.rs
+++ b/src/mem/axum_server.rs
@@ -23,13 +23,13 @@ use serde_json::{Value, json};
 use sqlx::SqlitePool;
 use tower_http::cors::{Any, CorsLayer};
 
-use super::graph::{compute_stats, rebuild_graph_json_pool};
-use super::server::{
-    compute_centrality_pool, handle_post_edge_pool, handle_post_node_pool, handle_put_node_pool,
+use super::graph::{compute_stats_pool, rebuild_graph_json_pool};
+use super::store::{
+    Edge, Node, NodeFrontmatter, append_edge_pool, importance_for_type, now_iso, write_node_pool,
 };
 use super::store::{
-    delete_edge_by_id, delete_node_file, read_index, read_node_pool, remove_edges_for_node,
-    remove_from_index, search_nodes_pool, validate_uuid,
+    delete_edge_by_id, delete_node_file, read_all_nodes_pool, read_node_pool,
+    remove_edges_for_node, remove_from_index, search_nodes_pool, validate_uuid,
 };
 use crate::store::pool;
 
@@ -107,6 +107,210 @@ async fn shutdown_signal() {
         .expect("failed to install CTRL+C handler");
 }
 
+// ── Business logic helpers (moved from server.rs) ─────────────────────────────
+
+const VALID_NODE_TYPES: &[&str] = &[
+    "decision",
+    "resolution",
+    "concept",
+    "project",
+    "error",
+    "session",
+    "pattern",
+    "instinct",
+    "psychographic",
+];
+
+const MAX_BODY_CHARS: usize = 65_536;
+const MAX_TITLE_CHARS: usize = 512;
+const MAX_ARRAY_ITEMS: usize = 50;
+const MAX_RELATION_CHARS: usize = 64;
+const WEIGHT_MIN: f64 = 0.0;
+const WEIGHT_MAX: f64 = 100.0;
+
+/// Create a new node using a pool connection.
+async fn handle_post_node_pool(body: &str, pool: &SqlitePool) -> Result<String, String> {
+    let v: serde_json::Value = serde_json::from_str(body).map_err(|e| e.to_string())?;
+    let id = uuid::Uuid::new_v4().to_string();
+    let now = now_iso();
+
+    let tags: Vec<String> = v["tags"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .take(MAX_ARRAY_ITEMS)
+                .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    let projects: Vec<String> = v["projects"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .take(MAX_ARRAY_ITEMS)
+                .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    let agents: Vec<String> = v["agents"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .take(MAX_ARRAY_ITEMS)
+                .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let node_type = v["type"].as_str().unwrap_or("concept").to_string();
+    if !VALID_NODE_TYPES.contains(&node_type.as_str()) {
+        return Err(format!("invalid node type: {node_type}"));
+    }
+    let importance = v["importance"]
+        .as_f64()
+        .unwrap_or_else(|| importance_for_type(&node_type))
+        .clamp(0.0, 1.0);
+    let node = Node {
+        frontmatter: NodeFrontmatter {
+            id: id.clone(),
+            node_type,
+            title: v["title"]
+                .as_str()
+                .unwrap_or("Untitled")
+                .chars()
+                .take(MAX_TITLE_CHARS)
+                .collect(),
+            tags,
+            projects,
+            agents,
+            created: now.clone(),
+            updated: now,
+            importance,
+            access_count: 0,
+            accessed_at: String::new(),
+        },
+        body: v["body"]
+            .as_str()
+            .unwrap_or("")
+            .chars()
+            .take(MAX_BODY_CHARS)
+            .collect(),
+    };
+
+    write_node_pool(pool, &node)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(id)
+}
+
+/// Update a node using a pool connection.
+async fn handle_put_node_pool(id: &str, body: &str, pool: &SqlitePool) -> Result<(), String> {
+    let mut node = read_node_pool(pool, id).await.map_err(|e| e.to_string())?;
+    let v: serde_json::Value = serde_json::from_str(body).map_err(|e| e.to_string())?;
+
+    if let Some(t) = v["title"].as_str() {
+        node.frontmatter.title = t.chars().take(MAX_TITLE_CHARS).collect();
+    }
+    if let Some(t) = v["type"].as_str() {
+        if !VALID_NODE_TYPES.contains(&t) {
+            return Err(format!("invalid node type: {t}"));
+        }
+        node.frontmatter.node_type = t.to_string();
+    }
+    if let Some(b) = v["body"].as_str() {
+        node.body = b.chars().take(MAX_BODY_CHARS).collect();
+    }
+    if let Some(tags) = v["tags"].as_array() {
+        node.frontmatter.tags = tags
+            .iter()
+            .take(MAX_ARRAY_ITEMS)
+            .filter_map(|x| x.as_str().map(|s| s.to_string()))
+            .collect();
+    }
+    if let Some(imp) = v["importance"].as_f64() {
+        node.frontmatter.importance = imp.clamp(0.0, 1.0);
+    }
+    node.frontmatter.updated = now_iso();
+
+    write_node_pool(pool, &node)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn parse_edge_payload(body: &str) -> Result<Edge, String> {
+    let v: serde_json::Value = serde_json::from_str(body).map_err(|e| e.to_string())?;
+    let source = v["source"].as_str().unwrap_or("").to_string();
+    let target = v["target"].as_str().unwrap_or("").to_string();
+    if !validate_uuid(&source) || !validate_uuid(&target) {
+        return Err("invalid source or target node id".to_string());
+    }
+    let relation: String = v["relation"]
+        .as_str()
+        .unwrap_or("related")
+        .chars()
+        .take(MAX_RELATION_CHARS)
+        .collect();
+    let weight = v["weight"]
+        .as_f64()
+        .unwrap_or(1.0)
+        .clamp(WEIGHT_MIN, WEIGHT_MAX);
+    Ok(Edge {
+        id: uuid::Uuid::new_v4().to_string(),
+        source,
+        target,
+        relation,
+        weight,
+        ts: now_iso(),
+    })
+}
+
+/// Create an edge using a pool connection.
+async fn handle_post_edge_pool(body: &str, pool: &SqlitePool) -> Result<String, String> {
+    let edge = parse_edge_payload(body)?;
+    let id = edge.id.clone();
+    append_edge_pool(pool, &edge)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(id)
+}
+
+/// Compute degree centrality using a pool connection.
+pub async fn compute_centrality_pool(pool: &SqlitePool, limit: usize) -> Vec<serde_json::Value> {
+    use sqlx::Row as SqlxRow;
+    let safe_limit = limit.min(100) as i64;
+    let sql = "SELECT n.id, n.title, n.type, n.importance, cnt.total_degree
+         FROM (
+             SELECT node_id, SUM(degree) AS total_degree FROM (
+                 SELECT source AS node_id, COUNT(*) AS degree FROM edges GROUP BY source
+                 UNION ALL
+                 SELECT target AS node_id, COUNT(*) AS degree FROM edges GROUP BY target
+             ) GROUP BY node_id
+         ) cnt
+         JOIN nodes n ON n.id = cnt.node_id
+         ORDER BY cnt.total_degree DESC
+         LIMIT ?1";
+
+    sqlx::query(sql)
+        .bind(safe_limit)
+        .fetch_all(pool)
+        .await
+        .map(|rows| {
+            rows.iter()
+                .map(|r| {
+                    serde_json::json!({
+                        "id": r.try_get::<String, _>(0).unwrap_or_default(),
+                        "title": r.try_get::<String, _>(1).unwrap_or_default(),
+                        "type": r.try_get::<String, _>(2).unwrap_or_default(),
+                        "importance": r.try_get::<f64, _>(3).unwrap_or(0.0),
+                        "degree": r.try_get::<i64, _>(4).unwrap_or(0),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 // ── Router ────────────────────────────────────────────────────────────────────
 
 pub fn build_router(state: AppState, port: u16) -> Router {
@@ -165,8 +369,9 @@ async fn handle_d3() -> impl IntoResponse {
         .unwrap()
 }
 
-async fn handle_stats() -> impl IntoResponse {
-    let body = compute_stats()
+async fn handle_stats(State(state): State<AppState>) -> impl IntoResponse {
+    let body = compute_stats_pool(&state.pool)
+        .await
         .map(|v| v.to_string())
         .unwrap_or_else(|_| r#"{"error":"stats unavailable"}"#.to_string());
     json_ok(body)
@@ -193,9 +398,22 @@ async fn handle_centrality(
     Json(data).into_response()
 }
 
-async fn handle_list_nodes() -> impl IntoResponse {
-    let idx = read_index();
-    Json(idx.nodes).into_response()
+async fn handle_list_nodes(State(state): State<AppState>) -> impl IntoResponse {
+    use super::store::IndexNode;
+    let nodes: Vec<IndexNode> = read_all_nodes_pool(&state.pool)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|n| IndexNode {
+            id: n.frontmatter.id,
+            title: n.frontmatter.title,
+            node_type: n.frontmatter.node_type,
+            tags: n.frontmatter.tags,
+            projects: n.frontmatter.projects,
+            updated: n.frontmatter.updated,
+        })
+        .collect();
+    Json(nodes).into_response()
 }
 
 async fn handle_create_node(State(state): State<AppState>, body: String) -> impl IntoResponse {

--- a/src/mem/graph.rs
+++ b/src/mem/graph.rs
@@ -5,11 +5,9 @@ use sqlx::{Row, SqlitePool};
 use std::collections::HashSet;
 use std::io;
 
-use rusqlite::{Connection, params_from_iter};
-
-use super::store::{
-    atomic_write, graph_path, list_node_ids_conn, open_db, read_edges_conn, read_nodes_conn,
-};
+use super::store::{list_node_ids_pool, read_edges_pool, read_nodes_pool};
+use crate::store::pool::memory_pool;
+use crate::store::runtime::block_on;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GraphNode {
@@ -44,206 +42,7 @@ pub struct Graph {
 /// Prevents unbounded memory growth on dense graphs.
 const MAX_GRAPH_EDGES: usize = 2000;
 
-/// Build a `Graph` value from an existing connection.
-/// Reuses the caller's connection — no additional `open_db` call.
-pub fn build_graph_conn(conn: &Connection) -> io::Result<Graph> {
-    let ids = list_node_ids_conn(conn)?;
-    let id_refs: Vec<&str> = ids.iter().map(String::as_str).collect();
-    let nodes = read_nodes_conn(conn, &id_refs)?
-        .into_iter()
-        .map(|node| GraphNode {
-            id: node.frontmatter.id,
-            title: node.frontmatter.title,
-            node_type: node.frontmatter.node_type,
-            tags: node.frontmatter.tags,
-            importance: node.frontmatter.importance,
-        })
-        .collect();
-    let edges = read_edges_conn(conn, MAX_GRAPH_EDGES)?
-        .into_iter()
-        .map(|e| GraphEdge {
-            source: e.source,
-            target: e.target,
-            relation: e.relation,
-            weight: e.weight,
-        })
-        .collect();
-    Ok(Graph { nodes, edges })
-}
-
-/// Build a `Graph` value from the current DB state.
-/// Opens a fresh connection and delegates to `build_graph_conn`.
-fn build_graph() -> io::Result<Graph> {
-    let conn = open_db()?;
-    build_graph_conn(&conn)
-}
-
-/// Build graph JSON string from an existing connection (no open_db call).
-/// Used by the web server to always return fresh data via its shared connection.
-pub fn rebuild_graph_json_conn(conn: &Connection) -> io::Result<String> {
-    serde_json::to_string_pretty(&build_graph_conn(conn)?)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
-}
-
-pub fn rebuild_graph() -> io::Result<()> {
-    let data = serde_json::to_vec_pretty(&build_graph()?)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-    atomic_write(&graph_path(), &data)
-}
-
-/// Build graph JSON string directly from DB (no file I/O).
-/// Used by the web server to always return fresh data.
-#[allow(dead_code)]
-pub fn rebuild_graph_json() -> io::Result<String> {
-    serde_json::to_string_pretty(&build_graph()?)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
-}
-
-/// Get 1-hop neighbors using an existing connection.
-/// Returns `(neighbor_id, total_weight)` sorted by weight descending.
-/// Maximum seeds accepted per call — keeps `WHERE IN (?, ...)` well below
-/// SQLite's `SQLITE_LIMIT_VARIABLE_NUMBER` default of 999 (2 copies are bound).
-const MAX_SEED_IDS: usize = 100;
-
-pub fn graph_neighbors_conn(conn: &Connection, seed_ids: &[String]) -> Vec<(String, f64)> {
-    if seed_ids.is_empty() {
-        return vec![];
-    }
-    let seed_ids = if seed_ids.len() > MAX_SEED_IDS {
-        eprintln!(
-            "[mem/graph] graph_neighbors_conn: seed_ids.len()={} exceeds MAX_SEED_IDS={}, truncating",
-            seed_ids.len(),
-            MAX_SEED_IDS
-        );
-        &seed_ids[..MAX_SEED_IDS]
-    } else {
-        seed_ids
-    };
-
-    let ph: String = seed_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
-    // Sum weights per neighbor from both forward and backward edges.
-    let sql = format!(
-        "SELECT target AS nb, SUM(weight) AS w FROM edges WHERE source IN ({ph}) GROUP BY target \
-         UNION ALL \
-         SELECT source AS nb, SUM(weight) AS w FROM edges WHERE target IN ({ph}) GROUP BY source"
-    );
-
-    let mut stmt = match conn.prepare(&sql) {
-        Ok(s) => s,
-        Err(_) => return vec![],
-    };
-
-    let rows: Vec<(String, f64)> = stmt
-        .query_map(
-            params_from_iter(seed_ids.iter().chain(seed_ids.iter())),
-            |row| Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?)),
-        )
-        .map(|rows| rows.flatten().collect())
-        .unwrap_or_default();
-
-    // Accumulate weights and exclude seeds.
-    let seed_set: HashSet<&str> = seed_ids.iter().map(String::as_str).collect();
-    let mut weights: std::collections::HashMap<String, f64> = std::collections::HashMap::new();
-    for (nid, w) in rows {
-        if !seed_set.contains(nid.as_str()) {
-            *weights.entry(nid).or_default() += w;
-        }
-    }
-
-    let mut result: Vec<(String, f64)> = weights.into_iter().collect();
-    result.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-    result
-}
-
-/// BFS traversal using an existing connection.
-///
-/// `depth` is accepted for API compatibility but is not used as a hop limit.
-/// The single-column `UNION` CTE deduplicates on `node_id` alone, so each node
-/// enters the working set at most once. This prevents re-expansion of visited
-/// nodes in cyclic or dense graphs. Results are capped at 500.
-pub fn related_nodes_conn(conn: &Connection, start_id: &str, _depth: usize) -> Vec<String> {
-    let sql = "
-        WITH RECURSIVE bfs(node_id) AS (
-            SELECT target FROM edges WHERE source = ?1
-            UNION SELECT source FROM edges WHERE target = ?1
-            UNION SELECT e.target FROM edges e JOIN bfs ON e.source = bfs.node_id WHERE e.target != ?1
-            UNION SELECT e.source FROM edges e JOIN bfs ON e.target = bfs.node_id WHERE e.source != ?1
-        )
-        SELECT node_id FROM bfs
-        LIMIT 500
-    ";
-
-    conn.prepare(sql)
-        .and_then(|mut stmt| {
-            stmt.query_map(rusqlite::params![start_id], |row| row.get::<_, String>(0))
-                .map(|rows| rows.flatten().collect())
-        })
-        .unwrap_or_default()
-}
-
-/// Compute aggregate stats for the `/api/stats` endpoint using an existing connection.
-pub fn compute_stats_conn(conn: &Connection) -> io::Result<serde_json::Value> {
-    let total_nodes: i64 = conn
-        .query_row("SELECT COUNT(*) FROM nodes", [], |r| r.get(0))
-        .unwrap_or(0);
-    let total_edges: i64 = conn
-        .query_row("SELECT COUNT(*) FROM edges", [], |r| r.get(0))
-        .unwrap_or(0);
-    let avg_importance: f64 = conn
-        .query_row("SELECT AVG(importance) FROM nodes", [], |r| r.get(0))
-        .unwrap_or(0.0);
-
-    let mut stmt = conn
-        .prepare("SELECT type, COUNT(*) FROM nodes GROUP BY type")
-        .map_err(io::Error::other)?;
-    let by_type: serde_json::Map<String, serde_json::Value> = stmt
-        .query_map([], |row| {
-            let t: String = row.get(0)?;
-            let c: i64 = row.get(1)?;
-            Ok((t, serde_json::Value::from(c)))
-        })
-        .map(|rows| rows.flatten().collect())
-        .unwrap_or_default();
-
-    Ok(serde_json::json!({
-        "total_nodes": total_nodes,
-        "total_edges": total_edges,
-        "avg_importance": (avg_importance * 100.0).round() / 100.0,
-        "by_type": serde_json::Value::Object(by_type),
-    }))
-}
-
-/// Compute aggregate stats for the `/api/stats` endpoint.
-pub fn compute_stats() -> io::Result<serde_json::Value> {
-    let conn = open_db()?;
-    compute_stats_conn(&conn)
-}
-
-/// BFS traversal from `start_id` to all reachable nodes via a SQL recursive CTE.
-///
-/// Uses `idx_edges_source` / `idx_edges_target` on each recursive step so only
-/// reachable edges are touched — O(reachable_edges) instead of O(E) total.
-/// Single-column `UNION` deduplicates on `node_id` alone, so each node enters
-/// the working set exactly once — preventing re-expansion in cyclic or dense
-/// graphs. The `depth` argument is kept for API compatibility but is ignored;
-/// traversal reaches all reachable nodes up to the LIMIT 500 safety cap.
-pub fn related_nodes(start_id: &str, depth: usize) -> Vec<String> {
-    let conn = match open_db() {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("[mem/graph] related_nodes: open_db failed: {e}");
-            return vec![];
-        }
-    };
-    related_nodes_conn(&conn, start_id, depth)
-}
-
-// ── Async pool functions ─────────────────────────────
-
-use super::store::{list_node_ids_pool, read_edges_pool, read_nodes_pool};
-
 /// Build a `Graph` value using a sqlx pool.
-#[allow(dead_code)]
 pub async fn build_graph_pool(pool: &SqlitePool) -> io::Result<Graph> {
     let ids = list_node_ids_pool(pool).await?;
     let id_refs: Vec<&str> = ids.iter().map(String::as_str).collect();
@@ -272,14 +71,38 @@ pub async fn build_graph_pool(pool: &SqlitePool) -> io::Result<Graph> {
 }
 
 /// Build graph JSON string using a sqlx pool.
-#[allow(dead_code)]
 pub async fn rebuild_graph_json_pool(pool: &SqlitePool) -> io::Result<String> {
     serde_json::to_string_pretty(&build_graph_pool(pool).await?)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
 }
 
+/// Build graph JSON string — sync wrapper that acquires pool internally.
+/// Used by server.rs and other sync callers for the `/api/graph` endpoint.
+pub fn rebuild_graph_json() -> io::Result<String> {
+    block_on(async {
+        let pool = memory_pool().await?;
+        rebuild_graph_json_pool(&pool).await
+    })
+}
+
+/// Write the graph JSON to the graph file on disk.
+pub fn rebuild_graph() -> io::Result<()> {
+    block_on(async {
+        let pool = memory_pool().await?;
+        let graph = build_graph_pool(&pool).await?;
+        let data = serde_json::to_vec_pretty(&graph)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        use super::store::atomic_write;
+        use super::store::graph_path;
+        atomic_write(&graph_path(), &data)
+    })
+}
+
+/// Maximum seeds accepted per call — keeps `WHERE IN (?, ...)` well below
+/// SQLite's `SQLITE_LIMIT_VARIABLE_NUMBER` default of 999 (2 copies are bound).
+const MAX_SEED_IDS: usize = 100;
+
 /// Async 1-hop neighbors using QueryBuilder for the IN clause.
-#[allow(dead_code)]
 pub async fn graph_neighbors_pool(pool: &SqlitePool, seed_ids: &[String]) -> Vec<(String, f64)> {
     if seed_ids.is_empty() {
         return vec![];
@@ -295,8 +118,6 @@ pub async fn graph_neighbors_pool(pool: &SqlitePool, seed_ids: &[String]) -> Vec
         seed_ids
     };
 
-    // Build: SELECT target AS nb, SUM(weight) AS w FROM edges WHERE source IN (...) GROUP BY target
-    // UNION ALL SELECT source AS nb, SUM(weight) AS w FROM edges WHERE target IN (...) GROUP BY source
     let mut qb = sqlx::QueryBuilder::new(
         "SELECT target AS nb, SUM(weight) AS w FROM edges WHERE source IN (",
     );
@@ -325,7 +146,6 @@ pub async fn graph_neighbors_pool(pool: &SqlitePool, seed_ids: &[String]) -> Vec
         })
         .collect();
 
-    // Accumulate weights and exclude seeds.
     let seed_set: HashSet<&str> = seed_ids.iter().map(String::as_str).collect();
     let mut weights: std::collections::HashMap<String, f64> = std::collections::HashMap::new();
     for (nid, w) in raw {
@@ -339,8 +159,19 @@ pub async fn graph_neighbors_pool(pool: &SqlitePool, seed_ids: &[String]) -> Vec
     result
 }
 
-/// Async BFS traversal using a sqlx pool.
+/// Get 1-hop neighbors — sync wrapper that acquires pool internally.
 #[allow(dead_code)]
+pub fn graph_neighbors(seed_ids: &[String]) -> Vec<(String, f64)> {
+    block_on(async {
+        let pool = memory_pool().await.unwrap_or_else(|e| {
+            eprintln!("[mem/graph] graph_neighbors: pool failed: {e}");
+            panic!("memory_pool unavailable");
+        });
+        graph_neighbors_pool(&pool, seed_ids).await
+    })
+}
+
+/// Async BFS traversal using a sqlx pool.
 pub async fn related_nodes_pool(pool: &SqlitePool, start_id: &str, _depth: usize) -> Vec<String> {
     let sql = "
         WITH RECURSIVE bfs(node_id) AS (
@@ -367,8 +198,21 @@ pub async fn related_nodes_pool(pool: &SqlitePool, start_id: &str, _depth: usize
         .unwrap_or_default()
 }
 
+/// BFS traversal from `start_id` — sync wrapper that acquires pool internally.
+pub fn related_nodes(start_id: &str, depth: usize) -> Vec<String> {
+    block_on(async {
+        let pool = match memory_pool().await {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("[mem/graph] related_nodes: pool failed: {e}");
+                return vec![];
+            }
+        };
+        related_nodes_pool(&pool, start_id, depth).await
+    })
+}
+
 /// Async compute aggregate stats using a sqlx pool.
-#[allow(dead_code)]
 pub async fn compute_stats_pool(pool: &SqlitePool) -> io::Result<serde_json::Value> {
     let total_nodes: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM nodes")
         .fetch_one(pool)
@@ -405,21 +249,32 @@ pub async fn compute_stats_pool(pool: &SqlitePool) -> io::Result<serde_json::Val
     }))
 }
 
+/// Compute aggregate stats — sync wrapper that acquires pool internally.
+pub fn compute_stats() -> io::Result<serde_json::Value> {
+    block_on(async {
+        let pool = memory_pool().await?;
+        compute_stats_pool(&pool).await
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::super::store::{Edge, append_edge_conn, init_schema};
+    use super::super::store::{Edge, append_edge_pool, init_schema_pool};
     use super::*;
-    use rusqlite::Connection;
+    use sqlx::sqlite::SqlitePoolOptions;
 
-    /// Open a fresh in-memory SQLite DB with the full schema applied.
-    /// Each call returns an independent connection — no shared state, no env var mutation.
-    fn mem_db() -> Connection {
-        let conn = Connection::open_in_memory().expect("in-memory db");
-        init_schema(&conn).expect("init_schema");
-        conn
+    /// Open a fresh in-memory SQLite pool with the full schema applied.
+    async fn mem_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory pool");
+        init_schema_pool(&pool).await.expect("init_schema_pool");
+        pool
     }
 
-    fn insert_edge(conn: &Connection, id: &str, src: &str, tgt: &str) {
+    async fn insert_edge(pool: &SqlitePool, id: &str, src: &str, tgt: &str) {
         let e = Edge {
             id: id.to_string(),
             source: src.to_string(),
@@ -428,21 +283,21 @@ mod tests {
             weight: 1.0,
             ts: "2026-01-01T00:00:00Z".to_string(),
         };
-        append_edge_conn(conn, &e).expect("append_edge_conn");
+        append_edge_pool(pool, &e).await.expect("append_edge_pool");
     }
 
     /// graph_neighbors returns 1-hop neighbors including backward edges.
-    #[test]
-    fn graph_neighbors_returns_direct_neighbors() {
-        let conn = mem_db();
+    #[tokio::test]
+    async fn graph_neighbors_returns_direct_neighbors() {
+        let pool = mem_pool().await;
 
         // A -> B, A -> C, D -> A (backward edge)
-        insert_edge(&conn, "e1", "A", "B");
-        insert_edge(&conn, "e2", "A", "C");
-        insert_edge(&conn, "e3", "D", "A");
+        insert_edge(&pool, "e1", "A", "B").await;
+        insert_edge(&pool, "e2", "A", "C").await;
+        insert_edge(&pool, "e3", "D", "A").await;
 
         let seeds = vec!["A".to_string()];
-        let mut result = graph_neighbors_conn(&conn, &seeds);
+        let mut result = graph_neighbors_pool(&pool, &seeds).await;
         result.sort_by(|a, b| a.0.cmp(&b.0));
 
         let ids: Vec<&str> = result.iter().map(|r| r.0.as_str()).collect();
@@ -456,16 +311,16 @@ mod tests {
     }
 
     /// graph_neighbors excludes all seeds from the result set.
-    #[test]
-    fn graph_neighbors_excludes_seeds() {
-        let conn = mem_db();
+    #[tokio::test]
+    async fn graph_neighbors_excludes_seeds() {
+        let pool = mem_pool().await;
 
         // Seed A -> Seed B -> C
-        insert_edge(&conn, "e1", "A", "B");
-        insert_edge(&conn, "e2", "B", "C");
+        insert_edge(&pool, "e1", "A", "B").await;
+        insert_edge(&pool, "e2", "B", "C").await;
 
         let seeds = vec!["A".to_string(), "B".to_string()];
-        let result = graph_neighbors_conn(&conn, &seeds);
+        let result = graph_neighbors_pool(&pool, &seeds).await;
         let ids: Vec<&str> = result.iter().map(|r| r.0.as_str()).collect();
 
         assert!(ids.contains(&"C"), "C should be reachable from B");
@@ -474,26 +329,26 @@ mod tests {
     }
 
     /// graph_neighbors with empty seed list returns empty.
-    #[test]
-    fn graph_neighbors_empty_seeds() {
-        let conn = mem_db();
-        let result = graph_neighbors_conn(&conn, &[]);
+    #[tokio::test]
+    async fn graph_neighbors_empty_seeds() {
+        let pool = mem_pool().await;
+        let result = graph_neighbors_pool(&pool, &[]).await;
         assert!(result.is_empty(), "empty seeds -> empty result");
     }
 
     /// related_nodes uses a single-column recursive CTE that traverses all
     /// reachable nodes. Each node appears at most once (UNION deduplicates on
     /// node_id alone). Cycles must not produce duplicate results.
-    #[test]
-    fn related_nodes_recursive_cte() {
-        let conn = mem_db();
+    #[tokio::test]
+    async fn related_nodes_recursive_cte() {
+        let pool = mem_pool().await;
 
         // Chain: A -> B -> C
-        insert_edge(&conn, "e1", "A", "B");
-        insert_edge(&conn, "e2", "B", "C");
+        insert_edge(&pool, "e1", "A", "B").await;
+        insert_edge(&pool, "e2", "B", "C").await;
 
         // All reachable nodes from A should include B and C; start node excluded.
-        let result = related_nodes_conn(&conn, "A", 2);
+        let result = related_nodes_pool(&pool, "A", 2).await;
         assert!(result.contains(&"B".to_string()), "should reach B");
         assert!(result.contains(&"C".to_string()), "should reach C (2-hop)");
         assert!(
@@ -502,8 +357,8 @@ mod tests {
         );
 
         // Cycle: C -> A — results must still be deduplicated (no duplicates).
-        insert_edge(&conn, "e3", "C", "A");
-        let cyclic = related_nodes_conn(&conn, "A", 3);
+        insert_edge(&pool, "e3", "C", "A").await;
+        let cyclic = related_nodes_pool(&pool, "A", 3).await;
         let unique: HashSet<_> = cyclic.iter().collect();
         assert_eq!(
             cyclic.len(),
@@ -517,16 +372,16 @@ mod tests {
     }
 
     /// graph_neighbors returns weight sums (both seeds connect to C with weight 1.0 each → 2.0).
-    #[test]
-    fn graph_neighbors_connection_count() {
-        let conn = mem_db();
+    #[tokio::test]
+    async fn graph_neighbors_connection_count() {
+        let pool = mem_pool().await;
 
         // Both seeds A and B connect to C (default weight 1.0 each → total 2.0).
-        insert_edge(&conn, "e1", "A", "C");
-        insert_edge(&conn, "e2", "B", "C");
+        insert_edge(&pool, "e1", "A", "C").await;
+        insert_edge(&pool, "e2", "B", "C").await;
 
         let seeds = vec!["A".to_string(), "B".to_string()];
-        let result = graph_neighbors_conn(&conn, &seeds);
+        let result = graph_neighbors_pool(&pool, &seeds).await;
         let c_weight = result.iter().find(|(id, _)| id == "C").map(|(_, w)| *w);
         assert_eq!(
             c_weight,

--- a/src/mem/mcp.rs
+++ b/src/mem/mcp.rs
@@ -6,17 +6,18 @@
 //! Implements MCP protocol version 2024-11-05 over stdin/stdout.
 //! Tools: mem_add, mem_query, mem_search, mem_related, mem_context
 
-use rusqlite::Connection;
 use serde::Deserialize;
 use serde_json::{Value, json};
+use sqlx::SqlitePool;
 use std::io::{self, BufRead, Write};
 
-use super::graph::{graph_neighbors_conn, related_nodes_conn};
+use super::graph::{graph_neighbors_pool, related_nodes_pool};
 use super::store::{
-    Node, NodeFrontmatter, importance_for_type, new_uuid, now_iso, open_db, query_nodes_conn,
-    read_node_conn, read_nodes_conn, search_nodes_conn, smart_recall_conn, touch_nodes_conn,
-    validate_uuid, write_node_dedup_conn,
+    Node, NodeFrontmatter, importance_for_type, new_uuid, now_iso, query_nodes_pool,
+    read_node_pool, read_nodes_pool, search_nodes_pool, smart_recall_pool, touch_nodes_pool,
+    validate_uuid, write_node_dedup_pool,
 };
+use crate::store::runtime;
 
 // ── Tool definitions ───────────────────────────────────────────────────────────
 
@@ -112,7 +113,7 @@ fn tool_definitions() -> Value {
 
 // ── Tool implementations ───────────────────────────────────────────────────────
 
-fn tool_mem_add(conn: &Connection, args: &Value) -> Value {
+fn tool_mem_add(pool: &SqlitePool, args: &Value) -> Value {
     let title = match args["title"].as_str() {
         Some(s) if !s.is_empty() => s.to_string(),
         _ => return json!({ "error": "mem_add requires title, type, and body" }),
@@ -166,20 +167,21 @@ fn tool_mem_add(conn: &Connection, args: &Value) -> Value {
         body,
     };
 
-    match write_node_dedup_conn(conn, &node, 24) {
+    match runtime::block_on(write_node_dedup_pool(pool, &node, 24)) {
         Ok((existing_id, true)) => json!({ "id": existing_id, "deduplicated": true }),
         Ok((_, false)) => json!({ "id": id, "created": now }),
         Err(e) => json!({ "error": format!("write failed: {e}") }),
     }
 }
 
-fn tool_mem_query(conn: &Connection, args: &Value) -> Value {
+fn tool_mem_query(pool: &SqlitePool, args: &Value) -> Value {
     let tag = args["tag"].as_str();
     let type_filter = args["type"].as_str();
     let project = args["project"].as_str();
     let limit = args["limit"].as_u64().unwrap_or(10) as usize;
 
-    let nodes = query_nodes_conn(conn, tag, type_filter, project, limit).unwrap_or_default();
+    let nodes = runtime::block_on(query_nodes_pool(pool, tag, type_filter, project, limit))
+        .unwrap_or_default();
     let results: Vec<Value> = nodes
         .iter()
         .map(|node| {
@@ -201,18 +203,18 @@ fn tool_mem_query(conn: &Connection, args: &Value) -> Value {
     json!(results)
 }
 
-fn tool_mem_search(conn: &Connection, args: &Value) -> Value {
+fn tool_mem_search(pool: &SqlitePool, args: &Value) -> Value {
     let query = match args["query"].as_str() {
         Some(s) if !s.is_empty() => s,
         _ => return json!({ "error": "mem_search requires query" }),
     };
     let limit = args["limit"].as_u64().unwrap_or(20) as usize;
 
-    let nodes = search_nodes_conn(conn, query, limit).unwrap_or_default();
+    let nodes = runtime::block_on(search_nodes_pool(pool, query, limit as i64)).unwrap_or_default();
 
     // Touch retrieved nodes
     let ids: Vec<String> = nodes.iter().map(|n| n.frontmatter.id.clone()).collect();
-    touch_nodes_conn(conn, &ids);
+    runtime::block_on(touch_nodes_pool(pool, &ids));
 
     let results: Vec<Value> = nodes
         .iter()
@@ -241,7 +243,7 @@ fn tool_mem_search(conn: &Connection, args: &Value) -> Value {
     resp
 }
 
-fn tool_mem_related(conn: &Connection, args: &Value) -> Value {
+fn tool_mem_related(pool: &SqlitePool, args: &Value) -> Value {
     let id = match args["id"].as_str() {
         Some(s) if !s.is_empty() => s,
         _ => return json!({ "error": "mem_related requires id" }),
@@ -251,30 +253,32 @@ fn tool_mem_related(conn: &Connection, args: &Value) -> Value {
     }
 
     let depth = args["depth"].as_u64().unwrap_or(2) as usize;
-    let related_ids = related_nodes_conn(conn, id, depth);
+    let related_ids = runtime::block_on(related_nodes_pool(pool, id, depth));
 
     let results: Vec<Value> = related_ids
         .iter()
         .filter_map(|rid| {
-            read_node_conn(conn, rid).ok().map(|node| {
-                json!({
-                    "id":    node.frontmatter.id,
-                    "title": node.frontmatter.title,
-                    "type":  node.frontmatter.node_type
+            runtime::block_on(read_node_pool(pool, rid))
+                .ok()
+                .map(|node| {
+                    json!({
+                        "id":    node.frontmatter.id,
+                        "title": node.frontmatter.title,
+                        "type":  node.frontmatter.node_type
+                    })
                 })
-            })
         })
         .collect();
 
     json!(results)
 }
 
-fn tool_mem_context(conn: &Connection, args: &Value) -> Value {
+fn tool_mem_context(pool: &SqlitePool, args: &Value) -> Value {
     let project = args["project"].as_str();
     let limit = args["limit"].as_u64().unwrap_or(5) as usize;
 
     // Use smart_recall for importance-weighted context
-    let scored = match smart_recall_conn(conn, project, None, limit) {
+    let scored = match runtime::block_on(smart_recall_pool(pool, project, None, limit)) {
         Ok(s) => s,
         Err(e) => return json!({"error": format!("recall failed: {e}")}),
     };
@@ -298,7 +302,7 @@ fn tool_mem_context(conn: &Connection, args: &Value) -> Value {
     json!(results)
 }
 
-fn tool_mem_recall(conn: &Connection, args: &Value) -> Value {
+fn tool_mem_recall(pool: &SqlitePool, args: &Value) -> Value {
     let hint = match args["hint"].as_str() {
         Some(s) if !s.is_empty() => s,
         _ => return json!({ "error": "mem_recall requires hint" }),
@@ -308,7 +312,7 @@ fn tool_mem_recall(conn: &Connection, args: &Value) -> Value {
     let include_neighbors = args["include_neighbors"].as_bool().unwrap_or(true);
 
     // Phase 1: Smart recall with composite scoring
-    let scored = match smart_recall_conn(conn, project, Some(hint), limit) {
+    let scored = match runtime::block_on(smart_recall_pool(pool, project, Some(hint), limit)) {
         Ok(s) => s,
         Err(e) => return json!({"error": format!("recall failed: {e}")}),
     };
@@ -334,7 +338,7 @@ fn tool_mem_recall(conn: &Connection, args: &Value) -> Value {
             .iter()
             .map(|sn| sn.node.frontmatter.id.clone())
             .collect();
-        let neighbors = graph_neighbors_conn(conn, &seed_ids);
+        let neighbors = runtime::block_on(graph_neighbors_pool(pool, &seed_ids));
 
         // Add up to 5 graph neighbors not already in results — batch-read in one query.
         let existing_ids: std::collections::HashSet<&str> = scored
@@ -355,27 +359,28 @@ fn tool_mem_recall(conn: &Connection, args: &Value) -> Value {
             let weight_by_id: std::collections::HashMap<&str, f64> =
                 candidates.iter().cloned().collect();
 
-            let neighbor_results: Vec<Value> = read_nodes_conn(conn, &candidate_ids)
-                .unwrap_or_default()
-                .into_iter()
-                .map(|node| {
-                    let edge_weight = weight_by_id
-                        .get(node.frontmatter.id.as_str())
-                        .copied()
-                        .unwrap_or(0.0);
-                    json!({
-                        "id":          node.frontmatter.id,
-                        "title":       node.frontmatter.title,
-                        "type":        node.frontmatter.node_type,
-                        "tags":        node.frontmatter.tags,
-                        "importance":  node.frontmatter.importance,
-                        "score":       (edge_weight * 100.0).round() / 100.0,
-                        "body":        node.body.chars().take(200).collect::<String>(),
-                        "via_graph":   true,
-                        "connections": (edge_weight * 100.0).round() / 100.0
+            let neighbor_results: Vec<Value> =
+                runtime::block_on(read_nodes_pool(pool, &candidate_ids))
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|node| {
+                        let edge_weight = weight_by_id
+                            .get(node.frontmatter.id.as_str())
+                            .copied()
+                            .unwrap_or(0.0);
+                        json!({
+                            "id":          node.frontmatter.id,
+                            "title":       node.frontmatter.title,
+                            "type":        node.frontmatter.node_type,
+                            "tags":        node.frontmatter.tags,
+                            "importance":  node.frontmatter.importance,
+                            "score":       (edge_weight * 100.0).round() / 100.0,
+                            "body":        node.body.chars().take(200).collect::<String>(),
+                            "via_graph":   true,
+                            "connections": (edge_weight * 100.0).round() / 100.0
+                        })
                     })
-                })
-                .collect();
+                    .collect();
 
             results.extend(neighbor_results);
         }
@@ -388,14 +393,14 @@ fn tool_mem_recall(conn: &Connection, args: &Value) -> Value {
     })
 }
 
-fn call_tool(conn: &Connection, name: &str, args: &Value) -> Value {
+fn call_tool(pool: &SqlitePool, name: &str, args: &Value) -> Value {
     let result = match name {
-        "mem_add" => tool_mem_add(conn, args),
-        "mem_query" => tool_mem_query(conn, args),
-        "mem_search" => tool_mem_search(conn, args),
-        "mem_related" => tool_mem_related(conn, args),
-        "mem_context" => tool_mem_context(conn, args),
-        "mem_recall" => tool_mem_recall(conn, args),
+        "mem_add" => tool_mem_add(pool, args),
+        "mem_query" => tool_mem_query(pool, args),
+        "mem_search" => tool_mem_search(pool, args),
+        "mem_related" => tool_mem_related(pool, args),
+        "mem_context" => tool_mem_context(pool, args),
+        "mem_recall" => tool_mem_recall(pool, args),
         _ => json!({ "error": format!("Unknown tool: {name}") }),
     };
     json!({ "content": [{ "type": "text", "text": result.to_string() }] })
@@ -418,7 +423,7 @@ fn send(obj: &Value) {
     let _ = out.flush();
 }
 
-fn handle_message(conn: &Connection, msg: &RpcRequest) {
+fn handle_message(pool: &SqlitePool, msg: &RpcRequest) {
     match msg.method.as_str() {
         "initialize" => {
             let resp = json!({
@@ -454,7 +459,7 @@ fn handle_message(conn: &Connection, msg: &RpcRequest) {
                 .cloned()
                 .unwrap_or(json!({}));
 
-            let result = call_tool(conn, tool_name, &tool_args);
+            let result = call_tool(pool, tool_name, &tool_args);
             let resp = json!({
                 "jsonrpc": "2.0",
                 "id": msg.id,
@@ -479,12 +484,12 @@ fn handle_message(conn: &Connection, msg: &RpcRequest) {
 
 /// Run the stdio MCP server loop. Reads newline-delimited JSON-RPC from stdin.
 ///
-/// Opens the database once at startup so that all tool calls within the session
-/// share a single connection — avoids re-running WAL setup and schema migration
-/// on every request.
+/// Opens the database pool once at startup so that all tool calls within the
+/// session share a single connection pool — avoids re-running WAL setup and
+/// schema migration on every request.
 pub fn run_mcp_server() -> i32 {
-    let conn = match open_db() {
-        Ok(c) => c,
+    let pool = match runtime::block_on(crate::store::pool::memory_pool()) {
+        Ok(p) => p,
         Err(e) => {
             eprintln!("harness-mem: failed to open database: {e}");
             return 1;
@@ -502,7 +507,7 @@ pub fn run_mcp_server() -> i32 {
             continue;
         }
         match serde_json::from_str::<RpcRequest>(&line) {
-            Ok(msg) => handle_message(&conn, &msg),
+            Ok(msg) => handle_message(&pool, &msg),
             Err(_) => {
                 // Ignore parse errors silently (per MCP spec)
             }

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -4,7 +4,6 @@ pub mod axum_server;
 pub mod cli;
 pub mod graph;
 pub mod mcp;
-pub mod server;
 pub mod store;
 
 pub fn run(args: &[String]) -> i32 {

--- a/src/mem/store/decay.rs
+++ b/src/mem/store/decay.rs
@@ -1,100 +1,24 @@
 //! decay.rs — Importance decay, stale tagging, and access tracking
 
-use rusqlite::{Connection, params};
 use sqlx::SqlitePool;
 use std::io;
 
 use super::util::{days_to_ymd, now_iso};
 
 /// Record an access event: increment access_count and update accessed_at.
-pub fn touch_node_conn(conn: &Connection, id: &str) {
-    let now = now_iso();
-    let _ = conn.execute(
-        "UPDATE nodes SET access_count = access_count + 1, accessed_at = ?1 WHERE id = ?2",
-        params![now, id],
-    );
-}
-
-/// Batch-touch multiple nodes using an existing connection.
-pub fn touch_nodes_conn(conn: &Connection, ids: &[String]) {
-    if ids.is_empty() {
-        return;
-    }
-    let _ = conn.execute_batch("SAVEPOINT touch_batch");
-    for id in ids {
-        touch_node_conn(conn, id);
-    }
-    let _ = conn.execute_batch("RELEASE touch_batch");
-}
-
-/// Gradually decay importance for nodes not accessed in `days`.
-/// Instead of binary stale tagging, reduces importance by `factor` (e.g., 0.9 = 10% decay).
-/// Nodes with importance already at or below `floor` are not decayed further.
-/// Returns the number of nodes decayed.
-pub fn decay_importance(days: u64, factor: f64, floor: f64) -> io::Result<u64> {
-    let conn = super::open_db()?;
-    let cutoff = {
-        let secs = std::time::SystemTime::now()
-            .duration_since(std::time::SystemTime::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs()
-            .saturating_sub(days * 86400);
-        let (y, m, d) = days_to_ymd(secs / 86400);
-        let hh = (secs / 3600) % 24;
-        let mm = (secs / 60) % 60;
-        let ss = secs % 60;
-        format!("{y:04}-{m:02}-{d:02}T{hh:02}:{mm:02}:{ss:02}Z")
-    };
-    let changed = conn
-        .execute(
-            "UPDATE nodes SET importance = MAX(?3, importance * ?2)
-         WHERE (accessed_at < ?1 OR accessed_at = '')
-           AND updated < ?1
-           AND importance > ?3
-           AND ',' || tags || ',' NOT LIKE '%,pinned,%'",
-            params![cutoff, factor, floor],
-        )
-        .map_err(io::Error::other)?;
-    Ok(changed as u64)
-}
-
-/// Tag nodes not updated within `days` as stale by appending "stale" to their tags.
-pub fn tag_stale_nodes(days: u64) -> io::Result<u64> {
-    let conn = super::open_db()?;
-    // Compute cutoff timestamp in Rust to avoid format!() SQL interpolation.
-    let cutoff_secs = std::time::SystemTime::now()
-        .duration_since(std::time::SystemTime::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs()
-        .saturating_sub(days * 86400);
-    let cutoff = {
-        let s = cutoff_secs;
-        let (y, m, d) = days_to_ymd(s / 86400);
-        let hh = (s / 3600) % 24;
-        let mm = (s / 60) % 60;
-        let ss = s % 60;
-        format!("{y:04}-{m:02}-{d:02}T{hh:02}:{mm:02}:{ss:02}Z")
-    };
-    let changed = conn
-        .execute(
-            "UPDATE nodes SET tags = CASE
-            WHEN tags = '' THEN 'stale'
-            WHEN ',' || tags || ',' NOT LIKE '%,stale,%' THEN tags || ',stale'
-            ELSE tags
-         END
-         WHERE updated < ?1
-           AND ',' || tags || ',' NOT LIKE '%,stale,%'",
-            params![cutoff],
-        )
-        .map_err(io::Error::other)?;
-    Ok(changed as u64)
-}
-
-// ── Async pool functions ─────────────────────────────
-
-/// Async batch-touch using a single batched UPDATE (replaces N+1 per-row loop).
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
 #[allow(dead_code)]
+pub async fn touch_node_pool(pool: &SqlitePool, id: &str) {
+    let now = now_iso();
+    let _ = sqlx::query(
+        "UPDATE nodes SET access_count = access_count + 1, accessed_at = ? WHERE id = ?",
+    )
+    .bind(&now)
+    .bind(id)
+    .execute(pool)
+    .await;
+}
+
+/// Async batch-touch using a single batched UPDATE.
 pub async fn touch_nodes_pool(pool: &SqlitePool, ids: &[String]) {
     if ids.is_empty() {
         return;
@@ -124,9 +48,24 @@ pub async fn touch_nodes_pool(pool: &SqlitePool, ids: &[String]) {
     }
 }
 
+/// Gradually decay importance for nodes not accessed in `days`.
+/// Returns the number of nodes decayed.
+pub fn decay_importance(days: u64, factor: f64, floor: f64) -> io::Result<u64> {
+    crate::store::runtime::block_on(async {
+        let pool = crate::store::pool::memory_pool().await?;
+        decay_importance_pool(&pool, days, factor, floor).await
+    })
+}
+
+/// Tag nodes not updated within `days` as stale by appending "stale" to their tags.
+pub fn tag_stale_nodes(days: u64) -> io::Result<u64> {
+    crate::store::runtime::block_on(async {
+        let pool = crate::store::pool::memory_pool().await?;
+        tag_stale_nodes_pool(&pool, days).await
+    })
+}
+
 /// Async importance decay using pool.
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
 pub async fn decay_importance_pool(
     pool: &SqlitePool,
     days: u64,
@@ -164,8 +103,6 @@ pub async fn decay_importance_pool(
 }
 
 /// Async stale tagging using pool.
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
 pub async fn tag_stale_nodes_pool(pool: &SqlitePool, days: u64) -> io::Result<u64> {
     let cutoff_secs = std::time::SystemTime::now()
         .duration_since(std::time::SystemTime::UNIX_EPOCH)

--- a/src/mem/store/dedup.rs
+++ b/src/mem/store/dedup.rs
@@ -1,71 +1,22 @@
 //! dedup.rs — Node deduplication logic
 
-use rusqlite::{Connection, params};
 use sqlx::SqlitePool;
 use std::io;
 
-use super::node::{write_node_conn, write_node_pool};
+use super::node::write_node_pool;
 use super::types::Node;
 use super::util::days_to_ymd;
 
-/// Returns the ID of an existing node with the same title updated within the
-/// last `window_hours` hours.  Uses the composite idx_nodes_title_updated index
-/// for O(log N) lookup.  Used to prevent duplicate writes when multiple callers
-/// (observe hook + skills + direct MCP) fire for the same event.
-pub(crate) fn find_duplicate_in_conn(
-    conn: &Connection,
-    title: &str,
-    window_hours: u64,
-) -> Option<String> {
-    let cutoff_secs = std::time::SystemTime::now()
-        .duration_since(std::time::SystemTime::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs()
-        .saturating_sub(window_hours * 3600);
-    let cutoff = {
-        let s = cutoff_secs;
-        let (y, m, d) = days_to_ymd(s / 86400);
-        let hh = (s / 3600) % 24;
-        let mm = (s / 60) % 60;
-        let ss = s % 60;
-        format!("{y:04}-{m:02}-{d:02}T{hh:02}:{mm:02}:{ss:02}Z")
-    };
-    conn.query_row(
-        "SELECT id FROM nodes WHERE title = ?1 AND updated > ?2 ORDER BY updated DESC LIMIT 1",
-        params![title, cutoff],
-        |row| row.get::<_, String>(0),
-    )
-    .ok()
-}
-
-/// Write-with-dedup: opens a single connection, checks for a duplicate, and
-/// writes only when none is found.  Returns `(id, was_deduplicated)`.
+/// Write-with-dedup: checks for a duplicate, writes only when none is found.
+/// Returns `(id, was_deduplicated)`.
 pub fn write_node_dedup(node: &Node, window_hours: u64) -> io::Result<(String, bool)> {
-    let conn = super::open_db()?;
-    write_node_dedup_conn(&conn, node, window_hours)
+    crate::store::runtime::block_on(async {
+        let pool = crate::store::pool::memory_pool().await?;
+        write_node_dedup_pool(&pool, node, window_hours).await
+    })
 }
-
-/// Write-with-dedup using an existing connection (for batch/transaction use).
-pub fn write_node_dedup_conn(
-    conn: &Connection,
-    node: &Node,
-    window_hours: u64,
-) -> io::Result<(String, bool)> {
-    let title = &node.frontmatter.title;
-
-    if let Some(existing_id) = find_duplicate_in_conn(conn, title, window_hours) {
-        return Ok((existing_id, true));
-    }
-
-    write_node_conn(conn, node)?;
-    Ok((node.frontmatter.id.clone(), false))
-}
-
-// ── Async pool functions ─────────────────────────────
 
 /// Async write-with-dedup using a sqlx pool.
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
 pub async fn write_node_dedup_pool(
     pool: &SqlitePool,
     node: &Node,
@@ -81,8 +32,6 @@ pub async fn write_node_dedup_pool(
     Ok((node.frontmatter.id.clone(), false))
 }
 
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
 async fn find_duplicate_in_pool(
     pool: &SqlitePool,
     title: &str,

--- a/src/mem/store/edge.rs
+++ b/src/mem/store/edge.rs
@@ -1,67 +1,15 @@
 //! edge.rs — Edge CRUD operations
 
-use rusqlite::{Connection, params};
 use sqlx::{Row, SqlitePool};
 use std::io;
 
 use super::types::Edge;
 
 pub fn append_edge(edge: &Edge) -> io::Result<()> {
-    let conn = super::open_db()?;
-    conn.execute(
-        "INSERT OR IGNORE INTO edges (id, source, target, relation, weight, ts)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-        params![
-            edge.id,
-            edge.source,
-            edge.target,
-            edge.relation,
-            edge.weight,
-            edge.ts
-        ],
-    )
-    .map_err(io::Error::other)?;
-    Ok(())
-}
-
-/// Append an edge using an existing connection (for batch/transaction use).
-pub fn append_edge_conn(conn: &Connection, edge: &Edge) -> io::Result<()> {
-    conn.execute(
-        "INSERT OR IGNORE INTO edges (id, source, target, relation, weight, ts)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-        params![
-            edge.id,
-            edge.source,
-            edge.target,
-            edge.relation,
-            edge.weight,
-            edge.ts
-        ],
-    )
-    .map_err(io::Error::other)?;
-    Ok(())
-}
-
-/// Read edges using an existing connection, capped at `limit`.
-pub fn read_edges_conn(conn: &Connection, limit: usize) -> io::Result<Vec<Edge>> {
-    let mut stmt = conn
-        .prepare("SELECT id, source, target, relation, weight, ts FROM edges LIMIT ?1")
-        .map_err(io::Error::other)?;
-    let edges: Vec<Edge> = stmt
-        .query_map(params![limit as i64], |row| {
-            Ok(Edge {
-                id: row.get(0)?,
-                source: row.get(1)?,
-                target: row.get(2)?,
-                relation: row.get(3)?,
-                weight: row.get(4)?,
-                ts: row.get(5)?,
-            })
-        })
-        .map_err(io::Error::other)?
-        .filter_map(|r| r.ok())
-        .collect();
-    Ok(edges)
+    crate::store::runtime::block_on(async {
+        let pool = crate::store::pool::memory_pool().await?;
+        append_edge_pool(&pool, edge).await
+    })
 }
 
 #[allow(dead_code)] // used by integration tests (tests/mem_test.rs)
@@ -70,49 +18,32 @@ pub fn read_edges() -> Vec<Edge> {
 }
 
 pub fn read_edges_limit(limit: usize) -> Vec<Edge> {
-    match super::open_db() {
-        Ok(conn) => read_edges_conn(&conn, limit).unwrap_or_else(|e| {
-            eprintln!("[mem/store] read_edges: query failed: {e}");
-            vec![]
-        }),
-        Err(e) => {
-            eprintln!("[mem/store] read_edges: open_db failed: {e}");
-            vec![]
-        }
-    }
+    crate::store::runtime::block_on(async {
+        let pool = crate::store::pool::memory_pool().await?;
+        read_edges_pool(&pool, limit as i64).await
+    })
+    .unwrap_or_else(|e| {
+        eprintln!("[mem/store] read_edges: {e}");
+        vec![]
+    })
 }
 
 pub fn delete_edge_by_id(edge_id: &str) -> io::Result<()> {
-    let conn = super::open_db()?;
-    delete_edge_by_id_conn(&conn, edge_id)
-}
-
-/// Delete an edge using an existing connection (for use with shared state).
-pub fn delete_edge_by_id_conn(conn: &Connection, edge_id: &str) -> io::Result<()> {
-    conn.execute("DELETE FROM edges WHERE id = ?1", params![edge_id])
-        .map_err(io::Error::other)?;
-    Ok(())
+    crate::store::runtime::block_on(async {
+        let pool = crate::store::pool::memory_pool().await?;
+        delete_edge_by_id_pool(&pool, edge_id).await
+    })
 }
 
 pub fn remove_edges_for_node(node_id: &str) -> io::Result<()> {
-    let conn = super::open_db()?;
-    remove_edges_for_node_conn(&conn, node_id)
-}
-
-/// Remove edges for a node using an existing connection (for use with shared state).
-pub fn remove_edges_for_node_conn(conn: &Connection, node_id: &str) -> io::Result<()> {
-    conn.execute(
-        "DELETE FROM edges WHERE source = ?1 OR target = ?1",
-        params![node_id],
-    )
-    .map_err(io::Error::other)?;
-    Ok(())
+    crate::store::runtime::block_on(async {
+        let pool = crate::store::pool::memory_pool().await?;
+        remove_edges_for_node_pool(&pool, node_id).await
+    })
 }
 
 // ── Async pool functions ─────────────────────────────
 
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
 pub async fn append_edge_pool(pool: &SqlitePool, edge: &Edge) -> io::Result<()> {
     sqlx::query(
         "INSERT OR IGNORE INTO edges (id, source, target, relation, weight, ts)
@@ -130,8 +61,6 @@ pub async fn append_edge_pool(pool: &SqlitePool, edge: &Edge) -> io::Result<()> 
     Ok(())
 }
 
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
 pub async fn read_edges_pool(pool: &SqlitePool, limit: i64) -> io::Result<Vec<Edge>> {
     let rows = sqlx::query("SELECT id, source, target, relation, weight, ts FROM edges LIMIT ?")
         .bind(limit)
@@ -152,8 +81,6 @@ pub async fn read_edges_pool(pool: &SqlitePool, limit: i64) -> io::Result<Vec<Ed
         .collect()
 }
 
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
 pub async fn delete_edge_by_id_pool(pool: &SqlitePool, edge_id: &str) -> io::Result<()> {
     sqlx::query("DELETE FROM edges WHERE id = ?")
         .bind(edge_id)
@@ -163,8 +90,6 @@ pub async fn delete_edge_by_id_pool(pool: &SqlitePool, edge_id: &str) -> io::Res
     Ok(())
 }
 
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
 pub async fn remove_edges_for_node_pool(pool: &SqlitePool, node_id: &str) -> io::Result<()> {
     sqlx::query("DELETE FROM edges WHERE source = ? OR target = ?")
         .bind(node_id)

--- a/src/mem/store/index.rs
+++ b/src/mem/store/index.rs
@@ -1,73 +1,56 @@
 //! index.rs — Index (built from DB) operations
 
-use super::node::{delete_node_file, write_node};
+use super::node::{delete_node_file, read_all_nodes_pool, write_node};
 use super::types::{Index, IndexNode};
 use super::util::split_csv;
 
+#[allow(dead_code)]
 pub fn read_index() -> Index {
-    let conn = match super::open_db() {
-        Ok(c) => c,
-        Err(_) => return Index::default(),
-    };
-    let mut stmt = match conn
-        .prepare("SELECT id, type, title, tags, projects, updated FROM nodes ORDER BY updated DESC")
-    {
-        Ok(s) => s,
-        Err(_) => return Index::default(),
-    };
+    crate::store::runtime::block_on(async {
+        let pool = crate::store::pool::memory_pool().await?;
+        read_all_nodes_pool(&pool).await
+    })
+    .map(|nodes| {
+        let mut by_tag: std::collections::HashMap<String, Vec<String>> = Default::default();
+        let mut by_type: std::collections::HashMap<String, Vec<String>> = Default::default();
+        let mut by_project: std::collections::HashMap<String, Vec<String>> = Default::default();
 
-    let index_nodes: Vec<IndexNode> = stmt
-        .query_map([], |row| {
-            let id: String = row.get(0)?;
-            let node_type: String = row.get(1)?;
-            let title: String = row.get(2)?;
-            let tags_str: String = row.get(3)?;
-            let projects_str: String = row.get(4)?;
-            let updated: String = row.get(5)?;
-            Ok((id, node_type, title, tags_str, projects_str, updated))
-        })
-        .map(|rows| {
-            rows.filter_map(|r| r.ok())
-                .map(
-                    |(id, node_type, title, tags_str, projects_str, updated)| IndexNode {
-                        id,
-                        title,
-                        node_type,
-                        tags: split_csv(&tags_str),
-                        projects: split_csv(&projects_str),
-                        updated,
-                    },
-                )
-                .collect()
-        })
-        .unwrap_or_default();
+        let index_nodes: Vec<IndexNode> = nodes
+            .iter()
+            .map(|n| {
+                let fm = &n.frontmatter;
+                for tag in &fm.tags {
+                    by_tag.entry(tag.clone()).or_default().push(fm.id.clone());
+                }
+                by_type
+                    .entry(fm.node_type.clone())
+                    .or_default()
+                    .push(fm.id.clone());
+                for proj in &fm.projects {
+                    by_project
+                        .entry(proj.clone())
+                        .or_default()
+                        .push(fm.id.clone());
+                }
+                IndexNode {
+                    id: fm.id.clone(),
+                    title: fm.title.clone(),
+                    node_type: fm.node_type.clone(),
+                    tags: split_csv(&fm.tags.join(",")),
+                    projects: split_csv(&fm.projects.join(",")),
+                    updated: fm.updated.clone(),
+                }
+            })
+            .collect();
 
-    let mut by_tag: std::collections::HashMap<String, Vec<String>> = Default::default();
-    let mut by_type: std::collections::HashMap<String, Vec<String>> = Default::default();
-    let mut by_project: std::collections::HashMap<String, Vec<String>> = Default::default();
-
-    for n in &index_nodes {
-        for tag in &n.tags {
-            by_tag.entry(tag.clone()).or_default().push(n.id.clone());
+        Index {
+            nodes: index_nodes,
+            by_tag,
+            by_type,
+            by_project,
         }
-        by_type
-            .entry(n.node_type.clone())
-            .or_default()
-            .push(n.id.clone());
-        for proj in &n.projects {
-            by_project
-                .entry(proj.clone())
-                .or_default()
-                .push(n.id.clone());
-        }
-    }
-
-    Index {
-        nodes: index_nodes,
-        by_tag,
-        by_type,
-        by_project,
-    }
+    })
+    .unwrap_or_default()
 }
 
 /// Upsert a node into the DB (same as write_node — the index IS the DB).

--- a/src/mem/store/mod.rs
+++ b/src/mem/store/mod.rs
@@ -24,6 +24,7 @@ pub use types::{Edge, IndexNode, Node, NodeFrontmatter, importance_for_type};
 
 // ── Re-exports: util ─────────────────────────────────
 
+#[allow(unused_imports)]
 pub use util::{
     atomic_write, db_path, graph_path, new_uuid, nodes_dir, now_iso, parse_iso_to_secs,
     validate_uuid,
@@ -31,54 +32,47 @@ pub use util::{
 
 // ── Re-exports: schema ───────────────────────────────
 
-#[cfg(test)]
-pub(crate) use schema::init_schema;
+pub(crate) use schema::auto_migrate_legacy;
+pub use schema::init_schema_pool;
 
 // ── Re-exports: node ─────────────────────────────────
 
-#[allow(unused_imports)] // re-exported for external crate consumers (graphos-desktop)
 pub use node::{
-    delete_node_file, delete_node_file_conn, list_node_ids, list_node_ids_conn, node_exists_conn,
-    parse_node, read_all_nodes_conn, read_node, read_node_conn, read_nodes_conn,
-    read_nodes_limited_conn, serialize_node, write_node,
+    delete_node_file, list_node_ids, parse_node, read_node, serialize_node, write_node,
 };
 
-pub use node::write_node_conn;
+pub use node::write_node_pool;
 
 // ── Re-exports: edge ─────────────────────────────────
 
-#[allow(unused_imports)] // re-exported for external crate consumers (graphos-desktop)
-pub use edge::{
-    append_edge, append_edge_conn, delete_edge_by_id, delete_edge_by_id_conn, read_edges,
-    read_edges_conn, remove_edges_for_node, remove_edges_for_node_conn,
-};
+#[allow(unused_imports)]
+pub use edge::{append_edge, delete_edge_by_id, read_edges, remove_edges_for_node};
 
 // ── Re-exports: index ────────────────────────────────
 
+#[allow(unused_imports)]
 pub use index::{read_index, remove_from_index, upsert_index};
 
 // ── Re-exports: dedup ────────────────────────────────
 
-pub use dedup::{write_node_dedup, write_node_dedup_conn};
+pub use dedup::{write_node_dedup, write_node_dedup_pool};
 
 // ── Re-exports: decay ────────────────────────────────
 
-pub use decay::{decay_importance, tag_stale_nodes, touch_nodes_conn};
+pub use decay::{decay_importance, tag_stale_nodes, touch_nodes_pool};
 
 // ── Re-exports: recall ───────────────────────────────
 
-pub use recall::{smart_recall, smart_recall_conn};
+pub use recall::{smart_recall, smart_recall_pool};
 
 // ── Re-exports: search ───────────────────────────────
 
-pub use search::{query_nodes, query_nodes_conn, search_nodes, search_nodes_conn};
+pub use search::{query_nodes, search_nodes, search_nodes_pool};
 
 // ── Re-exports: async pool functions ──────────────────
 
-#[allow(unused_imports)] // new async APIs — not yet consumed by callers
-pub use decay::{decay_importance_pool, tag_stale_nodes_pool, touch_nodes_pool};
 #[allow(unused_imports)]
-pub use dedup::write_node_dedup_pool;
+pub use decay::{decay_importance_pool, tag_stale_nodes_pool};
 #[allow(unused_imports)]
 pub use edge::{
     append_edge_pool, delete_edge_by_id_pool, read_edges_pool, remove_edges_for_node_pool,
@@ -86,34 +80,7 @@ pub use edge::{
 #[allow(unused_imports)]
 pub use node::{
     delete_node_pool, list_node_ids_pool, node_exists_pool, read_all_nodes_pool, read_node_pool,
-    read_nodes_limited_pool, read_nodes_pool, write_node_pool,
+    read_nodes_limited_pool, read_nodes_pool,
 };
 #[allow(unused_imports)]
-pub use recall::smart_recall_pool;
-#[allow(unused_imports)]
-pub use schema::init_schema_pool;
-#[allow(unused_imports)]
-pub use search::{query_nodes_pool, search_nodes_pool};
-
-// ── DB connection ────────────────────────────────────
-
-use rusqlite::Connection;
-use std::fs;
-use std::io;
-
-/// Open the memory database, applying schema and auto-migration.
-pub fn open_db() -> io::Result<Connection> {
-    let path = db_path();
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let conn = Connection::open(&path).map_err(io::Error::other)?;
-
-    // WAL mode for better concurrency
-    conn.execute_batch("PRAGMA journal_mode=WAL;")
-        .map_err(io::Error::other)?;
-
-    schema::init_schema(&conn)?;
-    schema::auto_migrate_legacy(&conn);
-    Ok(conn)
-}
+pub use search::query_nodes_pool;

--- a/src/mem/store/node.rs
+++ b/src/mem/store/node.rs
@@ -1,6 +1,5 @@
 //! node.rs — Node CRUD operations
 
-use rusqlite::{Connection, params};
 use sqlx::{Row, SqlitePool};
 use std::io;
 
@@ -8,138 +7,31 @@ use super::types::Node;
 use super::util::{NODE_COLUMNS, join_csv};
 
 pub fn write_node(node: &Node) -> io::Result<()> {
-    let conn = super::open_db()?;
-    write_node_conn(&conn, node)
-}
-
-pub fn write_node_conn(conn: &Connection, node: &Node) -> io::Result<()> {
-    let fm = &node.frontmatter;
-    conn.execute(
-        "INSERT OR REPLACE INTO nodes (id, type, title, tags, projects, agents, created, updated, body, importance, access_count, accessed_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
-        params![
-            fm.id,
-            fm.node_type,
-            fm.title,
-            join_csv(&fm.tags),
-            join_csv(&fm.projects),
-            join_csv(&fm.agents),
-            fm.created,
-            fm.updated,
-            node.body,
-            fm.importance,
-            fm.access_count,
-            fm.accessed_at,
-        ],
-    )
-    .map_err(io::Error::other)?;
-    Ok(())
+    crate::store::runtime::block_on(async {
+        let pool = crate::store::pool::memory_pool().await?;
+        write_node_pool(&pool, node).await
+    })
 }
 
 pub fn read_node(id: &str) -> io::Result<Node> {
-    let conn = super::open_db()?;
-    read_node_conn(&conn, id)
-}
-
-/// Batch-read multiple nodes by ID in a single `WHERE id IN (...)` query.
-pub fn read_nodes_conn(conn: &Connection, ids: &[&str]) -> io::Result<Vec<Node>> {
-    if ids.is_empty() {
-        return Ok(vec![]);
-    }
-    let ph = ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
-    let sql = format!("SELECT {NODE_COLUMNS} FROM nodes WHERE id IN ({ph})");
-    let mut stmt = conn.prepare(&sql).map_err(io::Error::other)?;
-    let nodes: Vec<Node> = stmt
-        .query_map(
-            rusqlite::params_from_iter(ids.iter()),
-            super::util::row_to_node,
-        )
-        .map_err(io::Error::other)?
-        .filter_map(|r| {
-            r.map_err(|e| eprintln!("[mem/node] row deserialization error: {e}"))
-                .ok()
-        })
-        .collect();
-    Ok(nodes)
-}
-
-pub fn read_node_conn(conn: &Connection, id: &str) -> io::Result<Node> {
-    let sql = format!("SELECT {NODE_COLUMNS} FROM nodes WHERE id = ?1");
-    conn.query_row(&sql, params![id], super::util::row_to_node)
-        .map_err(|_| io::Error::new(io::ErrorKind::NotFound, format!("node not found: {id}")))
+    crate::store::runtime::block_on(async {
+        let pool = crate::store::pool::memory_pool().await?;
+        read_node_pool(&pool, id).await
+    })
 }
 
 pub fn delete_node_file(id: &str) -> io::Result<()> {
-    let conn = super::open_db()?;
-    delete_node_file_conn(&conn, id)
-}
-
-/// Delete a node using an existing connection (for use with shared state).
-/// Check if a node with the given ID exists.
-#[allow(dead_code)]
-pub fn node_exists_conn(conn: &Connection, id: &str) -> bool {
-    conn.query_row(
-        "SELECT EXISTS(SELECT 1 FROM nodes WHERE id = ?1)",
-        params![id],
-        |row| row.get::<_, bool>(0),
-    )
-    .unwrap_or(false)
-}
-
-pub fn delete_node_file_conn(conn: &Connection, id: &str) -> io::Result<()> {
-    conn.execute("DELETE FROM nodes WHERE id = ?1", params![id])
-        .map_err(io::Error::other)?;
-    Ok(())
-}
-
-/// Read all nodes ordered by updated DESC in a single query.
-#[allow(dead_code)] // used by graphos-desktop (Tauri) through public API
-pub fn read_all_nodes_conn(conn: &Connection) -> io::Result<Vec<Node>> {
-    let sql = format!("SELECT {NODE_COLUMNS} FROM nodes ORDER BY updated DESC");
-    let mut stmt = conn.prepare(&sql).map_err(io::Error::other)?;
-    let nodes: Vec<Node> = stmt
-        .query_map([], super::util::row_to_node)
-        .map_err(io::Error::other)?
-        .filter_map(|r| {
-            r.map_err(|e| eprintln!("[mem/node] row deserialization error: {e}"))
-                .ok()
-        })
-        .collect();
-    Ok(nodes)
-}
-
-/// Read nodes with a SQL-level LIMIT (avoids loading all rows into memory).
-pub fn read_nodes_limited_conn(conn: &Connection, limit: usize) -> io::Result<Vec<Node>> {
-    // format! is safe here — NODE_COLUMNS is a compile-time const, not user input.
-    let sql = format!("SELECT {NODE_COLUMNS} FROM nodes ORDER BY updated DESC LIMIT ?");
-    let mut stmt = conn.prepare(&sql).map_err(io::Error::other)?;
-    let nodes: Vec<Node> = stmt
-        .query_map(rusqlite::params![limit as i64], super::util::row_to_node)
-        .map_err(io::Error::other)?
-        .filter_map(|r| {
-            r.map_err(|e| eprintln!("[mem/node] row deserialization error: {e}"))
-                .ok()
-        })
-        .collect();
-    Ok(nodes)
+    crate::store::runtime::block_on(async {
+        let pool = crate::store::pool::memory_pool().await?;
+        delete_node_pool(&pool, id).await
+    })
 }
 
 pub fn list_node_ids() -> io::Result<Vec<String>> {
-    let conn = super::open_db()?;
-    list_node_ids_conn(&conn)
-}
-
-/// List all node IDs using an existing connection.
-pub fn list_node_ids_conn(conn: &Connection) -> io::Result<Vec<String>> {
-    let mut stmt = conn
-        .prepare("SELECT id FROM nodes")
-        .map_err(io::Error::other)?;
-    let ids: Vec<String> = stmt
-        .query_map([], |row| row.get(0))
-        .map_err(io::Error::other)?
-        .filter_map(|r| r.ok())
-        .collect();
-    Ok(ids)
+    crate::store::runtime::block_on(async {
+        let pool = crate::store::pool::memory_pool().await?;
+        list_node_ids_pool(&pool).await
+    })
 }
 
 // ── Node serialization (kept for migrate import) ──────
@@ -162,8 +54,6 @@ pub fn parse_node(content: &str) -> Option<Node> {
 
 // ── Async pool functions ─────────────────────────────
 
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
 pub async fn write_node_pool(pool: &SqlitePool, node: &Node) -> io::Result<()> {
     let fm = &node.frontmatter;
     sqlx::query(
@@ -188,8 +78,6 @@ pub async fn write_node_pool(pool: &SqlitePool, node: &Node) -> io::Result<()> {
     Ok(())
 }
 
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
 pub async fn read_node_pool(pool: &SqlitePool, id: &str) -> io::Result<Node> {
     let sql = format!("SELECT {NODE_COLUMNS} FROM nodes WHERE id = ?");
     let row = sqlx::query(&sql)
@@ -200,8 +88,6 @@ pub async fn read_node_pool(pool: &SqlitePool, id: &str) -> io::Result<Node> {
     row_to_node_pool(&row)
 }
 
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
 pub async fn read_nodes_pool(pool: &SqlitePool, ids: &[&str]) -> io::Result<Vec<Node>> {
     if ids.is_empty() {
         return Ok(vec![]);
@@ -220,8 +106,6 @@ pub async fn read_nodes_pool(pool: &SqlitePool, ids: &[&str]) -> io::Result<Vec<
     rows.iter().map(row_to_node_pool).collect()
 }
 
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
 pub async fn delete_node_pool(pool: &SqlitePool, id: &str) -> io::Result<()> {
     sqlx::query("DELETE FROM nodes WHERE id = ?")
         .bind(id)
@@ -231,7 +115,6 @@ pub async fn delete_node_pool(pool: &SqlitePool, id: &str) -> io::Result<()> {
     Ok(())
 }
 
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
 #[allow(dead_code)]
 pub async fn node_exists_pool(pool: &SqlitePool, id: &str) -> bool {
     sqlx::query_scalar::<_, i64>("SELECT EXISTS(SELECT 1 FROM nodes WHERE id = ?)")
@@ -241,8 +124,6 @@ pub async fn node_exists_pool(pool: &SqlitePool, id: &str) -> bool {
         .is_ok_and(|v| v != 0)
 }
 
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
 pub async fn read_all_nodes_pool(pool: &SqlitePool) -> io::Result<Vec<Node>> {
     let sql = format!("SELECT {NODE_COLUMNS} FROM nodes ORDER BY updated DESC");
     let rows = sqlx::query(&sql)
@@ -252,8 +133,6 @@ pub async fn read_all_nodes_pool(pool: &SqlitePool) -> io::Result<Vec<Node>> {
     rows.iter().map(row_to_node_pool).collect()
 }
 
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
 pub async fn read_nodes_limited_pool(pool: &SqlitePool, limit: i64) -> io::Result<Vec<Node>> {
     let sql = format!("SELECT {NODE_COLUMNS} FROM nodes ORDER BY updated DESC LIMIT ?");
     let rows = sqlx::query(&sql)
@@ -264,8 +143,6 @@ pub async fn read_nodes_limited_pool(pool: &SqlitePool, limit: i64) -> io::Resul
     rows.iter().map(row_to_node_pool).collect()
 }
 
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
 pub async fn list_node_ids_pool(pool: &SqlitePool) -> io::Result<Vec<String>> {
     let rows = sqlx::query("SELECT id FROM nodes")
         .fetch_all(pool)

--- a/src/mem/store/recall.rs
+++ b/src/mem/store/recall.rs
@@ -1,12 +1,11 @@
 //! recall.rs — Smart recall with composite scoring and graph boost
 
-use rusqlite::Connection;
 use sqlx::{Row, SqlitePool};
 use std::io;
 
-use super::decay::{touch_nodes_conn, touch_nodes_pool};
+use super::decay::touch_nodes_pool;
 use super::node::row_to_node_pool;
-use super::search::{search_nodes_conn, search_nodes_pool};
+use super::search::search_nodes_pool;
 use super::types::{Node, ScoredNode};
 use super::util::{NODE_COLUMNS, escape_like, parse_iso_to_secs};
 
@@ -17,167 +16,19 @@ pub const W_ACCESS: f64 = 0.15;
 pub const W_FTS: f64 = 0.20; // was 0.25
 pub const W_GRAPH: f64 = 0.10; // edge-weight connectivity boost (new)
 
-/// Smart recall using an existing connection.
-pub fn smart_recall_conn(
-    conn: &Connection,
-    project: Option<&str>,
-    hint: Option<&str>,
-    limit: usize,
-) -> io::Result<Vec<ScoredNode>> {
-    let now_secs = std::time::SystemTime::now()
-        .duration_since(std::time::SystemTime::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-
-    // Gather FTS matches if hint is provided
-    let fts_ids: std::collections::HashSet<String> = if let Some(h) = hint {
-        if !h.is_empty() {
-            search_nodes_conn(conn, h, limit * 4)?
-                .into_iter()
-                .map(|n| n.frontmatter.id.clone())
-                .collect()
-        } else {
-            Default::default()
-        }
-    } else {
-        Default::default()
-    };
-
-    // Fetch candidate nodes (broad set); candidate_limit is computed, not user input.
-    let candidate_limit = (limit * 4).max(40) as i64;
-    let mut conditions: Vec<&str> = vec!["',' || tags || ',' NOT LIKE '%,stale,%'"];
-    // Collect bound parameter values alongside conditions.
-    let mut param_vals: Vec<Box<dyn rusqlite::ToSql>> = vec![];
-    if let Some(p) = project {
-        conditions.push("(',' || projects || ',' LIKE '%,' || ? || ',%' ESCAPE '\\')");
-        param_vals.push(Box::new(escape_like(p)));
-    }
-    let where_clause = format!("WHERE {}", conditions.join(" AND "));
-    let sql = format!(
-        "SELECT {NODE_COLUMNS} FROM nodes {where_clause}
-         ORDER BY importance DESC, updated DESC
-         LIMIT {candidate_limit}"
-    );
-
-    let mut stmt = conn.prepare(&sql).map_err(io::Error::other)?;
-    let refs: Vec<&dyn rusqlite::ToSql> = param_vals.iter().map(|b| b.as_ref()).collect();
-    let candidates: Vec<Node> = stmt
-        .query_map(refs.as_slice(), super::util::row_to_node)
-        .map(|rows| rows.filter_map(|r| r.ok()).collect())
-        .unwrap_or_default();
-
-    // Score each candidate
-    let mut scored: Vec<ScoredNode> = candidates
-        .into_iter()
-        .map(|node| {
-            let recency = compute_recency(&node.frontmatter.updated, now_secs);
-            let importance = node.frontmatter.importance;
-            let access_freq = (node.frontmatter.access_count.max(0) as f64 / 20.0).min(1.0);
-            let fts_match = if fts_ids.contains(&node.frontmatter.id) {
-                1.0
-            } else {
-                0.0
-            };
-
-            let score = W_RECENCY * recency
-                + W_IMPORTANCE * importance
-                + W_ACCESS * access_freq
-                + W_FTS * fts_match;
-
-            ScoredNode { node, score }
-        })
-        .collect();
-
-    scored.sort_by(|a, b| {
-        b.score
-            .partial_cmp(&a.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
-    scored.truncate(limit);
-
-    // Graph-boost pass: add W_GRAPH * edge_weight_score for edges between top candidates.
-    if scored.len() > 1 {
-        const MAX_GRAPH_BOOST_PARTICIPANTS: usize = 100;
-        let boost_ids: Vec<&str> = scored
-            .iter()
-            .take(MAX_GRAPH_BOOST_PARTICIPANTS)
-            .map(|sn| sn.node.frontmatter.id.as_str())
-            .collect();
-        let ph = boost_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
-        // Sum edge weights for each node connected to other top-scored candidates.
-        let sql = format!(
-            "SELECT source AS node_id, SUM(weight) AS w FROM edges \
-             WHERE source IN ({ph}) AND target IN ({ph}) GROUP BY source \
-             UNION ALL \
-             SELECT target AS node_id, SUM(weight) AS w FROM edges \
-             WHERE source IN ({ph}) AND target IN ({ph}) GROUP BY target"
-        );
-        if let Ok(mut stmt) = conn.prepare(&sql) {
-            let base: Vec<&dyn rusqlite::ToSql> = boost_ids
-                .iter()
-                .map(|s| s as &dyn rusqlite::ToSql)
-                .collect();
-            let sql_params: Vec<&dyn rusqlite::ToSql> = base
-                .iter()
-                .copied()
-                .chain(base.iter().copied())
-                .chain(base.iter().copied())
-                .chain(base.iter().copied())
-                .collect();
-            let weight_map: std::collections::HashMap<String, f64> = stmt
-                .query_map(sql_params.as_slice(), |row| {
-                    Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?))
-                })
-                .map(|rows| {
-                    let mut map: std::collections::HashMap<String, f64> = Default::default();
-                    for r in rows.flatten() {
-                        *map.entry(r.0).or_default() += r.1;
-                    }
-                    map
-                })
-                .unwrap_or_default();
-            let max_w = weight_map
-                .values()
-                .cloned()
-                .fold(0.0_f64, f64::max)
-                .max(1.0);
-            for sn in &mut scored {
-                let boost = weight_map
-                    .get(&sn.node.frontmatter.id)
-                    .copied()
-                    .unwrap_or(0.0);
-                sn.score += W_GRAPH * (boost / max_w);
-            }
-            // Re-sort after boost
-            scored.sort_by(|a, b| {
-                b.score
-                    .partial_cmp(&a.score)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            });
-        }
-    }
-
-    // Touch retrieved nodes (batch)
-    let ids: Vec<String> = scored
-        .iter()
-        .map(|sn| sn.node.frontmatter.id.clone())
-        .collect();
-    touch_nodes_conn(conn, &ids);
-
-    Ok(scored)
-}
-
 /// Smart recall: returns nodes ranked by composite relevance.
-///
-/// Opens its own connection; for repeated calls within a single session prefer
-/// `smart_recall_conn` to reuse an already-open connection.
 pub fn smart_recall(
     project: Option<&str>,
     hint: Option<&str>,
     limit: usize,
 ) -> io::Result<Vec<ScoredNode>> {
-    let conn = super::open_db()?;
-    smart_recall_conn(&conn, project, hint, limit)
+    // Clone to static strings so they can be sent across the thread boundary.
+    let project = project.map(|s| s.to_string());
+    let hint = hint.map(|s| s.to_string());
+    crate::store::runtime::block_on(async {
+        let pool = crate::store::pool::memory_pool().await?;
+        smart_recall_pool(&pool, project.as_deref(), hint.as_deref(), limit).await
+    })
 }
 
 /// Compute recency score (0.0–1.0) with exponential decay, half-life = 30 days.
@@ -194,8 +45,6 @@ pub(crate) fn compute_recency(updated: &str, now_secs: u64) -> f64 {
 // ── Async pool functions ─────────────────────────────
 
 /// Async smart recall using a sqlx pool.
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
 pub async fn smart_recall_pool(
     pool: &SqlitePool,
     project: Option<&str>,

--- a/src/mem/store/schema.rs
+++ b/src/mem/store/schema.rs
@@ -1,6 +1,5 @@
 //! schema.rs — Database schema initialization and legacy migration
 
-use rusqlite::Connection;
 use sqlx::SqlitePool;
 use std::fs;
 use std::io;
@@ -8,204 +7,7 @@ use std::io;
 use super::types::Edge;
 use super::util::{db_path, join_csv};
 
-/// Apply the full schema (tables, indexes, triggers) to an open connection.
-/// Exposed for tests that open an in-memory DB and need the same schema.
-pub(crate) fn init_schema(conn: &Connection) -> io::Result<()> {
-    // WAL auto-checkpoint for better concurrency
-    let _ = conn.execute_batch("PRAGMA wal_autocheckpoint=100;");
-
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS nodes (
-            id           TEXT PRIMARY KEY,
-            type         TEXT NOT NULL,
-            title        TEXT NOT NULL,
-            tags         TEXT NOT NULL DEFAULT '',
-            projects     TEXT NOT NULL DEFAULT '',
-            agents       TEXT NOT NULL DEFAULT '',
-            created      TEXT NOT NULL,
-            updated      TEXT NOT NULL,
-            body         TEXT NOT NULL DEFAULT '',
-            importance   REAL NOT NULL DEFAULT 0.5,
-            access_count INTEGER NOT NULL DEFAULT 0,
-            accessed_at  TEXT NOT NULL DEFAULT ''
-        );
-
-        CREATE VIRTUAL TABLE IF NOT EXISTS nodes_fts
-            USING fts5(title, body, tags, content=nodes, content_rowid=rowid, tokenize='trigram');
-
-        CREATE TRIGGER IF NOT EXISTS nodes_ai AFTER INSERT ON nodes BEGIN
-            INSERT INTO nodes_fts(rowid, title, body, tags)
-            VALUES (new.rowid, new.title, new.body, new.tags);
-        END;
-        CREATE TRIGGER IF NOT EXISTS nodes_ad AFTER DELETE ON nodes BEGIN
-            INSERT INTO nodes_fts(nodes_fts, rowid, title, body, tags)
-            VALUES('delete', old.rowid, old.title, old.body, old.tags);
-        END;
-        CREATE TRIGGER IF NOT EXISTS nodes_au AFTER UPDATE ON nodes BEGIN
-            INSERT INTO nodes_fts(nodes_fts, rowid, title, body, tags)
-            VALUES('delete', old.rowid, old.title, old.body, old.tags);
-            INSERT INTO nodes_fts(rowid, title, body, tags)
-            VALUES (new.rowid, new.title, new.body, new.tags);
-        END;
-
-        -- Schema migration: add importance/access columns if missing
-        -- ALTER TABLE IF NOT EXISTS is not supported, so we use a trick:
-        -- these will silently fail if columns already exist.
-        ",
-    )
-    .map_err(io::Error::other)?;
-
-    // Migrate existing DBs: add new columns (ignore errors if already present)
-    let _ = conn.execute_batch("ALTER TABLE nodes ADD COLUMN importance REAL NOT NULL DEFAULT 0.5");
-    let _ =
-        conn.execute_batch("ALTER TABLE nodes ADD COLUMN access_count INTEGER NOT NULL DEFAULT 0");
-    let _ = conn.execute_batch("ALTER TABLE nodes ADD COLUMN accessed_at TEXT NOT NULL DEFAULT ''");
-
-    // Backfill importance for existing nodes based on type
-    let _ = conn.execute_batch(
-        "UPDATE nodes SET importance = 0.9 WHERE importance = 0.5 AND type = 'decision';
-         UPDATE nodes SET importance = 0.8 WHERE importance = 0.5 AND type = 'resolution';
-         UPDATE nodes SET importance = 0.7 WHERE importance = 0.5 AND type = 'concept';
-         UPDATE nodes SET importance = 0.7 WHERE importance = 0.5 AND type = 'project';
-         UPDATE nodes SET importance = 0.4 WHERE importance = 0.5 AND type = 'error';
-         UPDATE nodes SET importance = 0.05 WHERE importance = 0.5 AND type = 'session';",
-    );
-
-    // Downgrade session importance from 0.2 to 0.05 (for existing DBs where backfill already ran)
-    let _ = conn.execute_batch(
-        "UPDATE nodes SET importance = 0.05 WHERE type = 'session' AND importance > 0.05;",
-    );
-
-    // Schema version tracking
-    let _ = conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS _meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
-         INSERT OR IGNORE INTO _meta (key, value) VALUES ('schema_version', '2');",
-    );
-
-    // Migrate FTS to trigram tokenizer if needed (schema_version < 2)
-    let needs_fts_migrate: bool = conn
-        .query_row(
-            "SELECT value FROM _meta WHERE key = 'schema_version'",
-            [],
-            |row| row.get::<_, String>(0),
-        )
-        .ok()
-        .is_none_or(|v| v != "2");
-
-    if needs_fts_migrate {
-        let _ = conn.execute_batch(
-            "DROP TABLE IF EXISTS nodes_fts;
-             CREATE VIRTUAL TABLE nodes_fts
-                 USING fts5(title, body, tags, content=nodes, content_rowid=rowid, tokenize='trigram');
-             INSERT INTO nodes_fts(nodes_fts) VALUES('rebuild');
-             UPDATE _meta SET value = '2' WHERE key = 'schema_version';"
-        );
-    }
-
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS edges (
-            id       TEXT PRIMARY KEY,
-            source   TEXT NOT NULL,
-            target   TEXT NOT NULL,
-            relation TEXT NOT NULL DEFAULT 'related',
-            weight   REAL NOT NULL DEFAULT 1.0,
-            ts       TEXT NOT NULL
-        );
-
-        CREATE INDEX IF NOT EXISTS idx_edges_source  ON edges(source);
-        CREATE INDEX IF NOT EXISTS idx_edges_target  ON edges(target);
-        CREATE UNIQUE INDEX IF NOT EXISTS idx_edges_src_tgt_rel ON edges(source, target, relation);
-        CREATE INDEX IF NOT EXISTS idx_nodes_type    ON nodes(type);
-        CREATE INDEX IF NOT EXISTS idx_nodes_updated ON nodes(updated DESC);
-        CREATE INDEX IF NOT EXISTS idx_nodes_title_updated ON nodes(title, updated DESC);
-        CREATE INDEX IF NOT EXISTS idx_nodes_importance ON nodes(importance DESC);
-        CREATE INDEX IF NOT EXISTS idx_nodes_accessed ON nodes(accessed_at DESC);
-        ",
-    )
-    .map_err(io::Error::other)?;
-
-    Ok(())
-}
-
-/// Silently import any legacy `nodes/*.md` + `edges.jsonl` into the DB.
-/// Runs only once — leaves a `.migrated` marker in the old nodes dir.
-pub(crate) fn auto_migrate_legacy(conn: &Connection) {
-    use super::node::parse_node;
-    use super::types::importance_for_type;
-
-    let harness_dir = db_path()
-        .parent()
-        .unwrap_or_else(|| std::path::Path::new("/tmp"))
-        .to_path_buf();
-    let legacy_nodes_dir = harness_dir.join("memory").join("nodes");
-    let marker = harness_dir.join("memory").join(".migrated");
-
-    // Already migrated or no legacy data
-    if marker.exists() || !legacy_nodes_dir.exists() {
-        return;
-    }
-
-    // Import nodes/*.md
-    let mut count = 0usize;
-    if let Ok(entries) = fs::read_dir(&legacy_nodes_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) != Some("md") {
-                continue;
-            }
-            let Ok(content) = fs::read_to_string(&path) else {
-                continue;
-            };
-            let Some(node) = parse_node(&content) else {
-                continue;
-            };
-            let fm = &node.frontmatter;
-            let imp = importance_for_type(&fm.node_type);
-            let _ = conn.execute(
-                "INSERT OR IGNORE INTO nodes
-                 (id, type, title, tags, projects, agents, created, updated, body, importance, access_count, accessed_at)
-                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,0,'')",
-                rusqlite::params![
-                    fm.id, fm.node_type, fm.title,
-                    join_csv(&fm.tags), join_csv(&fm.projects), join_csv(&fm.agents),
-                    fm.created, fm.updated, node.body, imp,
-                ],
-            );
-            count += 1;
-        }
-    }
-
-    // Import edges.jsonl
-    let edges_path = harness_dir.join("memory").join("edges.jsonl");
-    if edges_path.exists()
-        && let Ok(content) = fs::read_to_string(&edges_path)
-    {
-        for line in content.lines() {
-            if let Ok(edge) = serde_json::from_str::<Edge>(line) {
-                let _ = conn.execute(
-                    "INSERT OR IGNORE INTO edges
-                     (id, source, target, relation, weight, ts)
-                     VALUES (?1,?2,?3,?4,?5,?6)",
-                    rusqlite::params![
-                        edge.id,
-                        edge.source,
-                        edge.target,
-                        edge.relation,
-                        edge.weight,
-                        edge.ts,
-                    ],
-                );
-            }
-        }
-    }
-
-    // Write marker so we never run again
-    let _ = fs::write(&marker, format!("migrated {} nodes\n", count));
-}
-
-/// Async version of [`init_schema`] using a sqlx pool.
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
+/// Async version of schema initialization using a sqlx pool.
 pub async fn init_schema_pool(pool: &SqlitePool) -> io::Result<()> {
     sqlx::raw_sql("PRAGMA wal_autocheckpoint=100;")
         .execute(pool)
@@ -332,4 +134,87 @@ pub async fn init_schema_pool(pool: &SqlitePool) -> io::Result<()> {
     .map_err(crate::store::sqlx_err)?;
 
     Ok(())
+}
+
+/// Silently import any legacy `nodes/*.md` + `edges.jsonl` into the pool.
+/// Runs only once — leaves a `.migrated` marker in the old nodes dir.
+pub(crate) async fn auto_migrate_legacy(pool: &SqlitePool) {
+    use super::node::parse_node;
+    use super::types::importance_for_type;
+
+    let harness_dir = db_path()
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("/tmp"))
+        .to_path_buf();
+    let legacy_nodes_dir = harness_dir.join("memory").join("nodes");
+    let marker = harness_dir.join("memory").join(".migrated");
+
+    // Already migrated or no legacy data
+    if marker.exists() || !legacy_nodes_dir.exists() {
+        return;
+    }
+
+    // Import nodes/*.md
+    let mut count = 0usize;
+    if let Ok(entries) = fs::read_dir(&legacy_nodes_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("md") {
+                continue;
+            }
+            let Ok(content) = fs::read_to_string(&path) else {
+                continue;
+            };
+            let Some(node) = parse_node(&content) else {
+                continue;
+            };
+            let fm = &node.frontmatter;
+            let imp = importance_for_type(&fm.node_type);
+            let _ = sqlx::query(
+                "INSERT OR IGNORE INTO nodes
+                 (id, type, title, tags, projects, agents, created, updated, body, importance, access_count, accessed_at)
+                 VALUES (?,?,?,?,?,?,?,?,?,?,0,'')",
+            )
+            .bind(&fm.id)
+            .bind(&fm.node_type)
+            .bind(&fm.title)
+            .bind(join_csv(&fm.tags))
+            .bind(join_csv(&fm.projects))
+            .bind(join_csv(&fm.agents))
+            .bind(&fm.created)
+            .bind(&fm.updated)
+            .bind(&node.body)
+            .bind(imp)
+            .execute(pool)
+            .await;
+            count += 1;
+        }
+    }
+
+    // Import edges.jsonl
+    let edges_path = harness_dir.join("memory").join("edges.jsonl");
+    if edges_path.exists()
+        && let Ok(content) = fs::read_to_string(&edges_path)
+    {
+        for line in content.lines() {
+            if let Ok(edge) = serde_json::from_str::<Edge>(line) {
+                let _ = sqlx::query(
+                    "INSERT OR IGNORE INTO edges
+                     (id, source, target, relation, weight, ts)
+                     VALUES (?,?,?,?,?,?)",
+                )
+                .bind(&edge.id)
+                .bind(&edge.source)
+                .bind(&edge.target)
+                .bind(&edge.relation)
+                .bind(edge.weight)
+                .bind(&edge.ts)
+                .execute(pool)
+                .await;
+            }
+        }
+    }
+
+    // Write marker so we never run again
+    let _ = fs::write(&marker, format!("migrated {} nodes\n", count));
 }

--- a/src/mem/store/search.rs
+++ b/src/mem/store/search.rs
@@ -2,7 +2,6 @@
 
 use std::io;
 
-use rusqlite::{Connection, params};
 use sqlx::SqlitePool;
 
 use super::node::row_to_node_pool;
@@ -10,100 +9,14 @@ use super::types::Node;
 use super::util::{NODE_COLUMNS, NODE_COLUMNS_PREFIXED, escape_like};
 
 pub fn search_nodes(query: &str, limit: usize) -> Vec<Node> {
-    let conn = match super::open_db() {
-        Ok(c) => c,
-        Err(_) => return vec![],
-    };
-    search_nodes_conn(&conn, query, limit).unwrap_or_else(|_| vec![])
+    let query = query.to_string();
+    crate::store::runtime::block_on(async {
+        let pool = crate::store::pool::memory_pool().await?;
+        search_nodes_pool(&pool, &query, limit as i64).await
+    })
+    .unwrap_or_else(|_| vec![])
 }
 
-pub fn search_nodes_conn(conn: &Connection, query: &str, limit: usize) -> io::Result<Vec<Node>> {
-    let sql = format!(
-        "SELECT n.{NODE_COLUMNS_PREFIXED}
-         FROM nodes n
-         JOIN nodes_fts ON n.rowid = nodes_fts.rowid
-         WHERE nodes_fts MATCH ?1
-         ORDER BY n.importance DESC
-         LIMIT ?2"
-    );
-    let mut stmt = conn.prepare(&sql).map_err(io::Error::other)?;
-    let nodes: Vec<Node> = stmt
-        .query_map(params![query, limit as i64], super::util::row_to_node)
-        .map_err(io::Error::other)?
-        .filter_map(|r| r.ok())
-        .collect();
-    Ok(nodes)
-}
-
-/// Dynamic filter query using an existing connection.
-pub fn query_nodes_conn(
-    conn: &Connection,
-    tag: Option<&str>,
-    node_type: Option<&str>,
-    project: Option<&str>,
-    limit: usize,
-) -> io::Result<Vec<Node>> {
-    // Cap limit to prevent oversized result sets.
-    let limit = limit.min(200);
-
-    // Build parameterized conditions — no format!() interpolation of user values.
-    let mut condition_strs: Vec<&str> = vec![];
-    let mut param_vals: Vec<Box<dyn rusqlite::ToSql>> = vec![];
-
-    if let Some(t) = tag {
-        condition_strs.push("(',' || tags || ',' LIKE '%,' || ? || ',%' ESCAPE '\\')");
-        param_vals.push(Box::new(escape_like(t)));
-    }
-    if let Some(nt) = node_type {
-        condition_strs.push("type = ?");
-        param_vals.push(Box::new(nt.to_string()));
-    }
-    if let Some(p) = project {
-        condition_strs.push("(',' || projects || ',' LIKE '%,' || ? || ',%' ESCAPE '\\')");
-        param_vals.push(Box::new(escape_like(p)));
-    }
-
-    let where_clause = if condition_strs.is_empty() {
-        String::new()
-    } else {
-        format!("WHERE {}", condition_strs.join(" AND "))
-    };
-
-    // `limit` is not user-controlled; safe to format as i64.
-    let sql = format!(
-        "SELECT {NODE_COLUMNS}
-         FROM nodes {where_clause} ORDER BY updated DESC LIMIT {}",
-        limit as i64,
-    );
-
-    let mut stmt = conn.prepare(&sql).map_err(io::Error::other)?;
-    let refs: Vec<&dyn rusqlite::ToSql> = param_vals.iter().map(|b| b.as_ref()).collect();
-    let nodes: Vec<Node> = stmt
-        .query_map(refs.as_slice(), super::util::row_to_node)
-        .map_err(io::Error::other)?
-        .filter_map(|r| r.ok())
-        .collect();
-    Ok(nodes)
-}
-
-/// Dynamic filter query.
-pub fn query_nodes(
-    tag: Option<&str>,
-    node_type: Option<&str>,
-    project: Option<&str>,
-    limit: usize,
-) -> Vec<Node> {
-    let conn = match super::open_db() {
-        Ok(c) => c,
-        Err(_) => return vec![],
-    };
-    query_nodes_conn(&conn, tag, node_type, project, limit).unwrap_or_else(|_| vec![])
-}
-
-// ── Async pool functions ─────────────────────────────
-
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
 pub async fn search_nodes_pool(
     pool: &SqlitePool,
     query: &str,
@@ -126,9 +39,31 @@ pub async fn search_nodes_pool(
     rows.iter().map(row_to_node_pool).collect()
 }
 
+/// Dynamic filter query.
+pub fn query_nodes(
+    tag: Option<&str>,
+    node_type: Option<&str>,
+    project: Option<&str>,
+    limit: usize,
+) -> Vec<Node> {
+    let tag = tag.map(|s| s.to_string());
+    let node_type = node_type.map(|s| s.to_string());
+    let project = project.map(|s| s.to_string());
+    crate::store::runtime::block_on(async {
+        let pool = crate::store::pool::memory_pool().await?;
+        query_nodes_pool(
+            &pool,
+            tag.as_deref(),
+            node_type.as_deref(),
+            project.as_deref(),
+            limit,
+        )
+        .await
+    })
+    .unwrap_or_else(|_| vec![])
+}
+
 /// Async dynamic filter query using QueryBuilder.
-// TODO: Wire up when remaining sync callers migrate to pool (R4).
-#[allow(dead_code)]
 pub async fn query_nodes_pool(
     pool: &SqlitePool,
     tag: Option<&str>,

--- a/src/mem/store/types.rs
+++ b/src/mem/store/types.rs
@@ -64,6 +64,7 @@ pub struct Edge {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[allow(dead_code)]
 pub struct Index {
     pub nodes: Vec<IndexNode>,
     pub by_tag: std::collections::HashMap<String, Vec<String>>,

--- a/src/mem/store/util.rs
+++ b/src/mem/store/util.rs
@@ -1,6 +1,5 @@
 //! util.rs — Shared helpers: paths, UUID, timestamps, CSV, row mapping, constants
 
-use super::types::Node;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -44,31 +43,6 @@ pub(crate) fn escape_like(value: &str) -> String {
         }
     }
     out
-}
-
-// ── Row mapping ───────────────────────────────────────
-
-pub(crate) fn row_to_node(row: &rusqlite::Row<'_>) -> rusqlite::Result<Node> {
-    use super::types::NodeFrontmatter;
-    let tags: String = row.get(3)?;
-    let projects: String = row.get(4)?;
-    let agents: String = row.get(5)?;
-    Ok(Node {
-        frontmatter: NodeFrontmatter {
-            id: row.get(0)?,
-            node_type: row.get(1)?,
-            title: row.get(2)?,
-            tags: split_csv(&tags),
-            projects: split_csv(&projects),
-            agents: split_csv(&agents),
-            created: row.get(6)?,
-            updated: row.get(7)?,
-            importance: row.get(9).unwrap_or(0.5),
-            access_count: row.get::<_, i64>(10).unwrap_or(0),
-            accessed_at: row.get(11).unwrap_or_default(),
-        },
-        body: row.get(8)?,
-    })
 }
 
 // ── Paths ─────────────────────────────────────────────

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -283,15 +283,16 @@ fn handle_list_nodes(url: &str) -> Response<std::io::Cursor<Vec<u8>>> {
         .and_then(|v| v.parse().ok())
         .unwrap_or(200)
         .min(1000);
-    // Note: uses store::open_db() (memory.db for the knowledge graph),
+    // Note: uses the memory DB pool (memory.db for the knowledge graph),
     // not the harness operational DB passed as `db` to other handlers.
-    let nodes = match store::open_db() {
-        Ok(conn) => store::read_nodes_limited_conn(&conn, limit).unwrap_or_default(),
-        Err(e) => {
-            eprintln!("[serve] failed to open memory DB for /api/nodes: {e}");
-            Vec::new()
-        }
-    };
+    let nodes = crate::store::runtime::block_on(async {
+        let pool = crate::store::pool::memory_pool().await?;
+        store::read_nodes_limited_pool(&pool, limit as i64).await
+    })
+    .unwrap_or_else(|e| {
+        eprintln!("[serve] failed to open memory DB for /api/nodes: {e}");
+        Vec::new()
+    });
     let results: Vec<serde_json::Value> = nodes
         .into_iter()
         .map(|n| {

--- a/src/store/migrate.rs
+++ b/src/store/migrate.rs
@@ -5,17 +5,79 @@
 //!
 //! ## Why inline SQL instead of pool functions?
 //!
-//! This module uses rusqlite directly (not the async sqlx pool) because the
-//! `--to-global` consolidation path requires `ATTACH DATABASE` to merge
-//! per-project DBs into the global one. SQLite ATTACH only works on a raw
-//! connection — it cannot be issued through a sqlx pool. The import path
-//! (`do_migrate`) also needs transactional control (ImmediateTx) over a
-//! single connection to guarantee atomicity per file.
+//! This module uses a direct `sqlx::SqliteConnection` (not the async pool) because
+//! the `--to-global` consolidation path requires `ATTACH DATABASE` to merge
+//! per-project DBs into the global one. SQLite ATTACH is connection-scoped — it
+//! must be issued on the same connection as the subsequent INSERT/SELECT statements.
+//! Using a pool would route ATTACH and the follow-up queries to different connections.
+//! The import path (`do_migrate`) also uses per-connection transactional control
+//! (`BEGIN IMMEDIATE`) over a single connection to guarantee atomicity per file.
 
-use rusqlite::Connection;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
+use sqlx::{ConnectOptions, Executor, Row};
 use std::io::{self, BufRead};
+use std::str::FromStr;
 
-use super::{ImmediateTx, store_err};
+use super::sqlx_err;
+
+// ── Connection factory ──────────────────────────────────────────────────────
+
+/// Open a direct (non-pooled) sqlx `SqliteConnection` to the global harness.db.
+///
+/// Creates parent directories and sets WAL + FK pragmas. Schema must already
+/// exist (callers are expected to have run `init_schema_pool` at startup, or
+/// the DB was created by `open_harness_db` earlier in the same process).
+#[allow(dead_code)]
+pub(crate) async fn open_migrate_conn_for_schema() -> io::Result<sqlx::SqliteConnection> {
+    open_migrate_conn().await
+}
+
+async fn open_migrate_conn() -> io::Result<sqlx::SqliteConnection> {
+    let path = super::harness_db_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let url = format!("sqlite:{}", path.display());
+    let conn = SqliteConnectOptions::from_str(&url)
+        .map_err(sqlx_err)?
+        .foreign_keys(true)
+        .journal_mode(SqliteJournalMode::Wal)
+        .connect()
+        .await
+        .map_err(sqlx_err)?;
+    Ok(conn)
+}
+
+/// Open a direct sqlx `SqliteConnection` to an arbitrary DB path.
+#[allow(dead_code)]
+async fn open_conn_at(path: &std::path::Path) -> io::Result<sqlx::SqliteConnection> {
+    use sqlx::sqlite::SqliteConnectOptions;
+    let opts = SqliteConnectOptions::new()
+        .filename(path)
+        .foreign_keys(true)
+        .journal_mode(SqliteJournalMode::Wal);
+    let conn = opts.connect().await.map_err(sqlx_err)?;
+    Ok(conn)
+}
+
+// ── Transaction helpers ─────────────────────────────────────────────────────
+
+/// Begin an `IMMEDIATE` transaction on a direct connection.
+async fn begin_immediate(conn: &mut sqlx::SqliteConnection) -> io::Result<()> {
+    conn.execute("BEGIN IMMEDIATE").await.map_err(sqlx_err)?;
+    Ok(())
+}
+
+async fn commit(conn: &mut sqlx::SqliteConnection) -> io::Result<()> {
+    conn.execute("COMMIT").await.map_err(sqlx_err)?;
+    Ok(())
+}
+
+async fn rollback(conn: &mut sqlx::SqliteConnection) {
+    let _ = conn.execute("ROLLBACK").await;
+}
+
+// ── Public sync entry points ────────────────────────────────────────────────
 
 /// Entry point for the `migrate` subcommand.
 ///
@@ -24,7 +86,11 @@ use super::{ImmediateTx, store_err};
 /// allowing the import to be retried without manual DB surgery.
 /// Returns an exit code (0 = success, 1 = error).
 pub fn run_subcommand(dry_run: bool, reset: bool) -> i32 {
-    let conn = match super::open_harness_db() {
+    super::runtime::block_on(run_subcommand_async(dry_run, reset))
+}
+
+async fn run_subcommand_async(dry_run: bool, reset: bool) -> i32 {
+    let mut conn = match open_migrate_conn().await {
         Ok(c) => c,
         Err(e) => {
             eprintln!("[migrate] failed to open harness.db: {e}");
@@ -32,13 +98,13 @@ pub fn run_subcommand(dry_run: bool, reset: bool) -> i32 {
         }
     };
 
-    let migration_state: Option<String> = conn
-        .query_row(
-            "SELECT value FROM _harness_meta WHERE key = 'legacy_migrated'",
-            [],
-            |row| row.get::<_, String>(0),
-        )
-        .ok();
+    let migration_state: Option<String> =
+        sqlx::query("SELECT value FROM _harness_meta WHERE key = 'legacy_migrated'")
+            .fetch_optional(&mut conn)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|row| row.try_get::<String, _>(0).ok());
 
     match migration_state.as_deref() {
         Some("1") => {
@@ -47,10 +113,11 @@ pub fn run_subcommand(dry_run: bool, reset: bool) -> i32 {
         }
         Some("in_progress") => {
             if reset {
-                if let Err(e) = conn.execute(
-                    "DELETE FROM _harness_meta WHERE key = 'legacy_migrated'",
-                    [],
-                ) {
+                if let Err(e) = conn
+                    .execute("DELETE FROM _harness_meta WHERE key = 'legacy_migrated'")
+                    .await
+                    .map_err(sqlx_err)
+                {
                     eprintln!("[migrate] failed to clear in_progress marker: {e}");
                     return 1;
                 }
@@ -70,7 +137,7 @@ pub fn run_subcommand(dry_run: bool, reset: bool) -> i32 {
         return run_dry(&conn);
     }
 
-    match do_migrate(&conn) {
+    match do_migrate_async(&mut conn).await {
         Ok(stats) => {
             let error_pct = if stats.total_lines > 0 {
                 stats.errors as f64 / stats.total_lines as f64 * 100.0
@@ -102,7 +169,7 @@ pub fn run_subcommand(dry_run: bool, reset: bool) -> i32 {
 }
 
 /// Scan legacy files and report counts without importing.
-fn run_dry(conn: &Connection) -> i32 {
+fn run_dry(conn: &sqlx::SqliteConnection) -> i32 {
     let harness_dir = crate::shared::paths::harness_dir();
 
     let obs_count = count_jsonl_lines(&harness_dir.join("obs"));
@@ -152,6 +219,8 @@ fn count_jsonl_lines_single(path: &std::path::Path) -> usize {
         .unwrap_or(0)
 }
 
+// ── Migration statistics ────────────────────────────────────────────────────
+
 /// Migration statistics for diagnostics.
 pub(crate) struct MigrationStats {
     obs_imported: usize,
@@ -162,7 +231,14 @@ pub(crate) struct MigrationStats {
     total_lines: usize,
 }
 
-pub(crate) fn do_migrate(conn: &Connection) -> io::Result<MigrationStats> {
+#[allow(dead_code)]
+pub(crate) fn do_migrate(conn: &mut sqlx::SqliteConnection) -> io::Result<MigrationStats> {
+    super::runtime::block_on(do_migrate_async(conn))
+}
+
+pub(crate) async fn do_migrate_async(
+    conn: &mut sqlx::SqliteConnection,
+) -> io::Result<MigrationStats> {
     let harness_dir = crate::shared::paths::harness_dir();
     let mut stats = MigrationStats {
         obs_imported: 0,
@@ -172,53 +248,59 @@ pub(crate) fn do_migrate(conn: &Connection) -> io::Result<MigrationStats> {
         total_lines: 0,
     };
 
-    // Phase 1: Reserve migration under write lock. ImmediateTx serializes concurrent
-    // callers; re-checking the flag inside the lock closes the TOCTOU window between
-    // the outer read in run_subcommand and this BEGIN IMMEDIATE.
+    // Phase 1: Reserve migration under write lock. BEGIN IMMEDIATE serializes
+    // concurrent callers; re-checking the flag inside the lock closes the TOCTOU
+    // window between the outer read in run_subcommand and this BEGIN IMMEDIATE.
     {
-        let tx = ImmediateTx::begin(conn)?;
-        let already: bool = conn
-            .query_row(
-                "SELECT value FROM _harness_meta WHERE key = 'legacy_migrated'",
-                [],
-                |row| row.get::<_, String>(0),
-            )
-            .ok()
-            .is_some_and(|v| v == "1" || v == "in_progress");
+        begin_immediate(conn).await?;
+        let already: bool =
+            sqlx::query("SELECT value FROM _harness_meta WHERE key = 'legacy_migrated'")
+                .fetch_optional(&mut *conn)
+                .await
+                .ok()
+                .flatten()
+                .and_then(|row| row.try_get::<String, _>(0).ok())
+                .is_some_and(|v| v == "1" || v == "in_progress");
+
         if already {
-            return Ok(stats); // tx drops → auto-ROLLBACK
+            rollback(conn).await;
+            return Ok(stats);
         }
-        store_err(conn.execute(
+
+        sqlx::query(
             "INSERT OR REPLACE INTO _harness_meta (key, value) VALUES ('legacy_migrated', 'in_progress')",
-            [],
-        ))?;
-        tx.commit()?;
+        )
+        .execute(&mut *conn)
+        .await
+        .map_err(sqlx_err)?;
+        commit(conn).await?;
     }
 
-    // Phase 2: Per-file imports. Each source file gets its own ImmediateTx so the WAL
-    // never grows unboundedly for large legacy datasets. The 'in_progress' marker set
-    // above prevents concurrent migration attempts from racing with these small commits.
-    import_observations(conn, &harness_dir, &mut stats)?;
+    // Phase 2: Per-file imports. Each source file gets its own BEGIN IMMEDIATE so
+    // the WAL never grows unboundedly for large legacy datasets.
+    import_observations(conn, &harness_dir, &mut stats).await?;
     let slug = crate::shared::paths::project_slug();
-    import_sessions(conn, &slug, &harness_dir, &mut stats)?;
-    import_evolution(conn, &slug, &harness_dir, &mut stats)?;
-    import_metrics(conn, &slug, &harness_dir, &mut stats)?;
+    import_sessions(conn, &slug, &harness_dir, &mut stats).await?;
+    import_evolution(conn, &slug, &harness_dir, &mut stats).await?;
+    import_metrics(conn, &slug, &harness_dir, &mut stats).await?;
 
     // Phase 3: Mark complete.
     {
-        let tx = ImmediateTx::begin(conn)?;
-        store_err(conn.execute(
+        begin_immediate(conn).await?;
+        sqlx::query(
             "INSERT OR REPLACE INTO _harness_meta (key, value) VALUES ('legacy_migrated', '1')",
-            [],
-        ))?;
-        tx.commit()?;
+        )
+        .execute(&mut *conn)
+        .await
+        .map_err(sqlx_err)?;
+        commit(conn).await?;
     }
 
     Ok(stats)
 }
 
-fn import_observations(
-    conn: &Connection,
+async fn import_observations(
+    conn: &mut sqlx::SqliteConnection,
     harness_dir: &std::path::Path,
     stats: &mut MigrationStats,
 ) -> io::Result<()> {
@@ -240,17 +322,7 @@ fn import_observations(
             .unwrap_or(filename)
             .to_string();
 
-        // Each file gets its own ImmediateTx to bound WAL growth.
-        // do_migrate() released its outer tx before calling this function.
-        let tx = ImmediateTx::begin(conn)?;
-
-        let mut insert_stmt = store_err(conn.prepare(
-            "INSERT INTO observations
-             (timestamp, session_id, tool, tool_category, action, result, score,
-              dim_success, dim_quality, dim_cost, failure_category, error_snippet,
-              file_ext, sequence_id, pipeline_id)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15)",
-        ))?;
+        begin_immediate(conn).await?;
 
         let file = std::fs::File::open(&path)?;
         let reader = std::io::BufReader::new(file);
@@ -278,23 +350,31 @@ fn import_observations(
                         ),
                         None => (None, None, None),
                     };
-                    let result = insert_stmt.execute(rusqlite::params![
-                        rec.timestamp,
-                        session_id,
-                        rec.tool,
-                        rec.tool_category,
-                        rec.action,
-                        rec.result,
-                        rec.score,
-                        dim_s,
-                        dim_q,
-                        dim_c,
-                        rec.failure_category,
-                        rec.error_snippet,
-                        rec.file_ext,
-                        rec.sequence_id.map(super::u64_to_i64),
-                        rec.pipeline_id,
-                    ]);
+                    let result = sqlx::query(
+                        "INSERT INTO observations \
+                         (timestamp, session_id, tool, tool_category, action, result, score, \
+                          dim_success, dim_quality, dim_cost, failure_category, error_snippet, \
+                          file_ext, sequence_id, pipeline_id) \
+                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    )
+                    .bind(&rec.timestamp)
+                    .bind(&session_id)
+                    .bind(&rec.tool)
+                    .bind(&rec.tool_category)
+                    .bind(&rec.action)
+                    .bind(&rec.result)
+                    .bind(rec.score)
+                    .bind(dim_s)
+                    .bind(dim_q)
+                    .bind(dim_c)
+                    .bind(&rec.failure_category)
+                    .bind(&rec.error_snippet)
+                    .bind(&rec.file_ext)
+                    .bind(rec.sequence_id.map(super::u64_to_i64))
+                    .bind(&rec.pipeline_id)
+                    .execute(&mut *conn)
+                    .await;
+
                     if let Err(e) = result {
                         eprintln!("[migrate] insert obs error: {e}");
                         stats.errors += 1;
@@ -309,16 +389,13 @@ fn import_observations(
             }
         }
 
-        // Explicitly drop the prepared statement before committing —
-        // Statement holds a shared borrow of conn but commit() also needs conn.
-        drop(insert_stmt);
-        tx.commit()?;
+        commit(conn).await?;
     }
     Ok(())
 }
 
-fn import_sessions(
-    conn: &Connection,
+async fn import_sessions(
+    conn: &mut sqlx::SqliteConnection,
     slug: &str,
     harness_dir: &std::path::Path,
     stats: &mut MigrationStats,
@@ -370,8 +447,9 @@ fn import_sessions(
             }
         };
 
-        // Each file gets its own ImmediateTx to bound WAL growth.
-        let tx = ImmediateTx::begin(conn)?;
+        // Each file gets its own BEGIN IMMEDIATE to bound WAL growth.
+        begin_immediate(conn).await?;
+
         let pending_json = serde_json::to_string(&snap.pending_tasks).unwrap_or_else(|e| {
             eprintln!("[migrate] pending_tasks serialization failed: {e}");
             "[]".into()
@@ -382,30 +460,42 @@ fn import_sessions(
                 "{}".into()
             })
         });
-        let result = store_err(conn.execute(
-            "INSERT INTO sessions (timestamp, snap_type, summary, pending_tasks, context_usage, pipeline_state, created_at_millis, project) VALUES (?1,?2,?3,?4,?5,?6,?7,?8)",
-            rusqlite::params![
-                snap.timestamp, snap.snap_type, snap.summary, pending_json,
-                snap.context_usage, pipeline_json, millis, slug,
-            ],
-        ));
+
+        let result = sqlx::query(
+            "INSERT INTO sessions \
+             (timestamp, snap_type, summary, pending_tasks, context_usage, pipeline_state, \
+              created_at_millis, project) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&snap.timestamp)
+        .bind(&snap.snap_type)
+        .bind(&snap.summary)
+        .bind(&pending_json)
+        .bind(snap.context_usage)
+        .bind(&pipeline_json)
+        .bind(millis)
+        .bind(slug)
+        .execute(&mut *conn)
+        .await;
+
         match result {
             Ok(_) => {
                 stats.sess_imported += 1;
-                tx.commit()?;
+                commit(conn).await?;
             }
             Err(e) => {
                 eprintln!("[migrate] insert session error: {e}");
                 stats.errors += 1;
-                // tx drops → ROLLBACK; no partial state committed for this file
+                rollback(conn).await;
+                // No partial state committed for this file.
             }
         }
     }
     Ok(())
 }
 
-fn import_evolution(
-    conn: &Connection,
+async fn import_evolution(
+    conn: &mut sqlx::SqliteConnection,
     slug: &str,
     harness_dir: &std::path::Path,
     stats: &mut MigrationStats,
@@ -416,14 +506,13 @@ fn import_evolution(
     }
 
     // Stream via BufReader with batched transactions (BATCH_SIZE records per commit)
-    // to cap WAL growth. import_observations uses per-file transactions for the same
-    // reason; evolution.jsonl is a single large file so we batch by record count.
+    // to cap WAL growth. evolution.jsonl is a single large file so we batch by record count.
     const BATCH_SIZE: usize = 500;
     let file = std::fs::File::open(&evo_file)?;
     let reader = std::io::BufReader::new(file);
 
     let mut records_in_batch: usize = 0;
-    let mut current_tx = ImmediateTx::begin(conn)?;
+    begin_immediate(conn).await?;
 
     for line in reader.lines() {
         stats.total_lines += 1;
@@ -449,22 +538,27 @@ fn import_evolution(
                         eprintln!("[migrate] failure_patterns serialization failed: {e}");
                         "[]".into()
                     });
-                let result = store_err(conn.execute(
-                    "INSERT INTO evolution_records (timestamp, observations, success_rate, avg_score, error_patterns, failure_patterns, skills_seeded, skills_rolled_back, total_evolved, analysis_summary, project) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11)",
-                    rusqlite::params![
-                        rec.timestamp,
-                        super::u64_to_i64(rec.observations),
-                        rec.success_rate,
-                        rec.avg_score,
-                        error_json,
-                        failure_json,
-                        super::u64_to_i64(rec.skills_seeded),
-                        super::u64_to_i64(rec.skills_rolled_back),
-                        super::u64_to_i64(rec.total_evolved),
-                        rec.analysis_summary,
-                        slug,
-                    ],
-                ));
+                let result = sqlx::query(
+                    "INSERT INTO evolution_records \
+                     (timestamp, observations, success_rate, avg_score, error_patterns, \
+                      failure_patterns, skills_seeded, skills_rolled_back, total_evolved, \
+                      analysis_summary, project) \
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                )
+                .bind(&rec.timestamp)
+                .bind(super::u64_to_i64(rec.observations))
+                .bind(rec.success_rate)
+                .bind(rec.avg_score)
+                .bind(&error_json)
+                .bind(&failure_json)
+                .bind(super::u64_to_i64(rec.skills_seeded))
+                .bind(super::u64_to_i64(rec.skills_rolled_back))
+                .bind(super::u64_to_i64(rec.total_evolved))
+                .bind(&rec.analysis_summary)
+                .bind(slug)
+                .execute(&mut *conn)
+                .await;
+
                 if let Err(e) = result {
                     eprintln!("[migrate] insert evo error: {e}");
                     stats.errors += 1;
@@ -472,9 +566,9 @@ fn import_evolution(
                     stats.evo_imported += 1;
                     records_in_batch += 1;
                     if records_in_batch >= BATCH_SIZE {
-                        current_tx.commit()?;
+                        commit(conn).await?;
                         records_in_batch = 0;
-                        current_tx = ImmediateTx::begin(conn)?;
+                        begin_immediate(conn).await?;
                     }
                 }
             }
@@ -484,12 +578,12 @@ fn import_evolution(
             }
         }
     }
-    current_tx.commit()?;
+    commit(conn).await?;
     Ok(())
 }
 
-fn import_metrics(
-    conn: &Connection,
+async fn import_metrics(
+    conn: &mut sqlx::SqliteConnection,
     slug: &str,
     harness_dir: &std::path::Path,
     stats: &mut MigrationStats,
@@ -510,35 +604,45 @@ fn import_metrics(
                     crate::shared::evolution::default_metrics()
                 }
             };
-            // Inline key-value metrics_state write (replaces deleted save_metrics_conn).
-            let kv = |k: &str, v: &str| -> io::Result<()> {
-                store_err(conn.execute(
-                    "INSERT OR REPLACE INTO metrics_state (key, value, project) VALUES (?1, ?2, ?3)",
-                    rusqlite::params![k, v, slug],
-                ))?;
-                Ok(())
-            };
-            let result: io::Result<()> = (|| {
-                kv("total_sessions", &metrics.total_sessions.to_string())?;
-                kv("avg_success_rate", &metrics.avg_success_rate.to_string())?;
-                kv(
+
+            macro_rules! kv {
+                ($k:expr, $v:expr) => {
+                    sqlx::query(
+                        "INSERT OR REPLACE INTO metrics_state (key, value, project) \
+                         VALUES (?, ?, ?)",
+                    )
+                    .bind($k)
+                    .bind($v)
+                    .bind(slug)
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(sqlx_err)?
+                };
+            }
+
+            let result: io::Result<()> = async {
+                kv!("total_sessions", metrics.total_sessions.to_string());
+                kv!("avg_success_rate", metrics.avg_success_rate.to_string());
+                kv!(
                     "total_evolved_skills",
-                    &metrics.total_evolved_skills.to_string(),
-                )?;
+                    metrics.total_evolved_skills.to_string()
+                );
                 if let Some(ref v) = metrics.last_session {
-                    kv("last_session", v)?;
+                    kv!("last_session", v.clone());
                 }
                 if let Some(v) = metrics.best_score {
-                    kv("best_score", &v.to_string())?;
+                    kv!("best_score", v.to_string());
                 }
-                kv("best_session", &metrics.best_session)?;
-                kv("trend", &metrics.trend)?;
-                kv("stagnation_count", &metrics.stagnation_count.to_string())?;
+                kv!("best_session", metrics.best_session.clone());
+                kv!("trend", metrics.trend.clone());
+                kv!("stagnation_count", metrics.stagnation_count.to_string());
                 if let Some(ref v) = metrics.last_error_context {
-                    kv("last_error_context", v)?;
+                    kv!("last_error_context", v.clone());
                 }
                 Ok(())
-            })();
+            }
+            .await;
+
             if let Err(e) = result {
                 eprintln!("[migrate] save metrics error: {e}");
                 stats.errors += 1;
@@ -552,114 +656,27 @@ fn import_metrics(
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn do_migrate_is_idempotent() {
-        let conn = Connection::open_in_memory().unwrap();
-        super::super::schema::init_schema(&conn).unwrap();
-
-        // First run marks legacy_migrated=1
-        do_migrate(&conn).unwrap();
-        // Second run must see the flag and be a no-op (returns empty stats)
-        let stats = do_migrate(&conn).unwrap();
-        assert_eq!(stats.obs_imported, 0);
-        assert_eq!(stats.sess_imported, 0);
-
-        let migrated: String = conn
-            .query_row(
-                "SELECT value FROM _harness_meta WHERE key = 'legacy_migrated'",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap();
-        assert_eq!(migrated, "1");
-    }
-
-    #[test]
-    fn to_global_merges_per_project_dbs() {
-        let global_db = Connection::open_in_memory().unwrap();
-        super::super::schema::init_schema(&global_db).unwrap();
-
-        // Simulate a per-project DB (v3 schema — no project column)
-        let dir = tempfile::tempdir().unwrap();
-        let db_path = dir.path().join("harness.db");
-        let src_conn = Connection::open(&db_path).unwrap();
-        // Apply a minimal v3-like schema manually
-        src_conn
-            .execute_batch(
-                "CREATE TABLE observations (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    timestamp TEXT NOT NULL,
-                    session_id TEXT NOT NULL,
-                    tool TEXT NOT NULL,
-                    tool_category TEXT NOT NULL,
-                    action TEXT, result TEXT, score REAL,
-                    dim_success REAL, dim_quality REAL, dim_cost REAL,
-                    failure_category TEXT, error_snippet TEXT,
-                    file_ext TEXT, sequence_id INTEGER, pipeline_id TEXT
-                );
-                INSERT INTO observations (timestamp, session_id, tool, tool_category)
-                VALUES ('2026-01-01T00:00:00Z', 'sess1', 'Bash', 'shell');
-                CREATE TABLE sessions (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    timestamp TEXT NOT NULL,
-                    snap_type TEXT NOT NULL,
-                    summary TEXT,
-                    snapshot_json TEXT NOT NULL,
-                    millis INTEGER NOT NULL
-                );
-                CREATE TABLE evolution_records (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    timestamp TEXT NOT NULL, observations INTEGER NOT NULL DEFAULT 0,
-                    success_rate REAL NOT NULL, avg_score REAL NOT NULL,
-                    error_patterns TEXT NOT NULL DEFAULT '{}',
-                    failure_patterns TEXT NOT NULL DEFAULT '[]',
-                    skills_seeded INTEGER NOT NULL DEFAULT 0,
-                    skills_rolled_back INTEGER NOT NULL DEFAULT 0,
-                    total_evolved INTEGER NOT NULL DEFAULT 0,
-                    analysis_summary TEXT NOT NULL DEFAULT ''
-                );",
-            )
-            .unwrap();
-        drop(src_conn);
-
-        // Attach and merge
-        let slug = "test-project";
-        let escaped_path = db_path.display().to_string().replace('\'', "''");
-        global_db
-            .execute(&format!("ATTACH '{escaped_path}' AS src"), [])
-            .unwrap();
-
-        let merged = super::merge_attached_db(&global_db, slug, "src").unwrap();
-        global_db.execute("DETACH src", []).unwrap();
-
-        assert_eq!(merged.obs, 1, "should merge 1 observation");
-        assert_eq!(merged.sessions, 0, "sessions table was empty");
-
-        // Verify the project column is set
-        let count: i64 = global_db
-            .query_row(
-                "SELECT COUNT(*) FROM observations WHERE project = ?1",
-                rusqlite::params![slug],
-                |r| r.get(0),
-            )
-            .unwrap();
-        assert_eq!(count, 1);
-    }
-}
-
-// ── Per-project DB → Global DB consolidation ────────────
+// ── Per-project DB → Global DB consolidation ────────────────────────────────
 
 /// Merge a per-project harness.db into the global DB using ATTACH.
 ///
 /// `attach_name` is the SQLite schema name used in ATTACH (e.g., "src").
 /// All data from the attached DB is copied with `project` set to `slug`.
 /// Tables that already have rows for this project are skipped (INSERT OR IGNORE).
+///
+/// The caller is responsible for issuing ATTACH before calling this function
+/// and DETACH after. ATTACH is connection-scoped so both must use the same conn.
+#[allow(dead_code)]
 pub fn merge_attached_db(
-    conn: &Connection,
+    conn: &mut sqlx::SqliteConnection,
+    slug: &str,
+    attach_name: &str,
+) -> io::Result<GlobalMergeStats> {
+    super::runtime::block_on(merge_attached_db_async(conn, slug, attach_name))
+}
+
+pub async fn merge_attached_db_async(
+    conn: &mut sqlx::SqliteConnection,
     slug: &str,
     attach_name: &str,
 ) -> io::Result<GlobalMergeStats> {
@@ -706,13 +723,13 @@ pub fn merge_attached_db(
     for (table, dest_cols, src_cols) in &simple_tables {
         let sql = format!(
             "INSERT OR IGNORE INTO main.{table} ({dest_cols}) \
-             SELECT {src_cols}, ?1 FROM {attach_name}.{table}"
+             SELECT {src_cols}, ? FROM {attach_name}.{table}"
         );
-        match conn.execute(&sql, rusqlite::params![slug]) {
-            Ok(n) => match *table {
-                "observations" => stats.obs += n,
-                "sessions" => stats.sessions += n,
-                "evolution_records" => stats.evo += n,
+        match sqlx::query(&sql).bind(slug).execute(&mut *conn).await {
+            Ok(r) => match *table {
+                "observations" => stats.obs += r.rows_affected() as usize,
+                "sessions" => stats.sessions += r.rows_affected() as usize,
+                "evolution_records" => stats.evo += r.rows_affected() as usize,
                 _ => {}
             },
             Err(e) => {
@@ -725,61 +742,66 @@ pub fn merge_attached_db(
     }
 
     // metrics_state: key-value with project
-    if let Ok(n) = conn.execute(
-        &format!(
-            "INSERT OR IGNORE INTO main.metrics_state (key, value, project) \
-             SELECT key, value, ?1 FROM {attach_name}.metrics_state"
-        ),
-        rusqlite::params![slug],
-    ) {
-        stats.metrics += n;
+    if let Ok(r) = sqlx::query(&format!(
+        "INSERT OR IGNORE INTO main.metrics_state (key, value, project) \
+         SELECT key, value, ? FROM {attach_name}.metrics_state"
+    ))
+    .bind(slug)
+    .execute(&mut *conn)
+    .await
+    {
+        stats.metrics += r.rows_affected() as usize;
     }
 
     // score_history: has UNIQUE(timestamp) so INSERT OR IGNORE deduplicates
-    if let Ok(n) = conn.execute(
-        &format!(
-            "INSERT OR IGNORE INTO main.score_history \
-             (timestamp, success_rate, avg_score, observations, \
-              dim_success, dim_quality, dim_cost, project) \
-             SELECT timestamp, success_rate, avg_score, observations, \
-                    dim_success, dim_quality, dim_cost, ?1 \
-             FROM {attach_name}.score_history"
-        ),
-        rusqlite::params![slug],
-    ) {
-        stats.score_history += n;
+    if let Ok(r) = sqlx::query(&format!(
+        "INSERT OR IGNORE INTO main.score_history \
+         (timestamp, success_rate, avg_score, observations, \
+          dim_success, dim_quality, dim_cost, project) \
+         SELECT timestamp, success_rate, avg_score, observations, \
+                dim_success, dim_quality, dim_cost, ? \
+         FROM {attach_name}.score_history"
+    ))
+    .bind(slug)
+    .execute(&mut *conn)
+    .await
+    {
+        stats.score_history += r.rows_affected() as usize;
     }
 
     // skill_attribution: composite PK (skill_name, project) — safe to INSERT OR IGNORE
-    if let Ok(n) = conn.execute(
-        &format!(
-            "INSERT OR IGNORE INTO main.skill_attribution \
-             (skill_name, project, sessions_active, avg_score_with, avg_score_without, first_seen) \
-             SELECT skill_name, ?1, sessions_active, avg_score_with, avg_score_without, first_seen \
-             FROM {attach_name}.skill_attribution"
-        ),
-        rusqlite::params![slug],
-    ) {
-        stats.skill_attr += n;
+    if let Ok(r) = sqlx::query(&format!(
+        "INSERT OR IGNORE INTO main.skill_attribution \
+         (skill_name, project, sessions_active, avg_score_with, avg_score_without, first_seen) \
+         SELECT skill_name, ?, sessions_active, avg_score_with, avg_score_without, first_seen \
+         FROM {attach_name}.skill_attribution"
+    ))
+    .bind(slug)
+    .execute(&mut *conn)
+    .await
+    {
+        stats.skill_attr += r.rows_affected() as usize;
     }
 
     // promotion_counters: composite PK (pattern_key, project)
-    if let Ok(n) = conn.execute(
-        &format!(
-            "INSERT OR IGNORE INTO main.promotion_counters (pattern_key, project, count) \
-             SELECT pattern_key, ?1, count FROM {attach_name}.promotion_counters"
-        ),
-        rusqlite::params![slug],
-    ) {
-        stats.promo += n;
+    if let Ok(r) = sqlx::query(&format!(
+        "INSERT OR IGNORE INTO main.promotion_counters (pattern_key, project, count) \
+         SELECT pattern_key, ?, count FROM {attach_name}.promotion_counters"
+    ))
+    .bind(slug)
+    .execute(&mut *conn)
+    .await
+    {
+        stats.promo += r.rows_affected() as usize;
     }
 
     // orch_agents, orch_agent_events, orch_agent_inbox: FK-linked to orch_runs
     for table in ["orch_agents", "orch_agent_events", "orch_agent_inbox"] {
-        let _ = conn.execute(
-            &format!("INSERT OR IGNORE INTO main.{table} SELECT * FROM {attach_name}.{table}"),
-            [],
-        );
+        let _ = sqlx::query(&format!(
+            "INSERT OR IGNORE INTO main.{table} SELECT * FROM {attach_name}.{table}"
+        ))
+        .execute(&mut *conn)
+        .await;
     }
 
     Ok(stats)
@@ -790,6 +812,10 @@ pub fn merge_attached_db(
 /// Scans `~/.harness/projects/*/harness.db` and merges each into the global DB.
 /// Returns an exit code (0 = success, 1 = error).
 pub fn run_to_global(dry_run: bool) -> i32 {
+    super::runtime::block_on(run_to_global_async(dry_run))
+}
+
+async fn run_to_global_async(dry_run: bool) -> i32 {
     let projects_root = crate::shared::paths::harness_projects_root();
     if !projects_root.is_dir() {
         println!("no per-project directories found — nothing to do");
@@ -833,7 +859,7 @@ pub fn run_to_global(dry_run: bool) -> i32 {
     }
 
     // Open global DB
-    let conn = match super::open_harness_db() {
+    let mut conn = match open_migrate_conn().await {
         Ok(c) => c,
         Err(e) => {
             eprintln!("[migrate/to-global] failed to open global harness.db: {e}");
@@ -843,18 +869,22 @@ pub fn run_to_global(dry_run: bool) -> i32 {
 
     let mut total = GlobalMergeStats::default();
     for (slug, db_path) in &candidates {
-        // ATTACH the per-project DB read-only
-        let attach_name = "src";
+        // ATTACH the per-project DB.
         // SQLite ATTACH does not support parameterized arguments — the database
         // path must be interpolated into the SQL string. Single-quote escaping
         // prevents injection (unlikely in file paths but defensive).
-        let escaped_path = db_path.display().to_string().replace('\'', "''");
-        if let Err(e) = conn.execute(&format!("ATTACH '{escaped_path}' AS {attach_name}"), []) {
+        let attach_name = "src";
+        let escaped = db_path.display().to_string().replace('\'', "''");
+        if let Err(e) = conn
+            .execute(format!("ATTACH '{}' AS {attach_name}", escaped).as_str())
+            .await
+            .map_err(sqlx_err)
+        {
             eprintln!("[migrate/to-global] ATTACH failed for {slug}: {e}");
             continue;
         }
 
-        match merge_attached_db(&conn, slug, attach_name) {
+        match merge_attached_db_async(&mut conn, slug, attach_name).await {
             Ok(stats) => {
                 println!(
                     "  {slug}: {} obs, {} sessions, {} evo, {} metrics, {} score_history",
@@ -867,14 +897,18 @@ pub fn run_to_global(dry_run: bool) -> i32 {
             }
         }
 
-        let _ = conn.execute("DETACH src", []);
+        let _ = conn.execute("DETACH src").await;
     }
 
     // Mark consolidation complete
-    if let Err(e) = conn.execute(
-        "INSERT OR REPLACE INTO _harness_meta (key, value) VALUES ('global_consolidated', '1')",
-        [],
-    ) {
+    if let Err(e) = conn
+        .execute(
+            "INSERT OR REPLACE INTO _harness_meta (key, value) \
+             VALUES ('global_consolidated', '1')",
+        )
+        .await
+        .map_err(sqlx_err)
+    {
         eprintln!("[migrate/to-global] failed to set consolidation marker: {e}");
     }
 
@@ -912,9 +946,10 @@ impl std::ops::AddAssign for GlobalMergeStats {
     }
 }
 
-// ── Slug normalization (hash suffix removal) ────────────
+// ── Slug normalization (hash suffix removal) ────────────────────────────────
 
 /// Detect old-format slugs (`{name}-{6hex}`) and return the name part.
+#[allow(dead_code)]
 fn strip_hash_suffix(slug: &str) -> Option<&str> {
     if slug.len() > 7 {
         let maybe_sep = &slug[slug.len() - 7..slug.len() - 6];
@@ -933,15 +968,20 @@ fn strip_hash_suffix(slug: &str) -> Option<&str> {
 ///
 /// Called from `init_schema()` after migrations. Idempotent — tracked via
 /// `_harness_meta.slugs_normalized`.
-pub fn normalize_slugs_if_needed(conn: &Connection) -> io::Result<()> {
+#[allow(dead_code)]
+pub fn normalize_slugs_if_needed(conn: &mut sqlx::SqliteConnection) -> io::Result<()> {
+    super::runtime::block_on(normalize_slugs_if_needed_async(conn))
+}
+
+#[allow(dead_code)]
+pub async fn normalize_slugs_if_needed_async(conn: &mut sqlx::SqliteConnection) -> io::Result<()> {
     // Check if already done.
-    let done: bool = conn
-        .query_row(
-            "SELECT value FROM _harness_meta WHERE key = 'slugs_normalized'",
-            [],
-            |row| row.get::<_, String>(0),
-        )
+    let done: bool = sqlx::query("SELECT value FROM _harness_meta WHERE key = 'slugs_normalized'")
+        .fetch_optional(&mut *conn)
+        .await
         .ok()
+        .flatten()
+        .and_then(|row| row.try_get::<String, _>(0).ok())
         .is_some_and(|v| v == "1");
 
     if done {
@@ -949,15 +989,17 @@ pub fn normalize_slugs_if_needed(conn: &Connection) -> io::Result<()> {
     }
 
     // Collect all distinct project values that need normalization.
-    let slugs = collect_distinct_projects(conn)?;
+    let slugs = collect_distinct_projects(conn).await?;
     let mapping = build_normalization_mapping(&slugs);
 
     if mapping.is_empty() {
         // No hashed slugs found — just mark as done.
-        store_err(conn.execute(
+        sqlx::query(
             "INSERT OR REPLACE INTO _harness_meta (key, value) VALUES ('slugs_normalized', '1')",
-            [],
-        ))?;
+        )
+        .execute(&mut *conn)
+        .await
+        .map_err(sqlx_err)?;
         return Ok(());
     }
 
@@ -967,25 +1009,28 @@ pub fn normalize_slugs_if_needed(conn: &Connection) -> io::Result<()> {
     );
 
     // Apply within a transaction.
-    let tx = super::ImmediateTx::begin(conn)?;
-    apply_slug_mapping(conn, &mapping)?;
-    store_err(conn.execute(
+    begin_immediate(conn).await?;
+    apply_slug_mapping(conn, &mapping).await?;
+    sqlx::query(
         "INSERT OR REPLACE INTO _harness_meta (key, value) VALUES ('slugs_normalized', '1')",
-        [],
-    ))?;
-    tx.commit()?;
+    )
+    .execute(&mut *conn)
+    .await
+    .map_err(sqlx_err)?;
+    commit(conn).await?;
 
     // Rename per-project directories.
     rename_slug_directories(&mapping);
 
     // Normalize memory.db projects CSV.
-    normalize_memory_projects(&mapping);
+    normalize_memory_projects(&mapping).await;
 
     Ok(())
 }
 
 /// Collect all distinct `project` values across all relevant tables.
-fn collect_distinct_projects(conn: &Connection) -> io::Result<Vec<String>> {
+#[allow(dead_code)]
+async fn collect_distinct_projects(conn: &mut sqlx::SqliteConnection) -> io::Result<Vec<String>> {
     let tables = [
         "observations",
         "sessions",
@@ -1003,12 +1048,12 @@ fn collect_distinct_projects(conn: &Connection) -> io::Result<Vec<String>> {
     ];
     let mut seen = std::collections::HashSet::new();
     for table in &tables {
-        let rows: Vec<String> = conn
-            .prepare(&format!("SELECT DISTINCT project FROM {table}"))
-            .map_err(|e| std::io::Error::other(e.to_string()))?
-            .query_map([], |row| row.get(0))
-            .map_err(|e| std::io::Error::other(e.to_string()))?
-            .filter_map(|r| r.ok())
+        let rows: Vec<String> = sqlx::query(&format!("SELECT DISTINCT project FROM {table}"))
+            .fetch_all(&mut *conn)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|row| row.try_get::<String, _>(0).ok())
             .collect();
         for slug in rows {
             seen.insert(slug);
@@ -1018,6 +1063,7 @@ fn collect_distinct_projects(conn: &Connection) -> io::Result<Vec<String>> {
 }
 
 /// Build a mapping of `{old_hashed_slug} → {name_only_slug}`.
+#[allow(dead_code)]
 fn build_normalization_mapping(slugs: &[String]) -> Vec<(String, String)> {
     slugs
         .iter()
@@ -1026,9 +1072,11 @@ fn build_normalization_mapping(slugs: &[String]) -> Vec<(String, String)> {
 }
 
 /// Tables where `project` is part of a composite PK (need special handling).
+#[allow(dead_code)]
 const COMPOSITE_PK_TABLES: &[&str] = &["skill_attribution", "promotion_counters"];
 
 /// Tables with simple project column (UPDATE works directly).
+#[allow(dead_code)]
 const SIMPLE_TABLES: &[&str] = &[
     "observations",
     "sessions",
@@ -1044,41 +1092,61 @@ const SIMPLE_TABLES: &[&str] = &[
 ];
 
 /// Apply slug mapping to all tables in harness.db.
-fn apply_slug_mapping(conn: &Connection, mapping: &[(String, String)]) -> io::Result<()> {
+#[allow(dead_code)]
+async fn apply_slug_mapping(
+    conn: &mut sqlx::SqliteConnection,
+    mapping: &[(String, String)],
+) -> io::Result<()> {
     for (old, new) in mapping {
         // Simple tables: direct UPDATE.
         for table in SIMPLE_TABLES {
-            store_err(conn.execute(
-                &format!("UPDATE {table} SET project = ?1 WHERE project = ?2"),
-                rusqlite::params![new, old],
-            ))?;
+            sqlx::query(&format!("UPDATE {table} SET project = ? WHERE project = ?"))
+                .bind(new)
+                .bind(old)
+                .execute(&mut *conn)
+                .await
+                .map_err(sqlx_err)?;
         }
 
         // Composite PK tables: temp-table approach to handle PK conflicts
         // when two hashed slugs map to the same name-only slug.
         for table in COMPOSITE_PK_TABLES {
             // Step 1: Copy matching rows to temp table.
-            store_err(conn.execute(
-                &format!("CREATE TEMP TABLE _norm_tmp AS SELECT * FROM {table} WHERE project = ?1"),
-                rusqlite::params![old],
-            ))?;
+            sqlx::query(&format!(
+                "CREATE TEMP TABLE _norm_tmp AS SELECT * FROM {table} WHERE project = ?"
+            ))
+            .bind(old)
+            .execute(&mut *conn)
+            .await
+            .map_err(sqlx_err)?;
             // Step 2: Delete originals.
-            store_err(conn.execute(
-                &format!("DELETE FROM {table} WHERE project = ?1"),
-                rusqlite::params![old],
-            ))?;
+            sqlx::query(&format!("DELETE FROM {table} WHERE project = ?"))
+                .bind(old)
+                .execute(&mut *conn)
+                .await
+                .map_err(sqlx_err)?;
             // Step 3: Update project in temp.
-            store_err(conn.execute("UPDATE _norm_tmp SET project = ?1", rusqlite::params![new]))?;
+            sqlx::query("UPDATE _norm_tmp SET project = ?")
+                .bind(new)
+                .execute(&mut *conn)
+                .await
+                .map_err(sqlx_err)?;
             // Step 4: Insert back (IGNORE handles conflicts with existing rows).
-            store_err(conn.execute_batch(&format!(
-                "INSERT OR IGNORE INTO {table} SELECT * FROM _norm_tmp; DROP TABLE _norm_tmp;"
-            )))?;
+            conn.execute(
+                format!(
+                    "INSERT OR IGNORE INTO {table} SELECT * FROM _norm_tmp; DROP TABLE _norm_tmp;"
+                )
+                .as_str(),
+            )
+            .await
+            .map_err(sqlx_err)?;
         }
     }
     Ok(())
 }
 
 /// Rename per-project directories from hashed to name-only slugs.
+#[allow(dead_code)]
 fn rename_slug_directories(mapping: &[(String, String)]) {
     let root = crate::shared::paths::harness_projects_root();
     if !root.is_dir() {
@@ -1119,6 +1187,7 @@ fn rename_slug_directories(mapping: &[(String, String)]) {
 }
 
 /// Recursively merge contents of `src` into `dst`.
+#[allow(dead_code)]
 fn merge_dir_recursive(src: &std::path::Path, dst: &std::path::Path) {
     let _ = std::fs::create_dir_all(dst);
     if let Ok(entries) = std::fs::read_dir(src) {
@@ -1135,7 +1204,8 @@ fn merge_dir_recursive(src: &std::path::Path, dst: &std::path::Path) {
 }
 
 /// Normalize projects CSV in memory.db nodes table.
-fn normalize_memory_projects(mapping: &[(String, String)]) {
+#[allow(dead_code)]
+async fn normalize_memory_projects(mapping: &[(String, String)]) {
     if mapping.is_empty() {
         return;
     }
@@ -1145,43 +1215,51 @@ fn normalize_memory_projects(mapping: &[(String, String)]) {
     if !db_path.is_file() {
         return;
     }
-    let conn =
-        match Connection::open_with_flags(&db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE) {
-            Ok(c) => c,
-            Err(_) => return,
-        };
+
+    let mut conn = match open_conn_at(&db_path).await {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    let rows: Vec<(String, String)> = match sqlx::query("SELECT id, projects FROM nodes")
+        .fetch_all(&mut conn)
+        .await
+    {
+        Ok(rows) => rows
+            .into_iter()
+            .filter_map(|row| {
+                let id: String = row.try_get(0).ok()?;
+                let projects: String = row.try_get(1).ok()?;
+                Some((id, projects))
+            })
+            .collect(),
+        Err(_) => return,
+    };
 
     let mapping_map: std::collections::HashMap<&str, &str> = mapping
         .iter()
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
 
-    let mut stmt = match conn.prepare("SELECT id, projects FROM nodes") {
-        Ok(s) => s,
-        Err(_) => return,
-    };
-    let rows: Vec<(String, String)> = match stmt.query_map([], |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-    }) {
-        Ok(rows) => rows.filter_map(|r| r.ok()).collect(),
-        Err(_) => return,
-    };
-
     for (id, csv) in &rows {
         let new_csv = remap_csv(csv, &mapping_map);
         if new_csv != *csv {
-            let _ = conn.execute(
-                "UPDATE nodes SET projects = ?1 WHERE id = ?2",
-                rusqlite::params![new_csv, id],
-            );
+            let _ = sqlx::query("UPDATE nodes SET projects = ? WHERE id = ?")
+                .bind(&new_csv)
+                .bind(id)
+                .execute(&mut conn)
+                .await;
         }
     }
 
     // Update FTS.
-    let _ = conn.execute_batch("INSERT INTO nodes_fts(nodes_fts) VALUES('rebuild');");
+    let _ = conn
+        .execute("INSERT INTO nodes_fts(nodes_fts) VALUES('rebuild')")
+        .await;
 }
 
 /// Remap slug values in a comma-separated CSV string.
+#[allow(dead_code)]
 fn remap_csv(csv: &str, mapping: &std::collections::HashMap<&str, &str>) -> String {
     if csv.is_empty() {
         return csv.to_string();
@@ -1196,4 +1274,160 @@ fn remap_csv(csv: &str, mapping: &std::collections::HashMap<&str, &str>) -> Stri
         })
         .collect::<Vec<_>>()
         .join(",")
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::ConnectOptions;
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+
+    /// Create an in-memory harness DB with full schema applied via pool.
+    async fn make_global_pool() -> sqlx::SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        crate::store::schema::init_schema_pool(&pool).await.unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn do_migrate_is_idempotent() {
+        let pool = make_global_pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+
+        // First run marks legacy_migrated=1
+        do_migrate_async(&mut conn).await.unwrap();
+        // Second run must see the flag and be a no-op (returns empty stats)
+        let stats = do_migrate_async(&mut conn).await.unwrap();
+        assert_eq!(stats.obs_imported, 0);
+        assert_eq!(stats.sess_imported, 0);
+
+        let migrated: String =
+            sqlx::query("SELECT value FROM _harness_meta WHERE key = 'legacy_migrated'")
+                .fetch_one(&mut *conn)
+                .await
+                .unwrap()
+                .try_get(0)
+                .unwrap();
+        assert_eq!(migrated, "1");
+    }
+
+    #[tokio::test]
+    async fn to_global_merges_per_project_dbs() {
+        // Use a file-based DB for global so ATTACH works correctly.
+        // sqlx in-memory pools may not share the same connection across ATTACH
+        // and subsequent queries when pool connection juggling occurs.
+        let dir = tempfile::tempdir().unwrap();
+        let global_db_path = dir.path().join("global.db");
+        let global_pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(
+                SqliteConnectOptions::new()
+                    .filename(&global_db_path)
+                    .create_if_missing(true),
+            )
+            .await
+            .unwrap();
+        crate::store::schema::init_schema_pool(&global_pool)
+            .await
+            .unwrap();
+        let mut global_conn = global_pool.acquire().await.unwrap();
+
+        // Simulate a per-project DB (v3 schema — no project column)
+        let db_path = dir.path().join("harness.db");
+
+        {
+            let mut src_conn = SqliteConnectOptions::new()
+                .filename(&db_path)
+                .create_if_missing(true)
+                .foreign_keys(true)
+                .connect()
+                .await
+                .unwrap();
+            // Apply a minimal v3-like schema manually
+            src_conn
+                .execute(
+                    "CREATE TABLE observations (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        timestamp TEXT NOT NULL,
+                        session_id TEXT NOT NULL,
+                        tool TEXT NOT NULL,
+                        tool_category TEXT NOT NULL,
+                        action TEXT, result TEXT, score REAL,
+                        dim_success REAL, dim_quality REAL, dim_cost REAL,
+                        failure_category TEXT, error_snippet TEXT,
+                        file_ext TEXT, sequence_id INTEGER, pipeline_id TEXT
+                    )",
+                )
+                .await
+                .unwrap();
+            src_conn
+                .execute(
+                    "INSERT INTO observations (timestamp, session_id, tool, tool_category) \
+                     VALUES ('2026-01-01T00:00:00Z', 'sess1', 'Bash', 'shell')",
+                )
+                .await
+                .unwrap();
+            src_conn
+                .execute(
+                    "CREATE TABLE sessions (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        timestamp TEXT NOT NULL,
+                        snap_type TEXT NOT NULL,
+                        summary TEXT,
+                        snapshot_json TEXT NOT NULL,
+                        millis INTEGER NOT NULL
+                    )",
+                )
+                .await
+                .unwrap();
+            src_conn
+                .execute(
+                    "CREATE TABLE evolution_records (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        timestamp TEXT NOT NULL, observations INTEGER NOT NULL DEFAULT 0,
+                        success_rate REAL NOT NULL, avg_score REAL NOT NULL,
+                        error_patterns TEXT NOT NULL DEFAULT '{}',
+                        failure_patterns TEXT NOT NULL DEFAULT '[]',
+                        skills_seeded INTEGER NOT NULL DEFAULT 0,
+                        skills_rolled_back INTEGER NOT NULL DEFAULT 0,
+                        total_evolved INTEGER NOT NULL DEFAULT 0,
+                        analysis_summary TEXT NOT NULL DEFAULT ''
+                    )",
+                )
+                .await
+                .unwrap();
+        }
+
+        // Attach and merge
+        let slug = "test-project";
+        let escaped_path = db_path.display().to_string().replace('\'', "''");
+        global_conn
+            .execute(format!("ATTACH '{escaped_path}' AS src").as_str())
+            .await
+            .unwrap();
+
+        let merged = merge_attached_db_async(&mut global_conn, slug, "src")
+            .await
+            .unwrap();
+        global_conn.execute("DETACH src").await.unwrap();
+
+        assert_eq!(merged.obs, 1, "should merge 1 observation");
+        assert_eq!(merged.sessions, 0, "sessions table was empty");
+
+        // Verify the project column is set
+        let count: i64 = sqlx::query("SELECT COUNT(*) FROM observations WHERE project = ?")
+            .bind(slug)
+            .fetch_one(&mut *global_conn)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+        assert_eq!(count, 1);
+    }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -27,61 +27,13 @@ mod tests;
 
 // ── Store error helpers ──────────────────────────────
 
-/// Convert a rusqlite result to io::Result, preserving context.
-#[inline]
-pub(crate) fn store_err<T>(result: Result<T, rusqlite::Error>) -> io::Result<T> {
-    result.map_err(io::Error::other)
-}
-
 /// Convert a sqlx error to io::Result. Used by all `*_pool` async functions.
 #[inline]
-pub(crate) fn sqlx_err(e: sqlx::Error) -> io::Error {
-    io::Error::other(e)
+pub(crate) fn sqlx_err(e: sqlx::Error) -> std::io::Error {
+    std::io::Error::other(e)
 }
 
-// ── RAII transaction guard ───────────────────────────
-
-/// RAII guard for `BEGIN IMMEDIATE` transactions.
-///
-/// Calls `ROLLBACK` on drop if not explicitly committed, preventing
-/// connection state corruption when errors occur mid-transaction.
-pub(crate) struct ImmediateTx<'a> {
-    conn: &'a Connection,
-    committed: bool,
-}
-
-impl<'a> ImmediateTx<'a> {
-    pub(crate) fn begin(conn: &'a Connection) -> io::Result<Self> {
-        store_err(conn.execute_batch("BEGIN IMMEDIATE"))?;
-        Ok(Self {
-            conn,
-            committed: false,
-        })
-    }
-
-    pub(crate) fn commit(mut self) -> io::Result<()> {
-        self.committed = true;
-        store_err(self.conn.execute_batch("COMMIT"))
-    }
-}
-
-impl Drop for ImmediateTx<'_> {
-    fn drop(&mut self) {
-        if !self.committed {
-            let _ = self.conn.execute_batch("ROLLBACK");
-        }
-    }
-}
-
-// ── DB connection ────────────────────────────────────
-
-use rusqlite::Connection;
-use std::fs;
-use std::io;
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
-
-use crate::shared::paths;
+// ── Numeric helpers ──────────────────────────────────
 
 /// Convert u64 to i64 for SQLite storage.
 ///
@@ -124,38 +76,5 @@ pub(crate) fn i64_to_u64(v: i64) -> u64 {
 /// Shared across all projects alongside `memory.db`. Project scoping is handled
 /// via the `project` column in each table rather than separate DB files.
 pub fn harness_db_path() -> std::path::PathBuf {
-    paths::global_harness_db_path()
-}
-
-/// Open the harness operational database.
-///
-/// Creates the file if it doesn't exist. Applies schema (tables, indexes, WAL mode),
-/// and runs pending schema version migrations. Legacy JSONL/JSON data import is NOT
-/// automatic — run `epic-harness migrate` explicitly to import legacy data.
-pub fn open_harness_db() -> io::Result<Connection> {
-    let path = harness_db_path();
-
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let conn = Connection::open(&path).map_err(io::Error::other)?;
-
-    // Restrict DB file to owner-only (observation data may contain file paths,
-    // command text, etc.). Only applies on Unix; no-op on other platforms.
-    //
-    // TOCTOU note: there is a small window between Connection::open (which creates
-    // the file with default umask permissions) and set_permissions here. rusqlite
-    // does not expose an fd-level fchmod API, so this window cannot be eliminated
-    // without a custom VFS. The risk is low for a local single-user tool — the
-    // threat actor would need to read the file within milliseconds of first creation.
-    #[cfg(unix)]
-    {
-        let _ = fs::set_permissions(&path, PermissionsExt::from_mode(0o600));
-    }
-
-    // Apply schema (WAL + FK pragma are set inside init_schema as the first operation).
-    // Uses IF NOT EXISTS throughout, so safe to call on existing DBs.
-    schema::init_schema(&conn)?;
-
-    Ok(conn)
+    crate::shared::paths::global_harness_db_path()
 }

--- a/src/store/pool.rs
+++ b/src/store/pool.rs
@@ -1,11 +1,10 @@
 //! pool/ — Async connection pool factory (sqlx)
 //!
 //! Creates lazily-initialized `SqlitePool` instances for `harness.db` and `memory.db`.
-//! Pools are stored in global async `OnceCell` singletons — the first call creates the
-//! pool, subsequent calls return the existing one.
-//!
-//! This module lives alongside the existing rusqlite sync code in `store/mod.rs`.
-//! No existing code is modified; the async pools are additive for the migration.
+//! Each pool is stored in a `TokioMutex<Option<(url, pool)>>` — on every call the
+//! resolved URL is compared to the cached URL; if they differ the old pool is closed
+//! and a new one is opened.  This allows integration tests to redirect pool paths via
+//! `HARNESS_ROOT` without leaking state across tests.
 
 use std::fs;
 use std::io;
@@ -16,7 +15,6 @@ use std::str::FromStr;
 
 use sqlx::SqlitePool;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
-use tokio::sync::OnceCell;
 
 use crate::config::CONFIG;
 use crate::shared::paths;
@@ -28,6 +26,10 @@ fn default_harness_db_path() -> PathBuf {
 }
 
 fn default_memory_db_path() -> PathBuf {
+    // Honour HARNESS_ROOT if set (used by integration tests to redirect to a temp dir).
+    if let Ok(root) = std::env::var("HARNESS_ROOT") {
+        return PathBuf::from(root).join(".harness").join("memory.db");
+    }
     paths::dirs_home().join(".harness").join("memory.db")
 }
 
@@ -103,23 +105,41 @@ async fn build_pool(url: &str, max_connections: u32) -> io::Result<SqlitePool> {
 }
 
 // ── Global pool singletons ─────────────────────────
+//
+// In production (and in unit tests within the library crate), `HARNESS_ROOT` is
+// fixed for the lifetime of the process, so `OnceCell` is the right primitive.
+//
+// Integration tests (`tests/`) set `HARNESS_ROOT` to a fresh temp dir before each
+// test.  To support that pattern without forcing every integration test to call into
+// async pool machinery directly, each pool is stored as
+// `Mutex<Option<(url, pool)>>`.  On every call we check whether the resolved URL
+// still matches the cached URL; if not, the old pool is closed and a new one is
+// opened.  The mutex guarantees that concurrent async callers never see a torn
+// state.
 
-static HARNESS_POOL: OnceCell<SqlitePool> = OnceCell::const_new();
-static MEMORY_POOL: OnceCell<SqlitePool> = OnceCell::const_new();
+use tokio::sync::Mutex as TokioMutex;
+
+static HARNESS_POOL: TokioMutex<Option<(String, SqlitePool)>> = TokioMutex::const_new(None);
+static MEMORY_POOL: TokioMutex<Option<(String, SqlitePool)>> = TokioMutex::const_new(None);
 
 /// Returns a shared `SqlitePool` for `harness.db`.
 ///
 /// Creates the pool on first call; subsequent calls return the same instance.
 /// Uses `CONFIG.db` for URL and max_connections.
 pub async fn harness_pool() -> io::Result<SqlitePool> {
-    HARNESS_POOL
-        .get_or_try_init(|| async {
-            let pool = build_pool(&harness_url(), CONFIG.db.max_connections).await?;
-            super::schema::init_schema_pool(&pool).await?;
-            Ok(pool)
-        })
-        .await
-        .cloned()
+    let url = harness_url();
+    let mut guard = HARNESS_POOL.lock().await;
+    if guard.as_ref().map(|(u, _)| u == &url).unwrap_or(false) {
+        return Ok(guard.as_ref().unwrap().1.clone());
+    }
+    // URL changed (or first call) — close old pool and open a new one.
+    if let Some((_, old)) = guard.take() {
+        old.close().await;
+    }
+    let pool = build_pool(&url, CONFIG.db.max_connections).await?;
+    super::schema::init_schema_pool(&pool).await?;
+    *guard = Some((url, pool.clone()));
+    Ok(pool)
 }
 
 /// Returns a shared `SqlitePool` for `memory.db`.
@@ -127,29 +147,29 @@ pub async fn harness_pool() -> io::Result<SqlitePool> {
 /// Creates the pool on first call; subsequent calls return the same instance.
 /// Initializes the memory schema (nodes, edges, FTS5) on first creation.
 pub async fn memory_pool() -> io::Result<SqlitePool> {
-    MEMORY_POOL
-        .get_or_try_init(|| async {
-            let pool = build_pool(&memory_url(), CONFIG.db.max_connections).await?;
-            crate::mem::store::init_schema_pool(&pool).await?;
-            Ok(pool)
-        })
-        .await
-        .cloned()
+    let url = memory_url();
+    let mut guard = MEMORY_POOL.lock().await;
+    if guard.as_ref().map(|(u, _)| u == &url).unwrap_or(false) {
+        return Ok(guard.as_ref().unwrap().1.clone());
+    }
+    // URL changed (or first call) — close old pool and open a new one.
+    if let Some((_, old)) = guard.take() {
+        old.close().await;
+    }
+    let pool = build_pool(&url, CONFIG.db.max_connections).await?;
+    crate::mem::store::init_schema_pool(&pool).await?;
+    crate::mem::store::auto_migrate_legacy(&pool).await;
+    *guard = Some((url, pool.clone()));
+    Ok(pool)
 }
 
 /// Gracefully close all pools. Call on process shutdown to flush WAL.
-///
-/// Uses `get()` rather than `take()` because `OnceLock::take()` requires `&mut self`,
-/// which is unavailable on a `static`. After `close()`, any further pool operations
-/// will return an error — the desired behavior for a shutdown path.
-///
-/// Wire into the async shutdown hook once callers are migrated to pool functions.
 #[allow(dead_code)]
 pub async fn shutdown() {
-    if let Some(pool) = HARNESS_POOL.get() {
+    if let Some((_, pool)) = HARNESS_POOL.lock().await.take() {
         pool.close().await;
     }
-    if let Some(pool) = MEMORY_POOL.get() {
+    if let Some((_, pool)) = MEMORY_POOL.lock().await.take() {
         pool.close().await;
     }
 }

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -3,20 +3,15 @@
 //! Creates all tables for observations, sessions, evolution, metrics,
 //! orchestrator, orbit pipelines, evolved skills, and global patterns.
 
-use rusqlite::Connection;
 use sqlx::{Row, SqlitePool};
 use std::io;
 
-use super::store_err;
-
-/// Current schema version. Increment when adding migrations in `run_migrations`.
+/// Current schema version. Increment when adding migrations in `run_migrations_pool`.
 const SCHEMA_VERSION: u32 = 4;
 
 /// Complete DDL for all harness operational tables and indexes.
 ///
-/// Single source of truth — used by both [`apply_ddl`] (rusqlite sync path)
-/// and [`init_schema_pool`] (sqlx async path). Uses IF NOT EXISTS throughout
-/// so both paths are idempotent.
+/// Single source of truth. Uses IF NOT EXISTS throughout so both paths are idempotent.
 const DDL: &str = "
     CREATE TABLE IF NOT EXISTS _harness_meta (
         key   TEXT PRIMARY KEY,
@@ -216,342 +211,11 @@ const DDL: &str = "
     CREATE INDEX IF NOT EXISTS idx_evolved_proj_act ON evolved_skills(project, active);
 ";
 
-/// Apply the full operational schema to an open connection.
-///
-/// On first run (no `_harness_meta` table): applies all DDL + PRAGMA.
-/// On subsequent runs: skips PRAGMA/DDL if schema version matches, only runs
-/// pending migrations for version bumps.
-pub(crate) fn init_schema(conn: &Connection) -> io::Result<()> {
-    // Check if schema already initialised by probing for the meta table.
-    let existing_version: Option<u32> = conn
-        .query_row(
-            "SELECT value FROM _harness_meta WHERE key = 'schema_version'",
-            [],
-            |row| row.get::<_, String>(0),
-        )
-        .ok()
-        .and_then(|v| v.parse().ok());
-
-    if let Some(version) = existing_version {
-        // Schema exists — just ensure PRAGMA are set and run pending migrations.
-        apply_pragma(conn)?;
-        if version < SCHEMA_VERSION {
-            run_migrations(conn, version, SCHEMA_VERSION)?;
-        }
-        // After migrations, apply DDL to create any tables/indexes added in newer
-        // versions that the migration itself didn't create (e.g., because a table
-        // was added in v4 but the DB started at v2 with a minimal schema subset).
-        // IF NOT EXISTS makes this a no-op for tables that already exist.
-        apply_ddl(conn)?;
-        // Normalize old hashed slugs to name-only format (idempotent).
-        if let Err(e) = super::migrate::normalize_slugs_if_needed(conn) {
-            eprintln!("[harness] slug normalization failed: {e}");
-        }
-        return Ok(());
-    }
-
-    // First run: apply everything.
-    apply_pragma(conn)?;
-    apply_ddl(conn)?;
-    set_version(conn, SCHEMA_VERSION)?;
-
-    Ok(())
-}
-
-/// Apply WAL, FK, and autocheckpoint PRAGMA.
-fn apply_pragma(conn: &Connection) -> io::Result<()> {
-    store_err(conn.execute_batch(
-        "PRAGMA journal_mode=WAL;
-         PRAGMA foreign_keys=ON;
-         PRAGMA wal_autocheckpoint=100;
-         PRAGMA busy_timeout=5000;",
-    ))
-}
-
-/// Apply the full DDL (tables + indexes) via the shared [`DDL`] const.
-fn apply_ddl(conn: &Connection) -> io::Result<()> {
-    store_err(conn.execute_batch(DDL))
-}
-
-/// Write the current schema version to _harness_meta.
-fn set_version(conn: &Connection, version: u32) -> io::Result<()> {
-    store_err(conn.execute(
-        "INSERT OR REPLACE INTO _harness_meta (key, value) VALUES ('schema_version', ?1)",
-        rusqlite::params![version.to_string()],
-    ))?;
-    Ok(())
-}
-
-/// Run schema migrations from `from_version` (exclusive) to `to_version` (inclusive).
-///
-/// Add migration blocks here when bumping `SCHEMA_VERSION`:
-///
-/// ```ignore
-/// if to_version >= 2 && from_version < 2 {
-///     conn.execute_batch("ALTER TABLE …")?;
-/// }
-/// ```
-fn run_migrations(conn: &Connection, from_version: u32, to_version: u32) -> io::Result<()> {
-    // v1→v2: Add missing FK indexes and performance indexes for existing DBs.
-    // SQLite doesn't support ALTER TABLE ADD CONSTRAINT, so FK references are
-    // enforced via the index + application logic for pre-existing data.
-    if to_version >= 2 && from_version < 2 {
-        store_err(conn.execute_batch(
-            "CREATE INDEX IF NOT EXISTS idx_orch_events_agent ON orch_agent_events(agent_id);
-             CREATE INDEX IF NOT EXISTS idx_orch_inbox_agent  ON orch_agent_inbox(agent_id);
-             CREATE INDEX IF NOT EXISTS idx_obs_tool_ts       ON observations(tool, timestamp);
-             CREATE INDEX IF NOT EXISTS idx_evolved_proj_act  ON evolved_skills(project, active);",
-        ))?;
-    }
-
-    // v2→v3: Add UNIQUE constraint on score_history.timestamp.
-    // SQLite doesn't support ALTER TABLE ADD CONSTRAINT, so we recreate the table.
-    //
-    // Concurrency: ImmediateTx acquires a write lock before the version re-check,
-    // closing the TOCTOU window where two processes could both read version=1 in
-    // init_schema() and both enter run_migrations(1, 3). The re-read inside the lock
-    // ensures the second process skips the migration once the first has committed.
-    //
-    // Crash recovery: if the process dies after ImmediateTx::begin but before commit(),
-    // the RAII guard issues ROLLBACK automatically. If it dies after commit(), the
-    // schema_version=3 row is durable and the re-check skips the migration on restart.
-    if to_version >= 3 && from_version < 3 {
-        let tx = super::ImmediateTx::begin(conn)?;
-        // Re-read version inside the lock to guard against concurrent migration.
-        let current_v: Option<u32> = conn
-            .query_row(
-                "SELECT value FROM _harness_meta WHERE key = 'schema_version'",
-                [],
-                |row| row.get::<_, String>(0),
-            )
-            .ok()
-            .and_then(|v| v.parse().ok());
-        if current_v.map(|v| v >= 3).unwrap_or(false) {
-            // Already migrated by a concurrent process — drop tx (auto-ROLLBACK).
-            // Fall through so set_version() at the bottom of run_migrations is reached.
-            // Skip v3→v4 check below since DB is already at v3+.
-            set_version(conn, to_version)?;
-            return Ok(());
-        } else {
-            store_err(conn.execute_batch(
-                "CREATE TABLE IF NOT EXISTS score_history_v3 (
-                     id           INTEGER PRIMARY KEY AUTOINCREMENT,
-                     timestamp    TEXT NOT NULL UNIQUE,
-                     success_rate REAL NOT NULL,
-                     avg_score    REAL NOT NULL,
-                     observations INTEGER NOT NULL DEFAULT 0,
-                     dim_success  REAL NOT NULL DEFAULT 0.0,
-                     dim_quality  REAL NOT NULL DEFAULT 0.0,
-                     dim_cost     REAL NOT NULL DEFAULT 0.0
-                 );
-                 INSERT OR IGNORE INTO score_history_v3
-                     SELECT id, timestamp, success_rate, avg_score, observations,
-                            dim_success, dim_quality, dim_cost FROM score_history;
-                 DROP TABLE score_history;
-                 ALTER TABLE score_history_v3 RENAME TO score_history;",
-            ))?;
-            tx.commit()?;
-        }
-        // Fall through — do NOT return early, so subsequent migrations (v3→v4, etc.)
-        // can run in the same init_schema() call.
-    }
-
-    // v3→v4: Add project column to all tables for global DB.
-    if to_version >= 4 && from_version < 4 {
-        migrate_v3_to_v4(conn)?;
-        // Fall through — do NOT return early, so set_version() is always reached.
-    }
-
-    set_version(conn, to_version)?;
-    Ok(())
-}
-
-/// v3→v4: Add `project` column to all tables for global DB support.
-///
-/// Tables that already have `project` (orbit_pipelines, evolved_skills,
-/// global_patterns) are skipped. Tables with single-row constraints
-/// (promotion_counters, skill_attribution, workspace_manifest) are recreated
-/// with composite primary keys. All others get a simple ALTER TABLE ADD COLUMN.
-fn migrate_v3_to_v4(conn: &Connection) -> io::Result<()> {
-    let tx = super::ImmediateTx::begin(conn)?;
-    // Re-read version inside the lock.
-    let current_v: Option<u32> = conn
-        .query_row(
-            "SELECT value FROM _harness_meta WHERE key = 'schema_version'",
-            [],
-            |row| row.get::<_, String>(0),
-        )
-        .ok()
-        .and_then(|v| v.parse().ok());
-    if current_v.map(|v| v >= 4).unwrap_or(false) {
-        return Ok(());
-    }
-
-    // Add project column to tables that exist but don't already have it.
-    // Tables that don't exist yet will be created by apply_ddl() after migrations.
-    let tables_needing_project = [
-        "observations",
-        "sessions",
-        "evolution_records",
-        "metrics_state",
-        "score_history",
-        "orch_runs",
-        "orch_control",
-    ];
-    for table in &tables_needing_project {
-        if table_exists(conn, table) && !has_column(conn, table, "project") {
-            store_err(conn.execute(
-                &format!("ALTER TABLE {table} ADD COLUMN project TEXT NOT NULL DEFAULT ''"),
-                [],
-            ))?;
-        }
-    }
-
-    // Tables that need PK or UNIQUE constraint changes — recreate with data.
-    // Only migrate if the original table exists; otherwise apply_ddl() will create
-    // the correct v4 schema from scratch after this migration.
-
-    // metrics_state: TEXT PK → (key, project) composite PK
-    if table_exists(conn, "metrics_state") {
-        store_err(conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS metrics_state_v4 (
-                 key     TEXT NOT NULL,
-                 value   TEXT NOT NULL,
-                 project TEXT NOT NULL DEFAULT '',
-                 PRIMARY KEY (key, project)
-             );
-             INSERT OR IGNORE INTO metrics_state_v4
-                 SELECT key, value, project FROM metrics_state;
-             DROP TABLE metrics_state;
-             ALTER TABLE metrics_state_v4 RENAME TO metrics_state;",
-        ))?;
-    }
-
-    // score_history: UNIQUE(timestamp) → UNIQUE(timestamp, project)
-    if table_exists(conn, "score_history") {
-        store_err(conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS score_history_v4 (
-                 id           INTEGER PRIMARY KEY AUTOINCREMENT,
-                 timestamp    TEXT NOT NULL,
-                 success_rate REAL NOT NULL,
-                 avg_score    REAL NOT NULL,
-                 observations INTEGER NOT NULL DEFAULT 0,
-                 dim_success  REAL NOT NULL DEFAULT 0.0,
-                 dim_quality  REAL NOT NULL DEFAULT 0.0,
-                 dim_cost     REAL NOT NULL DEFAULT 0.0,
-                 project      TEXT NOT NULL DEFAULT '',
-                 UNIQUE(timestamp, project)
-             );
-             INSERT OR IGNORE INTO score_history_v4
-                 SELECT id, timestamp, success_rate, avg_score, observations,
-                        dim_success, dim_quality, dim_cost, project FROM score_history;
-             DROP TABLE score_history;
-             ALTER TABLE score_history_v4 RENAME TO score_history;",
-        ))?;
-    }
-
-    if table_exists(conn, "skill_attribution") {
-        // skill_attribution: TEXT PK → (skill_name, project) composite PK
-        store_err(conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS skill_attribution_v4 (
-                 skill_name        TEXT NOT NULL,
-                 project           TEXT NOT NULL DEFAULT '',
-                 sessions_active   INTEGER NOT NULL DEFAULT 0,
-                 avg_score_with    REAL NOT NULL DEFAULT 0.0,
-                 avg_score_without REAL NOT NULL DEFAULT 0.0,
-                 first_seen        TEXT NOT NULL,
-                 PRIMARY KEY (skill_name, project)
-             );
-             INSERT OR IGNORE INTO skill_attribution_v4
-                 SELECT skill_name, '', sessions_active, avg_score_with,
-                        avg_score_without, first_seen FROM skill_attribution;
-             DROP TABLE skill_attribution;
-             ALTER TABLE skill_attribution_v4 RENAME TO skill_attribution;",
-        ))?;
-    }
-
-    if table_exists(conn, "promotion_counters") {
-        // promotion_counters: TEXT PK → (pattern_key, project) composite PK
-        store_err(conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS promotion_counters_v4 (
-                 pattern_key TEXT NOT NULL,
-                 project     TEXT NOT NULL DEFAULT '',
-                 count       INTEGER NOT NULL DEFAULT 0,
-                 PRIMARY KEY (pattern_key, project)
-             );
-             INSERT OR IGNORE INTO promotion_counters_v4
-                 SELECT pattern_key, '', count FROM promotion_counters;
-             DROP TABLE promotion_counters;
-             ALTER TABLE promotion_counters_v4 RENAME TO promotion_counters;",
-        ))?;
-    }
-
-    if table_exists(conn, "workspace_manifest") {
-        // workspace_manifest: id=1 CHECK → AUTOINCREMENT + project column
-        store_err(conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS workspace_manifest_v4 (
-                 id          INTEGER PRIMARY KEY AUTOINCREMENT,
-                 project     TEXT NOT NULL DEFAULT '',
-                 version     TEXT NOT NULL DEFAULT '1.0',
-                 updated     TEXT NOT NULL,
-                 skills_json TEXT NOT NULL DEFAULT '[]'
-             );
-             INSERT OR IGNORE INTO workspace_manifest_v4
-                 SELECT id, '', version, updated, skills_json FROM workspace_manifest;
-             DROP TABLE workspace_manifest;
-             ALTER TABLE workspace_manifest_v4 RENAME TO workspace_manifest;",
-        ))?;
-    }
-
-    // Add project indexes for tables that have the project column.
-    // Tables not yet created will get their indexes from apply_ddl().
-    let project_indexes = [
-        ("idx_obs_project", "observations"),
-        ("idx_sessions_project", "sessions"),
-        ("idx_evo_project", "evolution_records"),
-        ("idx_score_hist_project", "score_history"),
-        ("idx_metrics_state_project", "metrics_state"),
-        ("idx_orch_runs_project", "orch_runs"),
-    ];
-    for (idx, tbl) in &project_indexes {
-        if has_column(conn, tbl, "project") {
-            store_err(conn.execute(
-                &format!("CREATE INDEX IF NOT EXISTS {idx} ON {tbl}(project)"),
-                [],
-            ))?;
-        }
-    }
-
-    tx.commit()?;
-    Ok(())
-}
-
-/// Check whether a table exists in the database.
-fn table_exists(conn: &Connection, table: &str) -> bool {
-    conn.query_row(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1",
-        rusqlite::params![table],
-        |_| Ok(true),
-    )
-    .unwrap_or(false)
-}
-
-/// Check whether a table has a specific column.
-fn has_column(conn: &Connection, table: &str, column: &str) -> bool {
-    let Ok(mut stmt) = conn.prepare(&format!("PRAGMA table_info({table})")) else {
-        return false;
-    };
-    let Ok(rows) = stmt.query_map([], |row| row.get::<_, String>(1)) else {
-        return false;
-    };
-    rows.filter_map(|r| r.ok()).any(|name| name == column)
-}
-
 // ── Async (sqlx) schema initialization ────────────
 
 /// Apply the full operational schema to a `SqlitePool`.
 ///
-/// Async equivalent of `init_schema()` for use with sqlx pools.
+/// Async equivalent of the removed rusqlite `init_schema()` for use with sqlx pools.
 /// Called once during pool creation in `pool::harness_pool()`.
 pub(crate) async fn init_schema_pool(pool: &SqlitePool) -> io::Result<()> {
     use sqlx::Executor;
@@ -566,7 +230,7 @@ pub(crate) async fn init_schema_pool(pool: &SqlitePool) -> io::Result<()> {
     .await
     .map_err(super::sqlx_err)?;
 
-    // DDL — shared with apply_ddl() via the DDL const above.
+    // DDL
     sqlx::raw_sql(DDL)
         .execute(pool)
         .await
@@ -582,7 +246,6 @@ pub(crate) async fn init_schema_pool(pool: &SqlitePool) -> io::Result<()> {
 }
 
 /// Check schema version in the pool and run pending migrations.
-/// Async equivalent of the rusqlite-based `run_migrations`.
 async fn run_migrations_pool(pool: &SqlitePool) -> io::Result<()> {
     // Read current version — None means fresh DB (no rows yet).
     let current: u32 = sqlx::query_as::<_, (String,)>(
@@ -662,11 +325,8 @@ async fn migrate_v3_to_v4_pool(pool: &SqlitePool) -> io::Result<()> {
         }
     }
 
-    // Composite-PK table recreations — same logic as the rusqlite path in
-    // migrate_v3_to_v4(). Tables that need PK changes are recreated with the
-    // correct v4 composite primary keys.
+    // Composite-PK table recreations
     let recreations: &[(&str, &str)] = &[
-        // (original_table, create_v4 + copy + drop + rename)
         (
             "metrics_state",
             "CREATE TABLE IF NOT EXISTS metrics_state_v4 (\
@@ -752,7 +412,6 @@ async fn migrate_v3_to_v4_pool(pool: &SqlitePool) -> io::Result<()> {
 
 /// Check if a table exists and has a single-column primary key (not yet migrated to composite).
 async fn table_has_single_pk(pool: &SqlitePool, table: &str) -> io::Result<bool> {
-    // PRAGMA table_info returns one row per column; pk > 0 marks PK columns.
     let cols = sqlx::query(&format!("PRAGMA table_info({table})"))
         .fetch_all(pool)
         .await
@@ -770,50 +429,6 @@ async fn table_has_single_pk(pool: &SqlitePool, table: &str) -> io::Result<bool>
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Verify DDL const works through the rusqlite path (apply_ddl).
-    #[test]
-    fn ddl_const_creates_all_tables_via_rusqlite() {
-        let conn = Connection::open_in_memory().unwrap();
-        apply_pragma(&conn).unwrap();
-        apply_ddl(&conn).unwrap();
-
-        let tables: Vec<String> = conn
-            .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
-            .unwrap()
-            .query_map([], |r| r.get(0))
-            .unwrap()
-            .filter_map(|r| r.ok())
-            .collect();
-
-        let expected = [
-            "_harness_meta",
-            "evolution_records",
-            "evolved_skills",
-            "global_patterns",
-            "metrics_state",
-            "observations",
-            "orch_agent_events",
-            "orch_agent_inbox",
-            "orch_agents",
-            "orch_control",
-            "orch_runs",
-            "orbit_pipelines",
-            "promotion_counters",
-            "score_history",
-            "sessions",
-            "skill_attribution",
-            "workspace_manifest",
-        ];
-        for t in &expected {
-            assert!(tables.contains(&t.to_string()), "missing table: {t}");
-        }
-        assert_eq!(
-            tables.len(),
-            expected.len() + 1,
-            "unexpected extra tables: {tables:?}"
-        );
-    }
 
     /// Verify DDL const works through the sqlx pool path (init_schema_pool).
     #[tokio::test]


### PR DESCRIPTION
## Summary

Converts all remaining rusqlite `_conn()` callers in `mem/`, `evolve/`, and `hooks/` to use the async `block_on(*_pool())` bridge introduced in PR #33. Also rewrites `store/migrate.rs` to use `SqliteConnectOptions` direct connection + raw sqlx query for `ATTACH DATABASE`.

### Changes

- `src/mem/mcp.rs` — `open_db()` → `block_on(memory_pool())`; all `*_conn()` → pool variants
- `src/mem/graph.rs` — `build_graph_conn`, `rebuild_graph_json_conn`, etc. → pool variants
- `src/evolve/ingest.rs` — 47 `*_conn()` calls converted, `ImmediateTx` removed
- `src/evolve/instincts.rs` — `open_db()` → `block_on(memory_pool())`
- `src/hooks/reflect.rs` — 3 remaining `*_conn()` calls converted
- `src/mem/axum_server.rs` — `handle_stats`, `handle_list_nodes` use async pool
- `src/mem/store/*.rs` — `_conn()` function definitions removed
- `src/store/migrate.rs` — Full rewrite: `rusqlite::Connection` → `SqliteConnectOptions::new().filename(...).connect().await`; ATTACH DATABASE as raw sqlx query
- `src/store/mod.rs` — Remove `ImmediateTx`, `open_harness_db()`, `store_err()`
- `src/store/pool.rs` — `OnceCell` → `TokioMutex` for integration test URL-change detection

## Test plan

- [ ] `cargo test` — 549 tests pass
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --check` — clean
- [ ] `grep -r "use rusqlite" src/` — empty (no rusqlite imports outside migrate.rs comments)

Closes #34

---
*Part of [#35](#) → [#36](#) stacked series completing full rusqlite removal.*