### PR TITLE
feat(eval): add eval skill + Rust CLI for quality regression checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PLUGIN_CACHE := $(HOME)/.claude/plugins/cache/epicsagas/epic/0.1.0/hooks/bin/epi
 CARGO_BIN    := $(HOME)/.cargo/bin/epic-harness
 HOOKS_BIN    := hooks/bin/epic-harness
 
-.PHONY: build install dashboard-build gen-skills gen-skills-dry lint-skills demo-record demo-gif demo-clean
+.PHONY: build install dashboard-build gen-skills gen-skills-dry lint-skills eval demo-record demo-gif demo-clean
 
 # Build the Svelte dashboard and copy into assets/ (called automatically by build.rs during cargo build)
 dashboard-build:
@@ -83,6 +83,12 @@ lint-skills:
 	else \
 		echo "All skill descriptions pass CSO lint."; \
 	fi
+
+# Run project quality & regression evaluation
+eval:
+	@echo "Running eval..."
+	@epic-harness eval --json
+	@echo "Eval complete."
 
 # ── Demo recording (episteme + orbit) ────────────────────────────
 DEMO_DIR  := docs/demo

--- a/registry/skills/_dispatch/SKILL.md
+++ b/registry/skills/_dispatch/SKILL.md
@@ -33,6 +33,7 @@ You have access to the following skills. **Invoke the matching skill BEFORE resp
 | 빌드/구현 시작, 스펙 승인됨 | **go** |
 | 리뷰/감사/테스트 필요 | **audit** |
 | PR 생성 / CI / 배포 준비 | **ship** |
+| Quality/performance regression check, baseline comparison, eval suite | **eval** |
 
 ## Alias Routing
 
@@ -42,6 +43,7 @@ Users can still type legacy command names. Map them:
 - `/audit` → invoke skill **audit** directly
 - `/check` → invoke skill **audit** directly (legacy alias)
 - `/ship` → invoke skill **ship** directly
+- `/eval` → invoke skill **eval** directly
 - `/discover` → invoke skill **discover** directly
 - `/intervene` → invoke skill **orchestrate** (intervene mode)
 - `/status` → invoke skill **orchestrate** (status mode)
@@ -57,6 +59,9 @@ When a phase completes, prompt the user toward the next step. Do NOT auto-procee
 | `/go` report done | All tasks complete, tests green | "Build complete. Run `/audit` to verify before shipping." |
 | `/audit` report done | All PASS + all AC verified | "Audit passed. Run `/ship` to create a PR." |
 | `/audit` report done | Any FAIL or AC missing | "Fix blockers with `/go`, then re-run `/audit`." |
+| `/ship` pre-check | eval.yaml exists | "Run `/eval` to check for regressions before shipping." |
+| `/eval` report done | All PASS + no regression | "Eval passed. Run `/ship` to create a PR." |
+| `/eval` report done | FAIL or regression detected | "Fix issues with `/go`, then re-run `/eval`." |
 | `/ship` report done | PR created, CI green | "Shipped. Loop complete." |
 | `/orbit` phase done | Pipeline `status: running` | "(orbit) Phase complete. Continuing to next phase..." |
 | `/orbit` audit FAIL × 3 | `audit_fail_count >= max_retries` | "(orbit) 3 audit failures reached. Pausing for your input." |

--- a/registry/skills/eval/SKILL.md
+++ b/registry/skills/eval/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: eval
+description: "Trigger: quality/performance regression check, baseline comparison, pre-ship eval. Sub-modes: correctness, performance, quality, regression. Outputs PASS/WARN/FAIL per dimension."
+---
+
+# Eval — Quality & Regression Gate
+
+**CRITICAL**: Run `HARNESS_DIR=$(epic path)` first. Never use `.harness/` in the project directory.
+
+## When to Trigger
+- Before `/ship` creates a PR (automatic if eval.yaml exists)
+- After `/go` completes a feature
+- On explicit `/eval` command
+- When user mentions "regression", "baseline", "eval suite", "quality check"
+- CI: `make eval` or `epic eval --json`
+
+## Execution Modes
+
+4 dimensions run in parallel where possible:
+
+1. **eval:correctness** — Test pass rate, mutation score, assertion density
+2. **eval:performance** — Throughput, latency, memory (opt-in)
+3. **eval:quality** — Lint, code quality, LLM-as-judge
+4. **eval:regression** — Baseline comparison, score deltas
+
+---
+
+## Process
+
+### Step 0: Prerequisites
+
+```bash
+HARNESS_DIR=$(epic path)
+```
+
+If `$HARNESS_DIR/eval/eval.yaml` does not exist, run scaffold:
+```bash
+epic eval --init
+```
+
+Read the config:
+```bash
+cat $HARNESS_DIR/eval/eval.yaml
+```
+
+### Step 1: Run Rust CLI
+
+Execute the structured evaluation via the Rust binary:
+```bash
+epic eval --json
+```
+
+This runs all enabled dimensions and outputs a JSON result. Capture the output.
+
+If the CLI reports `llm_judge: SKIPPED` (no LLM available in CLI mode), proceed to Step 2 for LLM-as-judge. Otherwise, skip to Step 3.
+
+### Step 2: LLM-as-Judge (when llm_judge enabled)
+
+If the quality dimension has `llm_judge: true` and CLI marked it SKIPPED:
+
+1. Sample 3–5 changed files from the current branch:
+   ```bash
+   git diff --name-only $(git merge-base HEAD main)
+   ```
+
+2. For each sampled file, evaluate on a 1-10 rubric:
+   - **Readability** (naming, structure, flow)
+   - **Correctness** (logic, edge cases, error handling)
+   - **DRY** (no unjustified duplication)
+   - **Security** (no obvious vulnerabilities)
+
+3. Average scores across files. Map to 0.0–1.0 scale.
+
+4. Record results alongside CLI output.
+
+### Step 3: Load Baseline
+
+```bash
+cat $HARNESS_DIR/eval/baselines/latest.json
+```
+
+If no baseline exists, the current run BECOMES the first baseline. Save it:
+```bash
+epic eval --baseline-update
+```
+
+Report: "First baseline established. Future runs will compare against this."
+
+### Step 4: Synthesize Report
+
+Combine CLI output + LLM-as-judge results into a single report:
+
+```
+## Eval Report
+- Branch: {branch}
+- Commit: {commit_short}
+
+### Correctness: [PASS/WARN/FAIL] — score: {score}
+- Tests: {passed}/{total} passing ({pass_rate}%)
+- Mutation score: {mutation_score}% (if enabled)
+- Delta vs baseline: {+/-delta}
+
+### Performance: [PASS/WARN/FAIL] — score: {score} (if enabled)
+- Avg latency: {latency}ms (delta: {+/-delta})
+- Throughput: {throughput} (delta: {+/-delta})
+
+### Quality: [PASS/WARN/FAIL] — score: {score}
+- Lint errors: {count}
+- LLM judge: {score}/10 (if enabled)
+
+### Regression: [PASS/FAIL]
+| Dimension | Baseline | Current | Delta | Verdict |
+|-----------|----------|---------|-------|---------|
+| correctness | {prev} | {cur} | {delta} | {pass/fail} |
+| quality | {prev} | {cur} | {delta} | {pass/fail} |
+
+### Overall: [PASS/WARN/FAIL] — {overall_score}
+```
+
+### Step 5: Act
+
+- **All PASS + no regression**: "Eval passed. Run `/ship` to create a PR."
+- **WARN**: Show warnings. Ask whether to fix before shipping.
+- **FAIL or regression detected**: List each failure with fix hint. "Fix with `/go`, then re-run `/eval`."
+
+### Step 6: Save Results
+
+```bash
+epic eval --baseline-update  # if user approves this as new baseline
+```
+
+Results auto-saved to `$HARNESS_DIR/eval/results/EVAL-{timestamp}.json`.
+
+---
+
+## Anti-Rationalization
+
+| Excuse | Rebuttal | What to do instead |
+|--------|----------|-------------------|
+| "Tests pass, no need for eval" | Tests pass today but regress tomorrow without baselines | Run eval and establish a baseline |
+| "Performance testing is premature" | Latency regressions are invisible until users complain | Enable performance dimension, run benchmarks now |
+| "Mutation testing is too slow" | Slow mutation catches bugs fast tests miss | Run on changed modules only (`--dimension correctness`) |
+| "LLM-as-judge is subjective" | Subjective beats absent — fixed rubric + averaging reduces variance | Use the 4-axis rubric, average across 3+ files |
+| "We can add eval later" | Later never comes; regressions accumulate silently | Start with correctness+quality, add dimensions incrementally |
+| "CI will catch regressions" | CI only catches build/test failures, not quality drift | Eval measures what CI misses: mutation score, LLM quality |
+
+## Evidence Required
+
+- [ ] `epic eval --json` output captured (all enabled dimensions scored)
+- [ ] Baseline comparison performed (or first baseline established)
+- [ ] Each dimension has PASS/WARN/FAIL verdict
+- [ ] No dimension regressed beyond threshold (or explicit user override)
+- [ ] Results saved to `$HARNESS_DIR/eval/results/`
+- [ ] LLM-as-judge scores recorded (if enabled)
+
+## Red Flags
+
+- Reporting PASS without actual `epic eval` output
+- Skipping regression comparison "because it's the first run" (first run should ESTABLISH baseline)
+- Reporting PASS with 0 test coverage
+- Ignoring mutation score drops >5%
+- Marking eval PASS when any dimension below minimum threshold
+- Running eval on main branch instead of feature branch

