### PR TITLE
feat(orbit): auto-close evolve gap via reflect hook

### DIFF
--- a/src/hooks/reflect.rs
+++ b/src/hooks/reflect.rs
@@ -1002,7 +1002,19 @@ pub fn run(_input: &HookInput) -> i32 {
         }
     }
 
-    // 11.6. Workspace manifest
+    // 11.6. Orbit evolve gap — patch pipelines that completed ship but missed evolve
+    // (happens when CI wait causes session timeout before orbit can chain to evolve).
+    // reflect already performs the evolve analysis above, so retroactively marking
+    // these pipelines closes the gap without duplicating work.
+    let evolve_patched = patch_orbit_evolve_gap(&orbit_dir(), &now_iso());
+    if evolve_patched > 0 {
+        hint(
+            "reflect",
+            &format!("Orbit: evolve gap closed for {evolve_patched} pipeline(s)"),
+        );
+    }
+
+    // 11.7. Workspace manifest
     evolve::write_workspace_manifest();
 
     // 12. Report
@@ -1230,6 +1242,80 @@ fn ingest_to_episteme(analysis: &SessionAnalysis) -> bool {
     }
 }
 
+// ── Orbit evolve gap detection ──────────────────────────────────────────────
+
+/// Scan orbit pipeline files for completed pipelines that shipped but never
+/// recorded an evolve phase (i.e., the session timed out before orbit could
+/// chain ship → evolve).  Because `reflect::run` already performs the full
+/// evolve analysis, calling this afterward retroactively closes the gap by
+/// adding an evolve entry to the phase_history.  Idempotent: already-patched
+/// pipelines are skipped.  Returns the number of pipelines patched.
+fn patch_orbit_evolve_gap(orbit_dir: &std::path::Path, now: &str) -> usize {
+    let entries = match fs::read_dir(orbit_dir) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+    let mut patched = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if !name.starts_with("PIPELINE-") || !name.ends_with(".json") {
+            continue;
+        }
+        let content = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let mut pipeline: serde_json::Value = match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        // Only touch pipelines that completed ship but have no evolve entry.
+        let status_complete = matches!(
+            pipeline["status"].as_str(),
+            Some("complete") | Some("shipped")
+        );
+        if !status_complete {
+            continue;
+        }
+
+        let history = match pipeline["phase_history"].as_array() {
+            Some(h) => h,
+            None => continue,
+        };
+        let has_ship = history
+            .iter()
+            .any(|e| e["phase"] == "ship" && e["status"] == "complete");
+        let has_evolve = history.iter().any(|e| e["phase"] == "evolve");
+
+        if !has_ship || has_evolve {
+            continue;
+        }
+
+        // Insert evolve entry before the final "complete" entry (if present).
+        let evolve_entry = serde_json::json!({
+            "phase": "evolve",
+            "status": "complete",
+            "at": now,
+            "note": "applied via reflect hook (session-end gap recovery)"
+        });
+        if let Some(arr) = pipeline["phase_history"].as_array_mut() {
+            match arr.iter().rposition(|e| e["phase"] == "complete") {
+                Some(pos) => arr.insert(pos, evolve_entry),
+                None => arr.push(evolve_entry),
+            }
+        }
+
+        if let Ok(updated) = serde_json::to_string_pretty(&pipeline) {
+            if fs::write(&path, updated).is_ok() {
+                patched += 1;
+            }
+        }
+    }
+    patched
+}
+
 // ── Inline tests (kept here: run_context epoch helpers) ──
 #[cfg(test)]
 mod tests {
@@ -1338,5 +1424,75 @@ mod tests {
 
         assert_eq!(cutoff_tag, "20260101");
         assert_eq!(date_from, "20260101");
+    }
+
+    #[test]
+    fn patch_orbit_evolve_gap_patches_ship_complete_no_evolve() {
+        let dir = tempfile::tempdir().unwrap();
+        let pipeline = serde_json::json!({
+            "id": "test-pipeline",
+            "status": "complete",
+            "phase": "complete",
+            "phase_history": [
+                {"phase": "ship", "status": "complete", "at": "2026-01-01T00:00:00Z"},
+                {"phase": "complete", "status": "complete", "at": "2026-01-01T00:01:00Z"}
+            ]
+        });
+        let path = dir.path().join("PIPELINE-test.json");
+        fs::write(&path, serde_json::to_string_pretty(&pipeline).unwrap()).unwrap();
+
+        let patched = patch_orbit_evolve_gap(dir.path(), "2026-01-01T00:02:00Z");
+        assert_eq!(patched, 1);
+
+        let updated: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let history = updated["phase_history"].as_array().unwrap();
+        assert!(
+            history.iter().any(|e| e["phase"] == "evolve"),
+            "evolve entry should be present"
+        );
+        // evolve must come before the final complete entry
+        let evolve_pos = history.iter().position(|e| e["phase"] == "evolve").unwrap();
+        let complete_pos = history
+            .iter()
+            .rposition(|e| e["phase"] == "complete")
+            .unwrap();
+        assert!(evolve_pos < complete_pos, "evolve must precede complete");
+    }
+
+    #[test]
+    fn patch_orbit_evolve_gap_skips_already_evolved() {
+        let dir = tempfile::tempdir().unwrap();
+        let pipeline = serde_json::json!({
+            "id": "test-pipeline-2",
+            "status": "complete",
+            "phase_history": [
+                {"phase": "ship", "status": "complete", "at": "2026-01-01T00:00:00Z"},
+                {"phase": "evolve", "status": "complete", "at": "2026-01-01T00:01:00Z"},
+                {"phase": "complete", "status": "complete", "at": "2026-01-01T00:02:00Z"}
+            ]
+        });
+        let path = dir.path().join("PIPELINE-test2.json");
+        fs::write(&path, serde_json::to_string_pretty(&pipeline).unwrap()).unwrap();
+
+        let patched = patch_orbit_evolve_gap(dir.path(), "2026-01-01T00:03:00Z");
+        assert_eq!(patched, 0, "already-evolved pipeline must not be patched");
+    }
+
+    #[test]
+    fn patch_orbit_evolve_gap_skips_in_progress() {
+        let dir = tempfile::tempdir().unwrap();
+        let pipeline = serde_json::json!({
+            "id": "test-pipeline-3",
+            "status": "build",
+            "phase_history": [
+                {"phase": "ship", "status": "complete", "at": "2026-01-01T00:00:00Z"}
+            ]
+        });
+        let path = dir.path().join("PIPELINE-test3.json");
+        fs::write(&path, serde_json::to_string_pretty(&pipeline).unwrap()).unwrap();
+
+        let patched = patch_orbit_evolve_gap(dir.path(), "2026-01-01T00:01:00Z");
+        assert_eq!(patched, 0, "in-progress pipeline must not be patched");
     }
 }

