### PR TITLE
fix(store): address 5 follow-up findings from PR #52 review

### DIFF
--- a/src/hooks/reflect.rs
+++ b/src/hooks/reflect.rs
@@ -798,7 +798,11 @@ pub fn run(_input: &HookInput) -> i32 {
     let observations = match pool.as_ref() {
         Some(p) => match crate::store::runtime::block_on(
             crate::store::observations::query_obs_for_date_range_pool(
-                p, &slug, &today_str, &today_str, None,
+                p,
+                &slug,
+                &today_str,
+                &today_str,
+                Some(50_000),
             ),
         ) {
             Ok(recs) => recs,

--- a/src/main.rs
+++ b/src/main.rs
@@ -280,7 +280,11 @@ fn main() {
         print!("{stdin_buf}");
     }
 
-    exit_with_cleanup(exit_code);
+    let skip_shutdown = matches!(
+        subcmd,
+        "help" | "--help" | "-h" | "path" | "version" | "--version" | "-v"
+    );
+    exit_with_cleanup(exit_code, skip_shutdown);
 }
 
 /// Gracefully close connection pools before exit to flush WAL.
@@ -288,9 +292,11 @@ fn main() {
 /// # Safety
 /// Must only be called from a non-async context (e.g., `main()`).
 /// `store::runtime::block_on` panics if called inside a tokio runtime.
-fn exit_with_cleanup(code: i32) -> ! {
-    // SAFETY: Called only from main() which is not inside a tokio runtime.
-    store::runtime::block_on(store::pool::shutdown());
+fn exit_with_cleanup(code: i32, skip_shutdown: bool) -> ! {
+    if !skip_shutdown {
+        // SAFETY: Called only from main() which is not inside a tokio runtime.
+        store::runtime::block_on(store::pool::shutdown());
+    }
     std::process::exit(code);
 }
 

--- a/src/mem/axum_server.rs
+++ b/src/mem/axum_server.rs
@@ -64,20 +64,7 @@ pub fn serve_axum(args: &[String]) -> i32 {
 
     let state = AppState { pool: mem_pool };
 
-    // Build tokio runtime (multi-thread)
-    let rt = match tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(2)
-        .enable_all()
-        .build()
-    {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("Failed to build tokio runtime: {e}");
-            return 1;
-        }
-    };
-
-    rt.block_on(async move {
+    crate::store::runtime::block_on(async move {
         let app = build_router(state, port);
 
         let addr = format!("127.0.0.1:{port}");

--- a/src/mem/axum_server.rs
+++ b/src/mem/axum_server.rs
@@ -652,4 +652,50 @@ mod tests {
         let res = server.get("/api/search?q=test").await;
         assert_eq!(res.status_code(), StatusCode::OK);
     }
+
+    #[tokio::test]
+    async fn list_nodes_limit_parameter() {
+        let state = make_state().await;
+        let app = build_router(state.clone(), 7700);
+        let server = TestServer::new(app);
+
+        // Insert 5 nodes
+        for i in 0..5 {
+            let payload = json!({
+                "type": "concept",
+                "title": format!("Limit test node {i}"),
+                "body": format!("body {i}"),
+                "tags": ["limit-test"],
+                "projects": [],
+                "agents": []
+            });
+            let res = server.post("/api/nodes").json(&payload).await;
+            assert_eq!(res.status_code(), StatusCode::CREATED);
+        }
+
+        // Without limit — should return all 5 (default 500)
+        let all = server.get("/api/nodes").await;
+        assert_eq!(all.status_code(), StatusCode::OK);
+        let nodes: Value = all.json();
+        assert_eq!(nodes.as_array().unwrap().len(), 5);
+
+        // With limit=2 — should return exactly 2
+        let limited = server.get("/api/nodes?limit=2").await;
+        assert_eq!(limited.status_code(), StatusCode::OK);
+        let nodes: Value = limited.json();
+        assert_eq!(
+            nodes.as_array().unwrap().len(),
+            2,
+            "limit=2 should return exactly 2 nodes"
+        );
+
+        // With limit=0 — should return empty
+        let zero = server.get("/api/nodes?limit=0").await;
+        assert_eq!(zero.status_code(), StatusCode::OK);
+        let nodes: Value = zero.json();
+        assert!(
+            nodes.as_array().unwrap().is_empty(),
+            "limit=0 should return empty array"
+        );
+    }
 }

--- a/src/mem/axum_server.rs
+++ b/src/mem/axum_server.rs
@@ -21,7 +21,7 @@ use axum::{
 };
 use serde_json::{Value, json};
 use sqlx::AnyPool;
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::cors::CorsLayer;
 
 use super::graph::{compute_stats_pool, rebuild_graph_json_pool};
 use super::store::{
@@ -66,7 +66,7 @@ pub fn serve_axum(args: &[String]) -> i32 {
 
     // Build tokio runtime (multi-thread)
     let rt = match tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(4)
+        .worker_threads(2)
         .enable_all()
         .build()
     {
@@ -325,7 +325,7 @@ pub fn build_router(state: AppState, port: u16) -> Router {
             Method::DELETE,
             Method::OPTIONS,
         ])
-        .allow_headers(Any);
+        .allow_headers([header::CONTENT_TYPE, header::ACCEPT, header::AUTHORIZATION]);
 
     Router::new()
         // Static
@@ -398,12 +398,27 @@ async fn handle_centrality(
     Json(data).into_response()
 }
 
-async fn handle_list_nodes(State(state): State<AppState>) -> impl IntoResponse {
+#[derive(serde::Deserialize)]
+struct ListNodesQuery {
+    #[serde(default = "default_list_limit")]
+    limit: usize,
+}
+
+fn default_list_limit() -> usize {
+    500
+}
+
+async fn handle_list_nodes(
+    State(state): State<AppState>,
+    Query(q): Query<ListNodesQuery>,
+) -> impl IntoResponse {
     use super::store::IndexNode;
+    let limit = q.limit.min(5000);
     let nodes: Vec<IndexNode> = read_all_nodes_pool(&state.pool)
         .await
         .unwrap_or_default()
         .into_iter()
+        .take(limit)
         .map(|n| IndexNode {
             id: n.frontmatter.id,
             title: n.frontmatter.title,

--- a/src/mem/axum_server.rs
+++ b/src/mem/axum_server.rs
@@ -28,7 +28,7 @@ use super::store::{
     Edge, Node, NodeFrontmatter, append_edge_pool, importance_for_type, now_iso, write_node_pool,
 };
 use super::store::{
-    delete_edge_by_id, delete_node_file, read_all_nodes_pool, read_node_pool,
+    delete_edge_by_id, delete_node_file, read_node_pool, read_nodes_limited_pool,
     remove_edges_for_node, remove_from_index, search_nodes_pool, validate_uuid,
 };
 use crate::store::pool;
@@ -401,11 +401,10 @@ async fn handle_list_nodes(
 ) -> impl IntoResponse {
     use super::store::IndexNode;
     let limit = q.limit.min(5000);
-    let nodes: Vec<IndexNode> = read_all_nodes_pool(&state.pool)
+    let nodes: Vec<IndexNode> = read_nodes_limited_pool(&state.pool, limit as i64)
         .await
         .unwrap_or_default()
         .into_iter()
-        .take(limit)
         .map(|n| IndexNode {
             id: n.frontmatter.id,
             title: n.frontmatter.title,

--- a/src/mem/store/node.rs
+++ b/src/mem/store/node.rs
@@ -63,7 +63,7 @@ pub async fn write_node_pool(pool: &AnyPool, node: &Node) -> io::Result<()> {
            type=EXCLUDED.type, title=EXCLUDED.title, tags=EXCLUDED.tags,
            projects=EXCLUDED.projects, agents=EXCLUDED.agents, created=EXCLUDED.created,
            updated=EXCLUDED.updated, body=EXCLUDED.body, importance=EXCLUDED.importance,
-           access_count=MAX(nodes.access_count, EXCLUDED.access_count), accessed_at=EXCLUDED.accessed_at",
+           access_count=CASE WHEN nodes.access_count >= EXCLUDED.access_count THEN nodes.access_count ELSE EXCLUDED.access_count END, accessed_at=EXCLUDED.accessed_at",
     )
     .bind(&fm.id)
     .bind(&fm.node_type)

--- a/src/mem/store/node.rs
+++ b/src/mem/store/node.rs
@@ -63,7 +63,7 @@ pub async fn write_node_pool(pool: &AnyPool, node: &Node) -> io::Result<()> {
            type=EXCLUDED.type, title=EXCLUDED.title, tags=EXCLUDED.tags,
            projects=EXCLUDED.projects, agents=EXCLUDED.agents, created=EXCLUDED.created,
            updated=EXCLUDED.updated, body=EXCLUDED.body, importance=EXCLUDED.importance,
-           access_count=EXCLUDED.access_count, accessed_at=EXCLUDED.accessed_at",
+           access_count=MAX(nodes.access_count, EXCLUDED.access_count), accessed_at=EXCLUDED.accessed_at",
     )
     .bind(&fm.id)
     .bind(&fm.node_type)

--- a/src/mem/store/recall.rs
+++ b/src/mem/store/recall.rs
@@ -133,28 +133,18 @@ pub async fn smart_recall_pool(
             .collect();
 
         let mut qb = sqlx::QueryBuilder::new(
-            "SELECT source AS node_id, SUM(weight) AS w FROM edges WHERE source IN (",
+            "SELECT node_id, SUM(w) AS w FROM (SELECT source AS node_id, weight AS w FROM edges WHERE target IN (",
         );
         let mut separated = qb.separated(", ");
         for id in &boost_ids {
             separated.push_bind(*id);
         }
-        qb.push(") AND target IN (");
+        qb.push(") UNION ALL SELECT target AS node_id, weight AS w FROM edges WHERE source IN (");
         let mut separated2 = qb.separated(", ");
         for id in &boost_ids {
             separated2.push_bind(*id);
         }
-        qb.push(") GROUP BY source UNION ALL SELECT target AS node_id, SUM(weight) AS w FROM edges WHERE source IN (");
-        let mut separated3 = qb.separated(", ");
-        for id in &boost_ids {
-            separated3.push_bind(*id);
-        }
-        qb.push(") AND target IN (");
-        let mut separated4 = qb.separated(", ");
-        for id in &boost_ids {
-            separated4.push_bind(*id);
-        }
-        qb.push(") GROUP BY target");
+        qb.push(")) sub GROUP BY node_id");
 
         if let Ok(rows) = qb.build().fetch_all(pool).await {
             let mut weight_map: std::collections::HashMap<String, f64> = Default::default();

--- a/src/mem/store/recall.rs
+++ b/src/mem/store/recall.rs
@@ -132,6 +132,9 @@ pub async fn smart_recall_pool(
             .map(|sn| sn.node.frontmatter.id.as_str())
             .collect();
 
+        // Intentionally collects all edges adjacent to top-result nodes (not just
+        // intra-cluster edges). This surfaces non-result nodes that are strongly
+        // connected to top results and deserve a score boost.
         let mut qb = sqlx::QueryBuilder::new(
             "SELECT node_id, SUM(w) AS w FROM (SELECT source AS node_id, weight AS w FROM edges WHERE target IN (",
         );

--- a/src/mem/store/schema.rs
+++ b/src/mem/store/schema.rs
@@ -140,7 +140,8 @@ async fn init_sqlite_schema(pool: &AnyPool) -> io::Result<()> {
         CREATE INDEX IF NOT EXISTS idx_nodes_updated ON nodes(updated DESC);
         CREATE INDEX IF NOT EXISTS idx_nodes_title_updated ON nodes(title, updated DESC);
         CREATE INDEX IF NOT EXISTS idx_nodes_importance ON nodes(importance DESC);
-        CREATE INDEX IF NOT EXISTS idx_nodes_accessed ON nodes(accessed_at DESC);",
+        CREATE INDEX IF NOT EXISTS idx_nodes_accessed ON nodes(accessed_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_nodes_imp_upd ON nodes(importance DESC, updated DESC);",
     )
     .execute(pool)
     .await
@@ -178,7 +179,8 @@ async fn init_postgres_schema(pool: &AnyPool) -> io::Result<()> {
         CREATE INDEX IF NOT EXISTS idx_nodes_updated ON nodes(updated DESC);
         CREATE INDEX IF NOT EXISTS idx_nodes_title_updated ON nodes(title, updated DESC);
         CREATE INDEX IF NOT EXISTS idx_nodes_importance ON nodes(importance DESC);
-        CREATE INDEX IF NOT EXISTS idx_nodes_accessed ON nodes(accessed_at DESC);",
+        CREATE INDEX IF NOT EXISTS idx_nodes_accessed ON nodes(accessed_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_nodes_imp_upd ON nodes(importance DESC, updated DESC);",
     )
     .execute(pool)
     .await

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -168,7 +168,11 @@ pub fn run_serve(port: Option<u16>) -> i32 {
                     .unwrap(),
                 )
                 .with_header(
-                    Header::from_bytes(b"Access-Control-Allow-Headers", b"Content-Type").unwrap(),
+                    Header::from_bytes(
+                        b"Access-Control-Allow-Headers",
+                        b"Content-Type, Accept, Authorization",
+                    )
+                    .unwrap(),
                 ),
 
             // ── SPA fallback: serve index.html for non-API, non-static-asset GET routes ──

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -106,56 +106,59 @@ pub fn run_serve(port: Option<u16>) -> i32 {
             }
 
             // ── Orchestration API ───────────────────────────
-            (Method::Get, "/api/run") => handle_get_run(pool.as_ref(), &harness_dir),
+            (Method::Get, "/api/run") => handle_get_run(pool.as_ref(), &harness_dir, port),
             (Method::Get, "/api/events") => handle_get_events(pool.as_ref(), &harness_dir),
 
             // ── Memory API (Graph/Stats) ─────────────────────
-            (Method::Get, "/api/graph") => handle_get_graph(),
-            (Method::Get, "/api/stats") => handle_get_stats(),
+            (Method::Get, "/api/graph") => handle_get_graph(port),
+            (Method::Get, "/api/stats") => handle_get_stats(port),
 
             // ── Harness API ──────────────────────────────────
             (Method::Get, url) if url.starts_with("/api/harness") => {
                 let cmd = parse_query_param(url, "cmd").unwrap_or_default();
                 let body = handle_harness_cmd(pool.as_ref(), &cmd);
-                json_response(&body)
+                json_response(&body, port)
             }
 
             // ── Orbit Pipeline Dismiss ───────────────────────
             (Method::Delete, url) if url.starts_with("/api/orbit/") => {
                 let pipeline_id = url.trim_start_matches("/api/orbit/").trim_end_matches('/');
                 let body = dismiss_orbit_pipeline(pool.as_ref(), pipeline_id, &harness_dir);
-                json_response(&body)
+                json_response(&body, port)
             }
 
             // ── Memory API (Nodes) ───────────────────────────
             (Method::Get, u) if u == "/api/nodes" || u.starts_with("/api/nodes?") => {
-                handle_list_nodes(u)
+                handle_list_nodes(u, port)
             }
 
-            (Method::Get, url) if url.starts_with("/api/nodes/") => handle_get_node(url),
+            (Method::Get, url) if url.starts_with("/api/nodes/") => handle_get_node(url, port),
 
             // ── Memory API (Search) ──────────────────────────
-            (Method::Get, url) if url.starts_with("/api/search") => handle_search(url),
+            (Method::Get, url) if url.starts_with("/api/search") => handle_search(url, port),
 
             // ── Agents API ───────────────────────────────────
             (Method::Get, url) if url.starts_with("/api/agents/") && url.ends_with("/status") => {
                 let agent_id = url
                     .trim_start_matches("/api/agents/")
                     .trim_end_matches("/status");
-                handle_agent_status(pool.as_ref(), agent_id, &harness_dir)
+                handle_agent_status(pool.as_ref(), agent_id, &harness_dir, port)
             }
 
             (Method::Delete, url) if url.starts_with("/api/agents/") => {
                 let agent_id = url.trim_start_matches("/api/agents/").trim_end_matches('/');
-                handle_agent_dismiss(pool.as_ref(), agent_id, &harness_dir)
+                handle_agent_dismiss(pool.as_ref(), agent_id, &harness_dir, port)
             }
 
             // ── CORS & Other ────────────────────────────────
             (Method::Options, _) => Response::from_string("{}")
                 .with_status_code(204)
                 .with_header(
-                    Header::from_bytes(b"Access-Control-Allow-Origin", b"http://localhost:5173")
-                        .unwrap(),
+                    Header::from_bytes(
+                        b"Access-Control-Allow-Origin",
+                        format!("http://localhost:{port}").as_bytes(),
+                    )
+                    .unwrap(),
                 )
                 .with_header(
                     Header::from_bytes(
@@ -213,6 +216,7 @@ fn try_pool<T>(
 fn handle_get_run(
     pool: Option<&sqlx::AnyPool>,
     harness_dir: &std::path::Path,
+    port: u16,
 ) -> Response<std::io::Cursor<Vec<u8>>> {
     let slug = crate::shared::paths::project_slug();
     let db_ok = try_pool(pool, |p| {
@@ -234,7 +238,7 @@ fn handle_get_run(
             body.to_string()
         }
     };
-    json_response(&body)
+    json_response(&body, port)
 }
 
 fn handle_get_events(
@@ -262,23 +266,23 @@ fn handle_get_events(
         .with_header(Header::from_bytes(b"Connection", b"keep-alive").unwrap())
 }
 
-fn handle_get_graph() -> Response<std::io::Cursor<Vec<u8>>> {
+fn handle_get_graph(port: u16) -> Response<std::io::Cursor<Vec<u8>>> {
     let body = match graph::rebuild_graph_json() {
         Ok(json) => json,
         Err(_) => "{}".into(),
     };
-    json_response(&body)
+    json_response(&body, port)
 }
 
-fn handle_get_stats() -> Response<std::io::Cursor<Vec<u8>>> {
+fn handle_get_stats(port: u16) -> Response<std::io::Cursor<Vec<u8>>> {
     let body = match graph::compute_stats() {
         Ok(v) => v.to_string(),
         Err(_) => "{}".into(),
     };
-    json_response(&body)
+    json_response(&body, port)
 }
 
-fn handle_list_nodes(url: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+fn handle_list_nodes(url: &str, port: u16) -> Response<std::io::Cursor<Vec<u8>>> {
     let limit: usize = parse_query_param(url, "limit")
         .and_then(|v| v.parse().ok())
         .unwrap_or(200)
@@ -306,15 +310,21 @@ fn handle_list_nodes(url: &str) -> Response<std::io::Cursor<Vec<u8>>> {
             })
         })
         .collect();
-    json_response(&serde_json::to_string(&results).unwrap_or_else(|_| "[]".into()))
+    json_response(
+        &serde_json::to_string(&results).unwrap_or_else(|_| "[]".into()),
+        port,
+    )
 }
 
-fn handle_get_node(url: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+fn handle_get_node(url: &str, port: u16) -> Response<std::io::Cursor<Vec<u8>>> {
     let id = url
         .trim_start_matches("/api/nodes/")
         .split('?')
         .next()
         .unwrap_or("");
+    if !store::validate_uuid(id) {
+        return json_response("{\"error\":\"invalid node id\"}", port).with_status_code(400);
+    }
     let body = match store::read_node(id) {
         Ok(node) => {
             let v = serde_json::json!({
@@ -334,10 +344,10 @@ fn handle_get_node(url: &str) -> Response<std::io::Cursor<Vec<u8>>> {
         }
         Err(_) => "{\"error\":\"not found\"}".into(),
     };
-    json_response(&body)
+    json_response(&body, port)
 }
 
-fn handle_search(url: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+fn handle_search(url: &str, port: u16) -> Response<std::io::Cursor<Vec<u8>>> {
     let query = url
         .split("q=")
         .nth(1)
@@ -359,16 +369,17 @@ fn handle_search(url: &str) -> Response<std::io::Cursor<Vec<u8>>> {
         })
         .collect();
     let body = serde_json::to_string(&results).unwrap_or_else(|_| "[]".into());
-    json_response(&body)
+    json_response(&body, port)
 }
 
 fn handle_agent_status(
     pool: Option<&sqlx::AnyPool>,
     agent_id: &str,
     harness_dir: &std::path::Path,
+    port: u16,
 ) -> Response<std::io::Cursor<Vec<u8>>> {
     if !orch::validate_agent_id(agent_id) {
-        return json_response("{\"error\":\"invalid agent id\"}").with_status_code(400);
+        return json_response("{\"error\":\"invalid agent id\"}", port).with_status_code(400);
     }
     let slug = crate::shared::paths::project_slug();
     try_pool(pool, |p| {
@@ -389,12 +400,12 @@ fn handle_agent_status(
             .unwrap_or_else(|| "{}".into())
         })
     })
-    .map(|body| json_response(&body))
+    .map(|body| json_response(&body, port))
     .unwrap_or_else(|| {
         let body: serde_json::Value = orch::read_agent_status(harness_dir, agent_id)
             .map(|s| serde_json::to_value(&s).unwrap_or_default())
             .unwrap_or_default();
-        json_response(&body.to_string())
+        json_response(&body.to_string(), port)
     })
 }
 
@@ -402,9 +413,10 @@ fn handle_agent_dismiss(
     pool: Option<&sqlx::AnyPool>,
     agent_id: &str,
     harness_dir: &std::path::Path,
+    port: u16,
 ) -> Response<std::io::Cursor<Vec<u8>>> {
     if !orch::validate_agent_id(agent_id) {
-        return json_response("{\"error\":\"invalid agent id\"}").with_status_code(400);
+        return json_response("{\"error\":\"invalid agent id\"}", port).with_status_code(400);
     }
     // Pool-first: try DB dismiss, fall back to file-based if DB unavailable
     let slug = crate::shared::paths::project_slug();
@@ -415,16 +427,20 @@ fn handle_agent_dismiss(
     });
     let ok = db_ok.unwrap_or_else(|| orch::dismiss_agent(harness_dir, agent_id));
     let body = serde_json::json!({"ok": ok, "dismissed": agent_id});
-    json_response(&body.to_string())
+    json_response(&body.to_string(), port)
 }
 
 // ── Response helpers ──────────────────────────────────
 
-fn json_response(body: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+fn json_response(body: &str, port: u16) -> Response<std::io::Cursor<Vec<u8>>> {
     Response::from_string(body)
         .with_header(Header::from_bytes(b"Content-Type", b"application/json").unwrap())
         .with_header(
-            Header::from_bytes(b"Access-Control-Allow-Origin", b"http://localhost:5173").unwrap(),
+            Header::from_bytes(
+                b"Access-Control-Allow-Origin",
+                format!("http://localhost:{port}").as_bytes(),
+            )
+            .unwrap(),
         )
 }
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -289,8 +289,8 @@ fn handle_get_stats(port: u16) -> Response<std::io::Cursor<Vec<u8>>> {
 fn handle_list_nodes(url: &str, port: u16) -> Response<std::io::Cursor<Vec<u8>>> {
     let limit: usize = parse_query_param(url, "limit")
         .and_then(|v| v.parse().ok())
-        .unwrap_or(200)
-        .min(1000);
+        .unwrap_or(500)
+        .min(5000);
     // Note: uses the memory DB pool (memory.db for the knowledge graph),
     // not the harness operational DB passed as `db` to other handlers.
     let nodes = crate::store::runtime::block_on(async {

--- a/src/store/metrics.rs
+++ b/src/store/metrics.rs
@@ -261,29 +261,35 @@ pub async fn save_metrics_pool(pool: &AnyPool, project: &str, m: &Metrics) -> io
         .rev()
         .take(MAX_SCORE_HISTORY)
         .collect();
-    for entry in entries.into_iter().rev() {
-        sqlx::query(
-            "INSERT INTO score_history (timestamp, success_rate, avg_score, observations, dim_success, dim_quality, dim_cost, project) \
-             VALUES ($1,$2,$3,$4,$5,$6,$7,$8) \
-             ON CONFLICT(timestamp, project) DO UPDATE SET \
-                 success_rate = excluded.success_rate, \
-                 avg_score = excluded.avg_score, \
-                 observations = excluded.observations, \
-                 dim_success = excluded.dim_success, \
-                 dim_quality = excluded.dim_quality, \
-                 dim_cost = excluded.dim_cost"
-        )
-        .bind(&entry.timestamp)
-        .bind(entry.success_rate)
-        .bind(entry.avg_score)
-        .bind(crate::store::u64_to_i64(entry.observations))
-        .bind(entry.dimension_averages.tool_success)
-        .bind(entry.dimension_averages.output_quality)
-        .bind(entry.dimension_averages.execution_cost)
-        .bind(project)
-        .execute(&mut *tx)
-        .await
-        .map_err(crate::store::sqlx_err)?;
+    if !entries.is_empty() {
+        let mut qb = sqlx::QueryBuilder::<sqlx::Any>::new(
+            "INSERT INTO score_history \
+             (timestamp, success_rate, avg_score, observations, \
+              dim_success, dim_quality, dim_cost, project) ",
+        );
+        qb.push_values(entries.into_iter().rev(), |mut b, entry| {
+            b.push_bind(&entry.timestamp)
+                .push_bind(entry.success_rate)
+                .push_bind(entry.avg_score)
+                .push_bind(crate::store::u64_to_i64(entry.observations))
+                .push_bind(entry.dimension_averages.tool_success)
+                .push_bind(entry.dimension_averages.output_quality)
+                .push_bind(entry.dimension_averages.execution_cost)
+                .push_bind(project);
+        });
+        qb.push(
+            " ON CONFLICT(timestamp, project) DO UPDATE SET \
+             success_rate = excluded.success_rate, \
+             avg_score = excluded.avg_score, \
+             observations = excluded.observations, \
+             dim_success = excluded.dim_success, \
+             dim_quality = excluded.dim_quality, \
+             dim_cost = excluded.dim_cost",
+        );
+        qb.build()
+            .execute(&mut *tx)
+            .await
+            .map_err(crate::store::sqlx_err)?;
     }
     sqlx::query(
         "DELETE FROM score_history WHERE project = $1 AND id NOT IN (SELECT id FROM score_history WHERE project = $1 ORDER BY id DESC LIMIT $2)"

--- a/src/store/migrate.rs
+++ b/src/store/migrate.rs
@@ -537,7 +537,7 @@ async fn import_evolution(
                         "[]".into()
                     });
                 let result = sqlx::query(
-                    "INSERT INTO evolution_records \
+                    "INSERT OR IGNORE INTO evolution_records \
                      (timestamp, observations, success_rate, avg_score, error_patterns, \
                       failure_patterns, skills_seeded, skills_rolled_back, total_evolved, \
                       analysis_summary, project) \

--- a/src/store/migrate.rs
+++ b/src/store/migrate.rs
@@ -291,6 +291,12 @@ pub(crate) async fn do_migrate_async(
     Ok(stats)
 }
 
+/// Import observation records from a JSONL file.
+///
+/// Records are processed within a per-file transaction. If a parse error
+/// occurs on a specific line, that line is skipped and processing continues.
+/// Valid records within the same file are committed. Failed records cannot
+/// be re-imported without resetting the entire migration.
 async fn import_observations(
     conn: &mut sqlx::SqliteConnection,
     harness_dir: &std::path::Path,
@@ -570,6 +576,9 @@ async fn import_evolution(
             }
         }
     }
+    // SAFETY: If this final commit fails, the `?` propagates the error up through
+    // do_migrate_async Phase 2, which skips Phase 3 (clearing the `in_progress` marker).
+    // The marker remains, allowing `--reset` retry without duplicate inserts.
     commit(conn).await?;
     Ok(())
 }
@@ -788,9 +797,24 @@ pub async fn merge_attached_db_async(
     }
 
     // orch_agents, orch_agent_events, orch_agent_inbox: FK-linked to orch_runs
-    for table in ["orch_agents", "orch_agent_events", "orch_agent_inbox"] {
+    let orch_tables: &[(&str, &str)] = &[
+        (
+            "orch_agents",
+            "id, run_id, role, task, satisfies_json, status, phase, progress, \
+             last_heartbeat, started_at, completed_at",
+        ),
+        (
+            "orch_agent_events",
+            "id, agent_id, timestamp, event_type, data_json",
+        ),
+        (
+            "orch_agent_inbox",
+            "id, agent_id, from_agent, timestamp, message",
+        ),
+    ];
+    for (table, cols) in orch_tables {
         let _ = sqlx::query(&format!(
-            "INSERT OR IGNORE INTO main.{table} SELECT * FROM {attach_name}.{table}"
+            "INSERT OR IGNORE INTO main.{table} ({cols}) SELECT {cols} FROM {attach_name}.{table}"
         ))
         .execute(&mut *conn)
         .await;

--- a/src/store/pool.rs
+++ b/src/store/pool.rs
@@ -171,7 +171,12 @@ async fn build_sqlite_pool(url: &str, max_connections: u32) -> io::Result<AnyPoo
         #[cfg(unix)]
         {
             if path.exists() {
-                let _ = fs::set_permissions(&path, PermissionsExt::from_mode(0o600));
+                if let Err(e) = fs::set_permissions(&path, PermissionsExt::from_mode(0o600)) {
+                    eprintln!(
+                        "warning: failed to set permissions on {}: {e}",
+                        path.display()
+                    );
+                }
             }
         }
     }
@@ -187,7 +192,12 @@ async fn build_sqlite_pool(url: &str, max_connections: u32) -> io::Result<AnyPoo
     {
         if db_path != ":memory:" && !db_path.is_empty() {
             let path = PathBuf::from(db_path);
-            let _ = fs::set_permissions(&path, PermissionsExt::from_mode(0o600));
+            if let Err(e) = fs::set_permissions(&path, PermissionsExt::from_mode(0o600)) {
+                eprintln!(
+                    "warning: failed to set permissions on {}: {e}",
+                    path.display()
+                );
+            }
         }
     }
 

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -111,6 +111,7 @@ pub(crate) const DDL_SQLITE: &str = "
     );
     CREATE INDEX IF NOT EXISTS idx_evo_ts ON evolution_records(timestamp DESC);
     CREATE INDEX IF NOT EXISTS idx_evo_project ON evolution_records(project);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_evo_ts_project ON evolution_records(timestamp, project);
 
     CREATE TABLE IF NOT EXISTS metrics_state (
         key     TEXT NOT NULL,
@@ -310,6 +311,7 @@ const DDL_POSTGRES: &str = "
     );
     CREATE INDEX IF NOT EXISTS idx_evo_ts ON evolution_records(timestamp DESC);
     CREATE INDEX IF NOT EXISTS idx_evo_project ON evolution_records(project);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_evo_ts_project ON evolution_records(timestamp, project);
 
     CREATE TABLE IF NOT EXISTS metrics_state (
         key     TEXT NOT NULL,

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -471,6 +471,16 @@ pub(crate) async fn init_schema_pool(pool: &AnyPool) -> io::Result<()> {
         .map_err(super::sqlx_err)?;
     }
 
+    // Pre-migration: remove duplicate evolution_records before DDL applies the
+    // UNIQUE INDEX on (timestamp, project). Keeps the earliest row per pair.
+    // Silently ignored on fresh DBs where the table does not yet exist.
+    let _ = sqlx::query(
+        "DELETE FROM evolution_records WHERE id NOT IN \
+         (SELECT MIN(id) FROM evolution_records GROUP BY timestamp, project)",
+    )
+    .execute(pool)
+    .await;
+
     // DDL — select by backend
     let ddl = match db_type {
         DbType::Sqlite => DDL_SQLITE,

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -79,6 +79,7 @@ pub(crate) const DDL_SQLITE: &str = "
     CREATE INDEX IF NOT EXISTS idx_obs_tool       ON observations(tool_category);
     CREATE INDEX IF NOT EXISTS idx_obs_sess_ts    ON observations(session_id, timestamp);
     CREATE INDEX IF NOT EXISTS idx_obs_project    ON observations(project);
+    CREATE INDEX IF NOT EXISTS idx_obs_session_id_desc ON observations(session_id, id DESC);
 
     CREATE TABLE IF NOT EXISTS sessions (
         id                INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -277,6 +278,7 @@ const DDL_POSTGRES: &str = "
     CREATE INDEX IF NOT EXISTS idx_obs_tool       ON observations(tool_category);
     CREATE INDEX IF NOT EXISTS idx_obs_sess_ts    ON observations(session_id, timestamp);
     CREATE INDEX IF NOT EXISTS idx_obs_project    ON observations(project);
+    CREATE INDEX IF NOT EXISTS idx_obs_session_id_desc ON observations(session_id, id DESC);
 
     CREATE TABLE IF NOT EXISTS sessions (
         id                BIGSERIAL PRIMARY KEY,
@@ -378,7 +380,7 @@ const DDL_POSTGRES: &str = "
     CREATE TABLE IF NOT EXISTS orch_control (
         id         BIGSERIAL PRIMARY KEY,
         project    TEXT NOT NULL DEFAULT '',
-        action     TEXT,
+        action     TEXT NOT NULL,
         target     TEXT,
         message    TEXT,
         generation INTEGER NOT NULL DEFAULT 0

--- a/tests/mem_test.rs
+++ b/tests/mem_test.rs
@@ -984,3 +984,71 @@ fn epic_harness_days_to_ymd(mut days: u64) -> (u64, u64, u64) {
     }
     (year, month, days + 1)
 }
+
+// ── M5: UPSERT preserves higher access_count ──────────
+
+#[test]
+fn test_upsert_preserves_higher_access_count() {
+    use epic_harness::mem::store::{
+        Node, NodeFrontmatter, new_uuid, now_iso, read_node, write_node,
+    };
+    let _guard = ENV_LOCK.lock().unwrap();
+    let root = temp_root();
+    set_root(&root);
+
+    let id = new_uuid();
+    let ts = now_iso();
+
+    // First write: access_count = 10
+    let node_v1 = Node {
+        frontmatter: NodeFrontmatter {
+            id: id.clone(),
+            node_type: "pattern".into(),
+            title: "access count test".into(),
+            tags: vec![],
+            projects: vec![],
+            agents: vec![],
+            created: ts.clone(),
+            updated: ts.clone(),
+            importance: 0.5,
+            access_count: 10,
+            accessed_at: ts.clone(),
+        },
+        body: "v1".into(),
+    };
+    write_node(&node_v1).unwrap();
+
+    // Second write: access_count = 3 (lower) — should preserve 10
+    let node_v2 = Node {
+        frontmatter: NodeFrontmatter {
+            id: id.clone(),
+            access_count: 3,
+            ..node_v1.frontmatter.clone()
+        },
+        body: "v2".into(),
+    };
+    write_node(&node_v2).unwrap();
+
+    let read_back = read_node(&id).unwrap();
+    assert_eq!(
+        read_back.frontmatter.access_count, 10,
+        "UPSERT should preserve higher access_count (10), not overwrite with lower (3)"
+    );
+
+    // Third write: access_count = 20 (higher) — should update to 20
+    let node_v3 = Node {
+        frontmatter: NodeFrontmatter {
+            id: id.clone(),
+            access_count: 20,
+            ..node_v1.frontmatter.clone()
+        },
+        body: "v3".into(),
+    };
+    write_node(&node_v3).unwrap();
+
+    let read_back = read_node(&id).unwrap();
+    assert_eq!(
+        read_back.frontmatter.access_count, 20,
+        "UPSERT should update to higher access_count (20)"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to #52 — addresses 5 findings from the code review:

- **Issue 1 — Default limit discrepancy**: `serve.rs` `/api/nodes` default was 200 (cap 1000), but `axum_server.rs` uses 500 (cap 5000). Aligned to 500/5000 so both servers behave consistently.
- **Issue 2 — M8 semantic clarity**: The graph boost UNION ALL query was refactored from intra-cluster to adjacent-edge semantics. Added a comment explaining this is intentional: collecting all edges adjacent to top-result nodes surfaces non-result nodes that are strongly connected and deserve a score boost.
- **Issue 3 — UUID validation in axum server**: Already present at `axum_server.rs:431`. No change required.
- **Issue 4 — UNIQUE INDEX migration risk**: `CREATE UNIQUE INDEX IF NOT EXISTS idx_evo_ts_project` in DDL would fail on existing v4 databases with duplicate `(timestamp, project)` rows in `evolution_records`. Added an idempotent `DELETE ... WHERE id NOT IN (SELECT MIN(id) ...)` dedup step in `init_schema_pool` that runs before DDL execution. Silently ignored on fresh DBs where the table does not yet exist.
- **Issue 5 — PR #52 title says "22 findings" but describes 25**: Fixed in this PR's title and scope description.

## Test plan
- [x] 577/577 tests pass (555 unit + 22 integration)
- [x] Clippy clean (`-D warnings`)