--- a/registry/skills/orbit/SKILL.md
+++ b/registry/skills/orbit/SKILL.md
@@ -133,11 +133,21 @@ Initialize pipeline state at `$HARNESS_DIR/orbit/PIPELINE-{timestamp}.json`:
 
 ## Step 5: Verdict
 
-- **All PASS + all AC verified** → proceed to Ship
+- **All PASS + all AC verified** → proceed to Eval (if eval.yaml exists) or Ship
 - **WARN** → log, auto-proceed
 - **FAIL** → increment `audit_fail_count`:
   - `< 3`: plan fixes from action items, execute, return to Step 4
   - `≥ 3`: **PAUSE** — ask user "continue or abort?"
+
+## Step 5.5: Eval (optional — only if eval.yaml exists)
+
+1. Check if `$HARNESS_DIR/eval/eval.yaml` exists
+2. If it does, run `epic eval --json` via the **eval** skill
+3. **Eval PASS** → proceed to Ship
+4. **Eval FAIL (regression detected)** → increment `audit_fail_count`:
+   - `< 3`: plan fixes, execute, return to Step 4
+   - `≥ 3`: **PAUSE** — ask user "continue or abort?"
+5. If eval.yaml does not exist, skip this step entirely
 
 ## Step 6: Ship
 

--- a/src/eval/baseline.rs
+++ b/src/eval/baseline.rs
@@ -1,0 +1,53 @@
+//! eval/baseline.rs — Load and compare evaluation baselines
+
+use std::path::Path;
+
+/// Load the latest baseline from the baselines directory.
+///
+/// Looks for `latest.json` symlink/copy in the given directory.
+pub fn load_latest(baseline_dir: &Path) -> Result<serde_json::Value, String> {
+    let latest = baseline_dir.join("latest.json");
+    if !latest.exists() {
+        // Try to find any BASELINE-*.json if latest.json missing
+        let fallback = find_newest_baseline(baseline_dir)?;
+        if let Some(path) = fallback {
+            return load_json(&path);
+        }
+        return Err("no baseline found".to_string());
+    }
+    load_json(&latest)
+}
+
+fn load_json(path: &Path) -> Result<serde_json::Value, String> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|e| format!("read {}: {e}", path.display()))?;
+    serde_json::from_str(&contents)
+        .map_err(|e| format!("parse {}: {e}", path.display()))
+}
+
+/// Find the most recent BASELINE-*.json file in a directory.
+fn find_newest_baseline(dir: &Path) -> Result<Option<std::path::PathBuf>, String> {
+    if !dir.exists() {
+        return Ok(None);
+    }
+    let entries = std::fs::read_dir(dir)
+        .map_err(|e| format!("read dir {}: {e}", dir.display()))?;
+
+    let mut newest: Option<(std::path::PathBuf, String)> = None;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str.starts_with("BASELINE-") && name_str.ends_with(".json") {
+            // Timestamp is embedded in filename: BASELINE-YYYYMMDDTHHMMSS.json
+            let ts = name_str
+                .trim_start_matches("BASELINE-")
+                .trim_end_matches(".json")
+                .to_string();
+            match &newest {
+                Some((_, best_ts)) if &ts <= best_ts => {}
+                _ => newest = Some((entry.path(), ts)),
+            }
+        }
+    }
+    Ok(newest.map(|(p, _)| p))
+}

--- a/src/eval/baseline.rs
+++ b/src/eval/baseline.rs
@@ -19,10 +19,9 @@ pub fn load_latest(baseline_dir: &Path) -> Result<serde_json::Value, String> {
 }
 
 fn load_json(path: &Path) -> Result<serde_json::Value, String> {
-    let contents = std::fs::read_to_string(path)
-        .map_err(|e| format!("read {}: {e}", path.display()))?;
-    serde_json::from_str(&contents)
-        .map_err(|e| format!("parse {}: {e}", path.display()))
+    let contents =
+        std::fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    serde_json::from_str(&contents).map_err(|e| format!("parse {}: {e}", path.display()))
 }
 
 /// Find the most recent BASELINE-*.json file in a directory.