--- a/src/hooks/reflect.rs
+++ b/src/hooks/reflect.rs
@@ -1002,10 +1002,7 @@ pub fn run(_input: &HookInput) -> i32 {
         }
     }
 
-    // 11.6. Orbit evolve gap — patch pipelines that completed ship but missed evolve
-    // (happens when CI wait causes session timeout before orbit can chain to evolve).
-    // reflect already performs the evolve analysis above, so retroactively marking
-    // these pipelines closes the gap without duplicating work.
+    // 11.6. Orbit evolve gap — retroactively close ship-but-no-evolve pipelines
     let evolve_patched = patch_orbit_evolve_gap(&orbit_dir(), &now_iso());
     if evolve_patched > 0 {
         hint(
@@ -1287,6 +1284,8 @@ fn patch_orbit_evolve_gap(orbit_dir: &std::path::Path, now: &str) -> usize {
         let has_ship = history
             .iter()
             .any(|e| e["phase"] == "ship" && e["status"] == "complete");
+        // Any evolve entry (including failed) blocks patching: if evolve ran and
+        // failed, patching it complete would misrepresent history.
         let has_evolve = history.iter().any(|e| e["phase"] == "evolve");
 
         if !has_ship || has_evolve {
@@ -1308,8 +1307,11 @@ fn patch_orbit_evolve_gap(orbit_dir: &std::path::Path, now: &str) -> usize {
         }
 
         if let Ok(updated) = serde_json::to_string_pretty(&pipeline) {
-            if fs::write(&path, updated).is_ok() {
+            let tmp = path.with_extension("json.tmp");
+            if fs::write(&tmp, updated).is_ok() && fs::rename(&tmp, &path).is_ok() {
                 patched += 1;
+            } else {
+                let _ = fs::remove_file(&tmp);
             }
         }
     }
@@ -1494,5 +1496,34 @@ mod tests {
 
         let patched = patch_orbit_evolve_gap(dir.path(), "2026-01-01T00:01:00Z");
         assert_eq!(patched, 0, "in-progress pipeline must not be patched");
+    }
+
+    #[test]
+    fn patch_orbit_evolve_gap_patches_shipped_status() {
+        let dir = tempfile::tempdir().unwrap();
+        let pipeline = serde_json::json!({
+            "id": "test-pipeline-4",
+            "status": "shipped",
+            "phase_history": [
+                {"phase": "ship", "status": "complete", "at": "2026-01-01T00:00:00Z"},
+                {"phase": "complete", "status": "complete", "at": "2026-01-01T00:01:00Z"}
+            ]
+        });
+        let path = dir.path().join("PIPELINE-test4.json");
+        fs::write(&path, serde_json::to_string_pretty(&pipeline).unwrap()).unwrap();
+
+        let patched = patch_orbit_evolve_gap(dir.path(), "2026-01-01T00:02:00Z");
+        assert_eq!(patched, 1, "shipped status must be patched like complete");
+
+        let updated: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(
+            updated["phase_history"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|e| e["phase"] == "evolve"),
+            "evolve entry should be present for shipped pipeline"
+        );
     }
 }

--- a/src/hooks/reflect.rs
+++ b/src/hooks/reflect.rs
@@ -1526,4 +1526,35 @@ mod tests {
             "evolve entry should be present for shipped pipeline"
         );
     }
+
+    #[test]
+    fn patch_orbit_evolve_gap_skips_failed_evolve() {
+        let dir = tempfile::tempdir().unwrap();
+        let pipeline = serde_json::json!({
+            "id": "test-pipeline-5",
+            "status": "complete",
+            "phase_history": [
+                {"phase": "ship", "status": "complete", "at": "2026-01-01T00:00:00Z"},
+                {"phase": "evolve", "status": "failed", "at": "2026-01-01T00:01:00Z"},
+                {"phase": "complete", "status": "complete", "at": "2026-01-01T00:02:00Z"}
+            ]
+        });
+        let path = dir.path().join("PIPELINE-test5.json");
+        fs::write(&path, serde_json::to_string_pretty(&pipeline).unwrap()).unwrap();
+
+        let patched = patch_orbit_evolve_gap(dir.path(), "2026-01-01T00:03:00Z");
+        assert_eq!(patched, 0, "failed evolve must not be overwritten");
+
+        // Verify the failed entry is preserved as-is
+        let updated: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let evolve_entries: Vec<_> = updated["phase_history"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|e| e["phase"] == "evolve")
+            .collect();
+        assert_eq!(evolve_entries.len(), 1, "must not add duplicate evolve entry");
+        assert_eq!(evolve_entries[0]["status"], "failed", "original failed status preserved");
+    }
 }

--- a/src/hooks/reflect.rs
+++ b/src/hooks/reflect.rs
@@ -1554,7 +1554,14 @@ mod tests {
             .iter()
             .filter(|e| e["phase"] == "evolve")
             .collect();
-        assert_eq!(evolve_entries.len(), 1, "must not add duplicate evolve entry");
-        assert_eq!(evolve_entries[0]["status"], "failed", "original failed status preserved");
+        assert_eq!(
+            evolve_entries.len(),
+            1,
+            "must not add duplicate evolve entry"
+        );
+        assert_eq!(
+            evolve_entries[0]["status"], "failed",
+            "original failed status preserved"
+        );
     }
 }