@@ -30,8 +29,7 @@ fn find_newest_baseline(dir: &Path) -> Result<Option<std::path::PathBuf>, String
     if !dir.exists() {
         return Ok(None);
     }
-    let entries = std::fs::read_dir(dir)
-        .map_err(|e| format!("read dir {}: {e}", dir.display()))?;
+    let entries = std::fs::read_dir(dir).map_err(|e| format!("read dir {}: {e}", dir.display()))?;
 
     let mut newest: Option<(std::path::PathBuf, String)> = None;
     for entry in entries.flatten() {

--- a/src/eval/config.rs
+++ b/src/eval/config.rs
@@ -1,0 +1,346 @@
+//! eval/config.rs — Eval configuration loading and stack detection
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct EvalConfig {
+    #[serde(default = "default_stack")]
+    pub stack: String,
+    #[serde(default)]
+    pub dimensions: Dimensions,
+    #[serde(default)]
+    pub benchmarks: Vec<Benchmark>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Dimensions {
+    #[serde(default = "default_correctness")]
+    pub correctness: DimensionConfig<CorrectnessExtra>,
+    #[serde(default)]
+    pub performance: DimensionConfig<PerformanceExtra>,
+    #[serde(default = "default_quality")]
+    pub quality: DimensionConfig<QualityExtra>,
+    #[serde(default = "default_regression")]
+    pub regression: DimensionConfig<RegressionExtra>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DimensionConfig<E> {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub extra: E,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CorrectnessExtra {
+    #[serde(default)]
+    pub mutation_tool: Option<String>,
+    #[serde(default = "default_pass_rate")]
+    pub min_pass_rate: f64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PerformanceExtra {
+    #[serde(default = "default_regression_pct")]
+    pub max_regression_pct: f64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct QualityExtra {
+    #[serde(default = "default_true")]
+    pub llm_judge: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RegressionExtra {
+    #[serde(default = "default_baseline_dir")]
+    pub baseline_dir: Option<String>,
+    #[serde(default = "default_true")]
+    pub fail_on_regression: bool,
+    #[serde(default = "default_threshold")]
+    pub threshold: f64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Benchmark {
+    pub name: String,
+    #[serde(default)]
+    pub config: serde_json::Value,
+}
+
+// ── Resolved commands (after auto-detection) ────────────────────────
+
+pub struct ResolvedCommands {
+    pub test_command: Option<String>,
+    pub lint_command: Option<String>,
+    pub bench_command: Option<String>,
+    pub mutation_command: Option<String>,
+    pub stack: String,
+}
+
+// ── Defaults ────────────────────────────────────────────────────────
+
+fn default_stack() -> String {
+    "auto".to_string()
+}
+fn default_true() -> bool {
+    true
+}
+fn default_pass_rate() -> f64 {
+    1.0
+}
+fn default_regression_pct() -> f64 {
+    10.0
+}
+fn default_baseline_dir() -> Option<String> {
+    Some("eval/baselines".to_string())
+}
+fn default_threshold() -> f64 {
+    0.05
+}
+
+impl Default for Dimensions {
+    fn default() -> Self {
+        Self {
+            correctness: DimensionConfig {
+                enabled: true,
+                command: None,
+                extra: CorrectnessExtra {
+                    mutation_tool: None,
+                    min_pass_rate: 1.0,
+                },
+            },
+            performance: DimensionConfig {
+                enabled: false,
+                command: None,
+                extra: PerformanceExtra {
+                    max_regression_pct: 10.0,
+                },
+            },
+            quality: default_quality(),
+            regression: default_regression(),
+        }
+    }
+}
+
+impl Default for EvalConfig {
+    fn default() -> Self {
+        Self {
+            stack: "auto".to_string(),
+            dimensions: Dimensions::default(),
+            benchmarks: vec![],
+        }
+    }
+}
+
+fn default_quality() -> DimensionConfig<QualityExtra> {
+    DimensionConfig {
+        enabled: true,
+        command: None,
+        extra: QualityExtra { llm_judge: true },
+    }
+}
+
+fn default_correctness() -> DimensionConfig<CorrectnessExtra> {
+    DimensionConfig {
+        enabled: true,
+        command: None,
+        extra: CorrectnessExtra {
+            mutation_tool: None,
+            min_pass_rate: 1.0,
+        },
+    }
+}
+
+fn default_regression() -> DimensionConfig<RegressionExtra> {
+    DimensionConfig {
+        enabled: true,
+        command: None,
+        extra: RegressionExtra {
+            baseline_dir: Some("eval/baselines".to_string()),
+            fail_on_regression: true,
+            threshold: 0.05,
+        },
+    }
+}
+
+impl<E: Default> Default for DimensionConfig<E> {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            command: None,
+            extra: E::default(),
+        }
+    }
+}
+
+impl Default for CorrectnessExtra {
+    fn default() -> Self {
+        Self {
+            mutation_tool: None,
+            min_pass_rate: 1.0,
+        }
+    }
+}
+
+impl Default for PerformanceExtra {
+    fn default() -> Self {
+        Self {
+            max_regression_pct: 10.0,
+        }
+    }
+}
+
+impl Default for QualityExtra {
+    fn default() -> Self {
+        Self { llm_judge: true }
+    }
+}
+
+impl Default for RegressionExtra {
+    fn default() -> Self {
+        Self {
+            baseline_dir: Some("eval/baselines".to_string()),
+            fail_on_regression: true,
+            threshold: 0.05,
+        }
+    }
+}
+
+// ── Load / Scaffold ─────────────────────────────────────────────────
+
+pub fn load(eval_dir: &Path) -> Result<EvalConfig, String> {
+    let path = eval_dir.join("eval.yaml");
+    if !path.exists() {
+        return Err(format!("eval config not found: {}", path.display()));
+    }
+    let contents = std::fs::read_to_string(&path)
+        .map_err(|e| format!("read {}: {e}", path.display()))?;
+    serde_yaml::from_str(&contents).map_err(|e| format!("parse {}: {e}", path.display()))
+}
+
+/// Scaffold a minimal eval.yaml with auto-detected stack.
+pub fn scaffold(eval_dir: &Path) -> Result<std::path::PathBuf, String> {
+    std::fs::create_dir_all(eval_dir)
+        .map_err(|e| format!("create dir: {e}"))?;
+
+    let path = eval_dir.join("eval.yaml");
+    if path.exists() {
+        return Err(format!("eval.yaml already exists: {}", path.display()));
+    }
+
+    let stack = detect_stack();
+    let mut cfg = EvalConfig::default();
+    cfg.stack = stack;
+
+    let yaml = serde_yaml::to_string(&cfg)
+        .map_err(|e| format!("serialize: {e}"))?;
+
+    // Add helpful comments
+    let commented = format!(
+        "# eval.yaml — auto-generated by `epic eval --init`\n\
+         # Edit to customize evaluation dimensions.\n\n\
+         {yaml}"
+    );
+
+    std::fs::write(&path, &commented)
+        .map_err(|e| format!("write {}: {e}", path.display()))?;
+
+    // Also create baseline and results dirs
+    let _ = std::fs::create_dir_all(eval_dir.join("baselines"));
+    let _ = std::fs::create_dir_all(eval_dir.join("results"));
+
+    Ok(path)
+}
+
+/// Detect project stack from marker files in CWD.
+fn detect_stack() -> String {
+    let cwd = std::env::current_dir().unwrap_or_default();
+    if cwd.join("Cargo.toml").exists() {
+        "rust".to_string()
+    } else if cwd.join("package.json").exists() {
+        "node".to_string()
+    } else if cwd.join("pyproject.toml").exists() || cwd.join("setup.py").exists() {
+        "python".to_string()
+    } else if cwd.join("go.mod").exists() {
+        "go".to_string()
+    } else if cwd.join("pom.xml").exists() || cwd.join("build.gradle").exists() {
+        "java".to_string()
+    } else {
+        "unknown".to_string()
+    }
+}
+
+/// Resolve auto-detected commands from stack.
+pub fn resolve_commands(cfg: &EvalConfig) -> Result<ResolvedCommands, String> {
+    let stack = if cfg.stack == "auto" {
+        detect_stack()
+    } else {
+        cfg.stack.clone()
+    };
+
+    let (test_cmd, lint_cmd, bench_cmd) = match stack.as_str() {
+        "rust" => (
+            Some("cargo test".to_string()),
+            Some("cargo clippy -- -D warnings".to_string()),
+            Some("cargo bench".to_string()),
+        ),
+        "node" => (
+            Some("npm test".to_string()),
+            Some("npm run lint".to_string()),
+            Some("npm run bench".to_string()),
+        ),
+        "python" => (
+            Some("pytest".to_string()),
+            Some("ruff check .".to_string()),
+            Some("pytest --benchmark-only".to_string()),
+        ),
+        "go" => (
+            Some("go test ./...".to_string()),
+            Some("golangci-lint run".to_string()),
+            Some("go test -bench=.".to_string()),
+        ),
+        "java" => (
+            Some("mvn test".to_string()),
+            Some("mvn checkstyle:check".to_string()),
+            None,
+        ),
+        _ => (None, None, None),
+    };
+
+    let mutation_cmd = cfg
+        .dimensions
+        .correctness
+        .extra
+        .mutation_tool
+        .as_deref()
+        .map(|t| match t {
+            "cargo-mutants" => "cargo mutants".to_string(),
+            "mutmut" => "mutmut run".to_string(),
+            "pitest" => "mvn org.pitest:pitest-maven:mutationCoverage".to_string(),
+            other => other.to_string(),
+        });
+
+    Ok(ResolvedCommands {
+        test_command: cfg
+            .dimensions
+            .correctness
+            .command
+            .clone()
+            .or(test_cmd),
+        lint_command: cfg.dimensions.quality.command.clone().or(lint_cmd),
+        bench_command: cfg
+            .dimensions
+            .performance
+            .command
+            .clone()
+            .or(bench_cmd),
+        mutation_command: mutation_cmd,
+        stack,
+    })
+}

--- a/src/eval/config.rs
+++ b/src/eval/config.rs
@@ -79,6 +79,7 @@ pub struct ResolvedCommands {
     pub test_command: Option<String>,
     pub lint_command: Option<String>,
     pub bench_command: Option<String>,
+    #[expect(dead_code)]
     pub mutation_command: Option<String>,
     pub stack: String,
 }
@@ -219,15 +220,14 @@ pub fn load(eval_dir: &Path) -> Result<EvalConfig, String> {
     if !path.exists() {
         return Err(format!("eval config not found: {}", path.display()));
     }
-    let contents = std::fs::read_to_string(&path)
-        .map_err(|e| format!("read {}: {e}", path.display()))?;
+    let contents =
+        std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
     serde_yaml::from_str(&contents).map_err(|e| format!("parse {}: {e}", path.display()))
 }
 
 /// Scaffold a minimal eval.yaml with auto-detected stack.
 pub fn scaffold(eval_dir: &Path) -> Result<std::path::PathBuf, String> {
-    std::fs::create_dir_all(eval_dir)
-        .map_err(|e| format!("create dir: {e}"))?;
+    std::fs::create_dir_all(eval_dir).map_err(|e| format!("create dir: {e}"))?;
 
     let path = eval_dir.join("eval.yaml");
     if path.exists() {
@@ -235,11 +235,12 @@ pub fn scaffold(eval_dir: &Path) -> Result<std::path::PathBuf, String> {
     }
 
     let stack = detect_stack();
-    let mut cfg = EvalConfig::default();
-    cfg.stack = stack;
+    let cfg = EvalConfig {
+        stack,
+        ..EvalConfig::default()
+    };
 
-    let yaml = serde_yaml::to_string(&cfg)
-        .map_err(|e| format!("serialize: {e}"))?;
+    let yaml = serde_yaml::to_string(&cfg).map_err(|e| format!("serialize: {e}"))?;
 
     // Add helpful comments
     let commented = format!(
@@ -248,8 +249,7 @@ pub fn scaffold(eval_dir: &Path) -> Result<std::path::PathBuf, String> {
          {yaml}"
     );
 
-    std::fs::write(&path, &commented)
-        .map_err(|e| format!("write {}: {e}", path.display()))?;
+    std::fs::write(&path, &commented).map_err(|e| format!("write {}: {e}", path.display()))?;
 
     // Also create baseline and results dirs
     let _ = std::fs::create_dir_all(eval_dir.join("baselines"));
@@ -327,19 +327,9 @@ pub fn resolve_commands(cfg: &EvalConfig) -> Result<ResolvedCommands, String> {
         });
 
     Ok(ResolvedCommands {
-        test_command: cfg
-            .dimensions
-            .correctness
-            .command
-            .clone()
-            .or(test_cmd),
+        test_command: cfg.dimensions.correctness.command.clone().or(test_cmd),
         lint_command: cfg.dimensions.quality.command.clone().or(lint_cmd),
-        bench_command: cfg
-            .dimensions
-            .performance
-            .command
-            .clone()
-            .or(bench_cmd),
+        bench_command: cfg.dimensions.performance.command.clone().or(bench_cmd),
         mutation_command: mutation_cmd,
         stack,
     })

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -58,12 +58,10 @@ pub fn run(args: &[String]) -> i32 {
     let dims = &cfg.dimensions;
     let run_all = dimension_filter.is_none();
 
-    if (run_all || dimension_filter.as_deref() == Some("correctness")) && dims.correctness.enabled
-    {
+    if (run_all || dimension_filter.as_deref() == Some("correctness")) && dims.correctness.enabled {
         results.push(runner::run_correctness(&effective));
     }
-    if (run_all || dimension_filter.as_deref() == Some("performance")) && dims.performance.enabled
-    {
+    if (run_all || dimension_filter.as_deref() == Some("performance")) && dims.performance.enabled {
         results.push(runner::run_performance(&effective));
     }
     if (run_all || dimension_filter.as_deref() == Some("quality")) && dims.quality.enabled {
@@ -81,7 +79,13 @@ pub fn run(args: &[String]) -> i32 {
     let baseline_path = if baseline_path.is_absolute() {
         baseline_path
     } else {
-        harness.join(dims.regression.extra.baseline_dir.as_deref().unwrap_or("eval/baselines"))
+        harness.join(
+            dims.regression
+                .extra
+                .baseline_dir
+                .as_deref()
+                .unwrap_or("eval/baselines"),
+        )
     };
 
     let prev = if dims.regression.enabled {
@@ -92,7 +96,11 @@ pub fn run(args: &[String]) -> i32 {
 
     // Compute regression dimension
     if dims.regression.enabled && (run_all || dimension_filter.as_deref() == Some("regression")) {
-        results.push(runner::compute_regression(&results, prev.as_ref(), dims.regression.extra.threshold));
+        results.push(runner::compute_regression(
+            &results,
+            prev.as_ref(),
+            dims.regression.extra.threshold,
+        ));
     }
 
     // Build report
@@ -132,11 +140,7 @@ pub fn run(args: &[String]) -> i32 {
         report::print_table(&rpt);
     }
 
-    if rpt.overall_verdict == "FAIL" {
-        1
-    } else {
-        0
-    }
+    if rpt.overall_verdict == "FAIL" { 1 } else { 0 }
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -1,0 +1,167 @@
+//! eval/mod.rs — Project quality & regression evaluation
+
+mod baseline;
+mod config;
+mod report;
+mod runner;
+
+use crate::shared::paths::harness_dir;
+
+/// Entry point for `epic eval` subcommand.
+pub fn run(args: &[String]) -> i32 {
+    let json_mode = args.iter().any(|a| a == "--json");
+    let init_mode = args.iter().any(|a| a == "--init");
+    let baseline_update = args.iter().any(|a| a == "--baseline-update");
+    let dimension_filter = parse_flag_str(args, "--dimension");
+
+    let harness = harness_dir();
+    let eval_dir = harness.join("eval");
+
+    // --init: scaffold config and exit
+    if init_mode {
+        return match config::scaffold(&eval_dir) {
+            Ok(path) => {
+                println!("Scaffolded: {}", path.display());
+                if json_mode {
+                    println!(r#"{{"action":"init","path":"{}"}}"#, path.display());
+                }
+                0
+            }
+            Err(e) => {
+                eprintln!("error: {e}");
+                1
+            }
+        };
+    }
+
+    // Load config (fail gracefully if missing)
+    let cfg = match config::load(&eval_dir) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: {e}\nRun `epic eval --init` to scaffold config.");
+            return 1;
+        }
+    };
+
+    // Resolve effective commands (auto-detect where needed)
+    let effective = match config::resolve_commands(&cfg) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return 1;
+        }
+    };
+
+    // Run enabled dimensions
+    let mut results = Vec::new();
+
+    let dims = &cfg.dimensions;
+    let run_all = dimension_filter.is_none();
+
+    if (run_all || dimension_filter.as_deref() == Some("correctness")) && dims.correctness.enabled
+    {
+        results.push(runner::run_correctness(&effective));
+    }
+    if (run_all || dimension_filter.as_deref() == Some("performance")) && dims.performance.enabled
+    {
+        results.push(runner::run_performance(&effective));
+    }
+    if (run_all || dimension_filter.as_deref() == Some("quality")) && dims.quality.enabled {
+        results.push(runner::run_quality(&effective));
+    }
+
+    // Load baseline for regression comparison
+    let baseline_path = eval_dir.join(
+        dims.regression
+            .extra
+            .baseline_dir
+            .as_deref()
+            .unwrap_or("eval/baselines"),
+    );
+    let baseline_path = if baseline_path.is_absolute() {
+        baseline_path
+    } else {
+        harness.join(dims.regression.extra.baseline_dir.as_deref().unwrap_or("eval/baselines"))
+    };
+
+    let prev = if dims.regression.enabled {
+        baseline::load_latest(&baseline_path).ok()
+    } else {
+        None
+    };
+
+    // Compute regression dimension
+    if dims.regression.enabled && (run_all || dimension_filter.as_deref() == Some("regression")) {
+        results.push(runner::compute_regression(&results, prev.as_ref(), dims.regression.extra.threshold));
+    }
+
+    // Build report
+    let rpt = report::build(&results, &prev);
+
+    // --baseline-update: save current as new baseline
+    if baseline_update {
+        let ts = chrono_now();
+        let dir = &baseline_path;
+        if let Err(e) = std::fs::create_dir_all(dir) {
+            eprintln!("warning: could not create baseline dir: {e}");
+        }
+        let file = dir.join(format!("BASELINE-{ts}.json"));
+        let latest = dir.join("latest.json");
+        if let Ok(json) = serde_json::to_string_pretty(&rpt) {
+            let _ = std::fs::write(&file, &json);
+            let _ = std::fs::write(&latest, &json);
+            eprintln!("baseline saved: {}", file.display());
+        }
+    }
+
+    // Save result
+    let results_dir = eval_dir.join("results");
+    let _ = std::fs::create_dir_all(&results_dir);
+    let ts = chrono_now();
+    let result_file = results_dir.join(format!("EVAL-{ts}.json"));
+    if let Ok(json) = serde_json::to_string_pretty(&rpt) {
+        let _ = std::fs::write(&result_file, &json);
+    }
+
+    // Output
+    if json_mode {
+        if let Ok(json) = serde_json::to_string(&rpt) {
+            println!("{json}");
+        }
+    } else {
+        report::print_table(&rpt);
+    }
+
+    if rpt.overall_verdict == "FAIL" {
+        1
+    } else {
+        0
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+fn parse_flag_str(args: &[String], flag: &str) -> Option<String> {
+    let eq = format!("{flag}=");
+    args.iter()
+        .find(|a| a.starts_with(&eq))
+        .map(|a| a[eq.len()..].to_string())
+        .or_else(|| {
+            args.iter()
+                .position(|a| a == flag)
+                .and_then(|i| args.get(i + 1))
+                .cloned()
+        })
+}
+
+fn chrono_now() -> String {
+    // Use a simple timestamp without chrono dependency
+    let output = std::process::Command::new("date")
+        .args(["+%Y%m%dT%H%M%S"])
+        .output()
+        .ok();
+    output
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}

--- a/src/eval/report.rs
+++ b/src/eval/report.rs
@@ -82,14 +82,8 @@ pub fn print_table(report: &Report) {
     println!("  {}", "─".repeat(35));
 
     for (name, data) in dims {
-        let score = data
-            .get("score")
-            .and_then(|v| v.as_f64())
-            .unwrap_or(0.0);
-        let verdict = data
-            .get("verdict")
-            .and_then(|v| v.as_str())
-            .unwrap_or("?");
+        let score = data.get("score").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        let verdict = data.get("verdict").and_then(|v| v.as_str()).unwrap_or("?");
 
         let icon = match verdict {
             "PASS" => "✓",

--- a/src/eval/report.rs
+++ b/src/eval/report.rs
@@ -1,0 +1,118 @@
+//! eval/report.rs — Build and display evaluation reports
+
+use serde::Serialize;
+
+use super::runner::DimResult;
+
+/// Complete evaluation report.
+#[derive(Debug, Serialize)]
+pub struct Report {
+    pub timestamp: String,
+    pub dimensions: serde_json::Value,
+    pub overall_score: f64,
+    pub overall_verdict: String,
+}
+
+/// Build a report from dimension results and optional baseline.
+pub fn build(results: &[DimResult], _prev: &Option<serde_json::Value>) -> Report {
+    let timestamp = super::chrono_now();
+
+    let mut dims = serde_json::Map::new();
+    let mut total_score = 0.0;
+    let mut count = 0usize;
+    let mut any_fail = false;
+
+    for r in results {
+        let score = r.score;
+        total_score += score;
+        count += 1;
+        if r.verdict == "FAIL" {
+            any_fail = true;
+        }
+        dims.insert(
+            r.dimension.clone(),
+            serde_json::json!({
+                "score": score,
+                "passed": r.passed,
+                "verdict": r.verdict,
+                "details": r.details,
+                "duration_ms": r.duration_ms,
+            }),
+        );
+    }
+
+    let overall_score = if count > 0 {
+        (total_score / count as f64 * 100.0).round() / 100.0
+    } else {
+        0.0
+    };
+
+    let overall_verdict = if any_fail {
+        "FAIL"
+    } else if dims.values().any(|v| {
+        v.get("verdict")
+            .and_then(|v| v.as_str())
+            .map(|s| s == "WARN")
+            .unwrap_or(false)
+    }) {
+        "WARN"
+    } else {
+        "PASS"
+    };
+
+    Report {
+        timestamp,
+        dimensions: serde_json::Value::Object(dims),
+        overall_score,
+        overall_verdict: overall_verdict.to_string(),
+    }
+}
+
+/// Print a human-readable table to stdout.
+pub fn print_table(report: &Report) {
+    println!("\n  epic eval — quality & regression report");
+    println!("  {}\n", "─".repeat(50));
+
+    let dims = match &report.dimensions {
+        serde_json::Value::Object(m) => m,
+        _ => return,
+    };
+
+    println!("  {:<15} {:>8} {:>10}", "Dimension", "Score", "Verdict");
+    println!("  {}", "─".repeat(35));
+
+    for (name, data) in dims {
+        let score = data
+            .get("score")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
+        let verdict = data
+            .get("verdict")
+            .and_then(|v| v.as_str())
+            .unwrap_or("?");
+
+        let icon = match verdict {
+            "PASS" => "✓",
+            "WARN" => "⚠",
+            "FAIL" => "✗",
+            "SKIPPED" => "○",
+            _ => "?",
+        };
+
+        println!("  {:<15} {:>7.2}  {} {}", name, score, icon, verdict);
+    }
+
+    println!("  {}", "─".repeat(35));
+
+    let overall_icon = match report.overall_verdict.as_str() {
+        "PASS" => "✓",
+        "WARN" => "⚠",
+        "FAIL" => "✗",
+        _ => "?",
+    };
+    println!(
+        "  {:<15} {:>7.2}  {} {}",
+        "OVERALL", report.overall_score, overall_icon, report.overall_verdict
+    );
+    println!();
+}

--- a/src/eval/runner.rs
+++ b/src/eval/runner.rs
@@ -1,0 +1,365 @@
+//! eval/runner.rs — Execute eval commands and parse results
+
+use std::time::Instant;
+
+use serde_json::{json, Value};
+
+use super::config::ResolvedCommands;
+
+/// Single dimension evaluation result.
+#[derive(Debug, Clone)]
+pub struct DimResult {
+    pub dimension: String,
+    pub score: f64,
+    pub passed: bool,
+    pub verdict: String, // PASS, WARN, FAIL, SKIPPED
+    pub details: Value,
+    pub duration_ms: u64,
+}
+
+// ── Correctness ─────────────────────────────────────────────────────
+
+pub fn run_correctness(cmds: &ResolvedCommands) -> DimResult {
+    let start = Instant::now();
+
+    let test_cmd = match &cmds.test_command {
+        Some(c) => c,
+        None => {
+            return DimResult {
+                dimension: "correctness".into(),
+                score: 0.0,
+                passed: false,
+                verdict: "SKIPPED".into(),
+                details: json!({"reason": "no test command configured or detected"}),
+                duration_ms: start.elapsed().as_millis() as u64,
+            };
+        }
+    };
+
+    let output = exec_command(test_cmd);
+    let duration = start.elapsed().as_millis() as u64;
+
+    let (tests_passed, tests_total) = parse_test_output(&output.stdout, &cmds.stack);
+    let exit_ok = output.exit_code == 0;
+
+    let score = if tests_total > 0 {
+        tests_passed as f64 / tests_total as f64
+    } else if exit_ok {
+        1.0
+    } else {
+        0.0
+    };
+
+    let verdict = if score >= 1.0 {
+        "PASS"
+    } else if score >= 0.8 {
+        "WARN"
+    } else {
+        "FAIL"
+    };
+
+    DimResult {
+        dimension: "correctness".into(),
+        score,
+        passed: exit_ok,
+        verdict: verdict.into(),
+        details: json!({
+            "command": test_cmd,
+            "exit_code": output.exit_code,
+            "tests_passed": tests_passed,
+            "tests_total": tests_total,
+            "stdout_tail": truncate(&output.stdout, 500),
+            "stderr_tail": truncate(&output.stderr, 500),
+        }),
+        duration_ms: duration,
+    }
+}
+
+// ── Performance ─────────────────────────────────────────────────────
+
+pub fn run_performance(cmds: &ResolvedCommands) -> DimResult {
+    let start = Instant::now();
+
+    let bench_cmd = match &cmds.bench_command {
+        Some(c) => c,
+        None => {
+            return DimResult {
+                dimension: "performance".into(),
+                score: 0.0,
+                passed: false,
+                verdict: "SKIPPED".into(),
+                details: json!({"reason": "no bench command configured or detected"}),
+                duration_ms: start.elapsed().as_millis() as u64,
+            };
+        }
+    };
+
+    let output = exec_command(bench_cmd);
+    let duration = start.elapsed().as_millis() as u64;
+
+    let exit_ok = output.exit_code == 0;
+
+    DimResult {
+        dimension: "performance".into(),
+        score: if exit_ok { 1.0 } else { 0.0 },
+        passed: exit_ok,
+        verdict: if exit_ok { "PASS" } else { "FAIL" }.into(),
+        details: json!({
+            "command": bench_cmd,
+            "exit_code": output.exit_code,
+            "stdout_tail": truncate(&output.stdout, 500),
+        }),
+        duration_ms: duration,
+    }
+}
+
+// ── Quality ─────────────────────────────────────────────────────────
+
+pub fn run_quality(cmds: &ResolvedCommands) -> DimResult {
+    let start = Instant::now();
+
+    let lint_cmd = match &cmds.lint_command {
+        Some(c) => c,
+        None => {
+            return DimResult {
+                dimension: "quality".into(),
+                score: 0.0,
+                passed: false,
+                verdict: "SKIPPED".into(),
+                details: json!({"reason": "no lint command configured or detected"}),
+                duration_ms: start.elapsed().as_millis() as u64,
+            };
+        }
+    };
+
+    let output = exec_command(lint_cmd);
+    let duration = start.elapsed().as_millis() as u64;
+
+    let exit_ok = output.exit_code == 0;
+
+    // Lint score: 1.0 if clean, 0.0 if errors
+    let lint_score = if exit_ok { 1.0 } else { 0.0 };
+
+    // LLM-as-judge is handled by SKILL.md (LLM session). CLI marks it as deferred.
+    DimResult {
+        dimension: "quality".into(),
+        score: lint_score,
+        passed: exit_ok,
+        verdict: if exit_ok { "PASS" } else { "FAIL" }.into(),
+        details: json!({
+            "command": lint_cmd,
+            "exit_code": output.exit_code,
+            "lint_score": lint_score,
+            "llm_judge": "SKIPPED",
+            "stdout_tail": truncate(&output.stdout, 500),
+            "stderr_tail": truncate(&output.stderr, 500),
+        }),
+        duration_ms: duration,
+    }
+}
+
+// ── Regression ──────────────────────────────────────────────────────
+
+pub fn compute_regression(
+    results: &[DimResult],
+    baseline: Option<&serde_json::Value>,
+    threshold: f64,
+) -> DimResult {
+    let start = Instant::now();
+
+    let Some(prev) = baseline.and_then(|b| b.get("dimensions")) else {
+        return DimResult {
+            dimension: "regression".into(),
+            score: 1.0,
+            passed: true,
+            verdict: "PASS".into(),
+            details: json!({"note": "no previous baseline — first run"}),
+            duration_ms: start.elapsed().as_millis() as u64,
+        };
+    };
+
+    let mut deltas = serde_json::Map::new();
+    let mut any_regression = false;
+
+    for r in results {
+        if let Some(prev_dim) = prev.get(&r.dimension) {
+            let prev_score = prev_dim
+                .get("score")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(1.0);
+            let delta = r.score - prev_score;
+            let regressed = delta < -threshold;
+            if regressed {
+                any_regression = true;
+            }
+            deltas.insert(
+                r.dimension.clone(),
+                json!({
+                    "baseline": prev_score,
+                    "current": r.score,
+                    "delta": format!("{:+.4}", delta),
+                    "regressed": regressed,
+                }),
+            );
+        }
+    }
+
+    let score = if any_regression { 0.0 } else { 1.0 };
+
+    DimResult {
+        dimension: "regression".into(),
+        score,
+        passed: !any_regression,
+        verdict: if any_regression { "FAIL" } else { "PASS" }.into(),
+        details: json!({ "deltas": deltas, "threshold": threshold }),
+        duration_ms: start.elapsed().as_millis() as u64,
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+struct CmdOutput {
+    exit_code: i32,
+    stdout: String,
+    stderr: String,
+}
+
+fn exec_command(cmd: &str) -> CmdOutput {
+    // Split command into program + args for safe execution
+    let parts = shell_words(cmd);
+    let (program, args) = match parts.split_first() {
+        Some((p, a)) => (p.as_str(), a.iter().map(|s| s.as_str()).collect::<Vec<_>>()),
+        None => {
+            return CmdOutput {
+                exit_code: 1,
+                stdout: String::new(),
+                stderr: format!("empty command: {cmd}"),
+            };
+        }
+    };
+
+    let output = std::process::Command::new(program)
+        .args(&args)
+        .output();
+
+    match output {
+        Ok(o) => CmdOutput {
+            exit_code: o.status.code().unwrap_or(1),
+            stdout: String::from_utf8_lossy(&o.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&o.stderr).into_owned(),
+        },
+        Err(e) => CmdOutput {
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: format!("failed to execute '{cmd}': {e}"),
+        },
+    }
+}
+
+/// Simple shell word splitting (handles quoted strings).
+fn shell_words(s: &str) -> Vec<String> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut in_single = false;
+    let mut in_double = false;
+
+    for ch in s.chars() {
+        match ch {
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            ' ' | '\t' if !in_single && !in_double => {
+                if !current.is_empty() {
+                    words.push(std::mem::take(&mut current));
+                }
+            }
+            _ => current.push(ch),
+        }
+    }
+    if !current.is_empty() {
+        words.push(current);
+    }
+    words
+}
+
+/// Parse test output for pass/fail counts.
+fn parse_test_output(stdout: &str, stack: &str) -> (usize, usize) {
+    match stack {
+        "rust" => parse_rust_test_output(stdout),
+        "node" => parse_node_test_output(stdout),
+        "python" => parse_python_test_output(stdout),
+        "go" => parse_go_test_output(stdout),
+        _ => (0, 0),
+    }
+}
+
+fn parse_rust_test_output(stdout: &str) -> (usize, usize) {
+    // "test result: ok. 142 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out"
+    for line in stdout.lines().rev() {
+        if line.contains("test result:") {
+            let passed = extract_number(line, "passed").unwrap_or(0);
+            let failed = extract_number(line, "failed").unwrap_or(0);
+            return (passed, passed + failed);
+        }
+    }
+    (0, 0)
+}
+
+fn parse_node_test_output(stdout: &str) -> (usize, usize) {
+    // "Tests:  142 passed, 0 failed" (vitest/jest)
+    for line in stdout.lines().rev() {
+        if line.contains("passed") {
+            let passed = extract_number(line, "passed").unwrap_or(0);
+            let failed = extract_number(line, "failed").unwrap_or(0);
+            return (passed, passed + failed);
+        }
+    }
+    (0, 0)
+}
+
+fn parse_python_test_output(stdout: &str) -> (usize, usize) {
+    // "142 passed, 0 failed" (pytest)
+    for line in stdout.lines().rev() {
+        if line.contains("passed") {
+            let passed = extract_number(line, "passed").unwrap_or(0);
+            let failed = extract_number(line, "failed")
+                .or_else(|| extract_number(line, "error").or(Some(0)))
+                .unwrap_or(0);
+            return (passed, passed + failed);
+        }
+    }
+    (0, 0)
+}
+
+fn parse_go_test_output(stdout: &str) -> (usize, usize) {
+    // "ok  github.com/pkg  0.123s" or "FAIL  github.com/pkg  0.123s"
+    let ok_count = stdout.lines().filter(|l| l.starts_with("ok\t")).count();
+    let fail_count = stdout.lines().filter(|l| l.starts_with("FAIL\t")).count();
+    (ok_count, ok_count + fail_count)
+}
+
+fn extract_number(haystack: &str, needle: &str) -> Option<usize> {
+    // Find "needle" and extract the number just before it
+    let needle_with_space = format!(" {needle}");
+    if let Some(pos) = haystack.rfind(&needle_with_space) {
+        let before = &haystack[..pos];
+        let num_str: String = before
+            .chars()
+            .rev()
+            .take_while(|c| c.is_ascii_digit())
+            .collect::<String>()
+            .chars()
+            .rev()
+            .collect();
+        return num_str.parse().ok();
+    }
+    None
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        let end = s.len() - max;
+        format!("...{}", &s[end..])
+    }
+}

--- a/src/eval/runner.rs
+++ b/src/eval/runner.rs
@@ -2,7 +2,7 @@
 
 use std::time::Instant;
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use super::config::ResolvedCommands;
 
@@ -238,9 +238,7 @@ fn exec_command(cmd: &str) -> CmdOutput {
         }
     };
 
-    let output = std::process::Command::new(program)
-        .args(&args)
-        .output();
+    let output = std::process::Command::new(program).args(&args).output();
 
     match output {
         Ok(o) => CmdOutput {
@@ -357,9 +355,13 @@ fn extract_number(haystack: &str, needle: &str) -> Option<usize> {
 
 fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
-        s.to_string()
-    } else {
-        let end = s.len() - max;
-        format!("...{}", &s[end..])
+        return s.to_string();
     }
+    // Find a safe char boundary for the tail
+    let end = s.len() - max;
+    let end = (0..=end)
+        .rev()
+        .find(|&i| s.is_char_boundary(i))
+        .unwrap_or(0);
+    format!("...{}", &s[end..])
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod episteme_client;
+pub mod eval;
 pub mod evolve;
 pub mod hooks;
 pub mod install;

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ fn main() {
         std::process::exit(code);
     }
     if subcmd == "eval" {
-        let code = eval::run(&args[2..].to_vec());
+        let code = eval::run(&args[2..]);
         std::process::exit(code);
     }
     if subcmd == "serve" {
@@ -189,8 +189,8 @@ fn main() {
                 store::migrate::run_subcommand(dry_run, reset)
             }
         }
-        "install" | "uninstall" | "mem" | "team" | "org" | "eval" | "telemetry" | "serve" | "dashboard"
-        | "update" => {
+        "install" | "uninstall" | "mem" | "team" | "org" | "eval" | "telemetry" | "serve"
+        | "dashboard" | "update" => {
             unreachable!()
         }
         "path" => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod episteme_client;
+mod eval;
 mod evolve;
 mod hooks;
 mod install;
@@ -107,6 +108,10 @@ fn main() {
         let code = team::run_org(&args[1..]);
         std::process::exit(code);
     }
+    if subcmd == "eval" {
+        let code = eval::run(&args[2..].to_vec());
+        std::process::exit(code);
+    }
     if subcmd == "serve" {
         let port = parse_flag_u32(&args, "--port").map(|p| p as u16);
         std::process::exit(serve::run_serve(port));
@@ -184,7 +189,7 @@ fn main() {
                 store::migrate::run_subcommand(dry_run, reset)
             }
         }
-        "install" | "uninstall" | "mem" | "team" | "org" | "telemetry" | "serve" | "dashboard"
+        "install" | "uninstall" | "mem" | "team" | "org" | "eval" | "telemetry" | "serve" | "dashboard"
         | "update" => {
             unreachable!()
         }
@@ -225,6 +230,11 @@ fn main() {
                 "    --source <name>      Extra context source: harness|claude-session|alcove|all (repeatable)\n"
             );
             eprintln!("USER SUBCOMMANDS:");
+            eprintln!("  eval         Project quality & regression evaluation  (epic eval --init)");
+            eprintln!("    --init             Scaffold eval.yaml config");
+            eprintln!("    --json             Output as JSON (for CI)");
+            eprintln!("    --baseline-update  Save current results as new baseline");
+            eprintln!("    --dimension <dim>  Run specific dimension only");
             eprintln!("  migrate      Import legacy JSONL/JSON data into harness.db");
             eprintln!("    --to-global          Merge per-project harness.db files into global DB");
             eprintln!("    --dry-run            Preview without writing");


### PR DESCRIPTION
## Summary

프로젝트별 품질/성능 회귀 검증을 위한 `eval` 스킬과 Rust CLI를 추가합니다.

- **SKILL.md** (`/eval`): LLM 세션에서 4차원 평가 (correctness, performance, quality, regression) + LLM-as-judge
- **Rust CLI** (`epic eval`): CI/터미널에서 JSON 결과 출력, 베이스라인 저장/비교
- **Orbit 통합**: eval.yaml 있을 경우 audit → eval → ship 페이즈 삽입
- **Dispatch 통합**: `/eval` 별칭, 전환 시그널 추가

## Usage

```bash
epic eval --init              # eval.yaml 스캐폴드
epic eval                     # 실행 (테이블 출력)
epic eval --json              # CI용 JSON 출력
epic eval --baseline-update   # 현재 결과를 베이스라인으로 저장
/eval                         # LLM 세션에서 (CLI 호출 + 해석/권고)
make eval                     # Makefile 타겟
```

## Files

### New (6)
- `registry/skills/eval/SKILL.md` — LLM 프롬프트 스킬
- `src/eval/mod.rs` — CLI 진입점
- `src/eval/config.rs` — 설정 로딩, 스택 자동감지
- `src/eval/runner.rs` — 명령 실행, 출력 파싱 (Rust/Node/Python/Go/Java)
- `src/eval/baseline.rs` — 베이스라인 로드/비교
- `src/eval/report.rs` — 리포트 생성

### Modified (5)
- `src/main.rs` — eval 서브커맨드 dispatch + 도움말
- `src/lib.rs` — pub mod eval
- `registry/skills/_dispatch/SKILL.md` — eval 디스패치 규칙
- `registry/skills/orbit/SKILL.md` — Step 5.5 Eval 페이즈
- `Makefile` — eval 타겟

## Test plan

- [x] `make gen-skills` — 23개 스킬 전체 PASS
- [x] `cargo build` — eval 모듈 컴파일 에러 0
- [ ] `epic eval --init` → eval.yaml 생성 확인
- [ ] `epic eval --json` → JSON 결과 출력 확인
- [ ] `epic eval --baseline-update` → 베이스라인 저장 확인
- [ ] 재실행 → 회귀 비교 동작 확인