### PR DESCRIPTION
## Summary

orbit의 ship→evolve 체이닝이 CI 대기 중 세션 타임아웃으로 끊길 때 evolve가 영구적으로 스킵되는 문제를 수정합니다.

## 문제

orbit 파이프라인은 ship → (CI green) → evolve 순서로 동작하지만, CI 대기 중 세션이 종료되면 evolve가 실행되지 않고 `PIPELINE-*.json`에도 기록되지 않습니다.

## 해결 방법

`reflect` 훅(세션 종료 시 자동 실행)이 이미 evolve와 동일한 분석을 수행하므로, 여기에 orbit 파이프라인 갭 감지 로직을 추가합니다:

- `patch_orbit_evolve_gap()`: orbit dir의 PIPELINE-*.json을 스캔
- ship 완료됐지만 evolve 미기록인 파이프라인을 찾아 phase_history에 evolve 엔트리 추가
- 다음 세션 시작 시 reflect 훅이 자동으로 처리

## 동작

| 상황 | 처리 |
|------|------|
| 세션 유지, CI 빠름 | 기존과 동일 — orbit이 직접 evolve 실행 |
| 세션 타임아웃, CI 느림 | 다음 세션 종료 시 reflect가 자동 보완 |
| 이미 evolve 기록됨 | 스킵 (멱등) |
| 파이프라인 진행 중 | 스킵 (status != complete) |

## Changes

- `src/hooks/reflect.rs`: `patch_orbit_evolve_gap()` 함수 추가 + step 11.6 삽입
- 3개 테스트: patch, 이미-evolved 스킵, 진행중 스킵

## Tests

- 578/578 passing
- Clippy: clean
- fmt: clean