### PR TITLE
feat(evolve): add InsufficientData variant to EpochClass enum

### DIFF
--- a/src/evolve/metrics.rs
+++ b/src/evolve/metrics.rs
@@ -145,7 +145,7 @@ pub fn classify_epoch(history: &[SessionScoreEntry]) -> EpochClass {
     let start = history.len().saturating_sub(window);
     let recent = &history[start..];
     if recent.len() < 2 {
-        return EpochClass::StableSuccess; // not enough data, assume neutral
+        return EpochClass::InsufficientData;
     }
 
     let avg: f64 = recent.iter().map(|e| e.avg_score).sum::<f64>() / recent.len() as f64;
@@ -565,7 +565,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_epoch_single_entry_defaults_stable() {
+    fn classify_epoch_single_entry_defaults_insufficient_data() {
         let history = vec![SessionScoreEntry {
             timestamp: "2026-04-09".into(),
             success_rate: 0.5,
@@ -573,7 +573,13 @@ mod tests {
             observations: 10,
             dimension_averages: ScoreDimensions::default(),
         }];
-        // With <2 entries, defaults to StableSuccess
-        assert_eq!(classify_epoch(&history), EpochClass::StableSuccess);
+        // With <2 entries, returns InsufficientData
+        assert_eq!(classify_epoch(&history), EpochClass::InsufficientData);
+    }
+
+    #[test]
+    fn classify_epoch_empty_history_is_insufficient_data() {
+        let history: Vec<SessionScoreEntry> = vec![];
+        assert_eq!(classify_epoch(&history), EpochClass::InsufficientData);
     }
 }

--- a/src/evolve/skills.rs
+++ b/src/evolve/skills.rs
@@ -143,6 +143,7 @@ pub fn update_meta_field(skills: &[String], epoch: &EpochClass, score: f64) {
         EpochClass::Regressing => "regressing",
         EpochClass::PersistentFailure => "persistent_failure",
         EpochClass::StableSuccess => "stable_success",
+        EpochClass::InsufficientData => return, // skip meta update when data is insufficient
     };
     let entry = SlowUpdateEntry {
         epoch_class: epoch_str.into(),

--- a/src/shared/evolution.rs
+++ b/src/shared/evolution.rs
@@ -38,6 +38,8 @@ pub enum EpochClass {
     Regressing,
     PersistentFailure,
     StableSuccess,
+    /// Not enough score history to determine a meaningful epoch class (< 2 entries).
+    InsufficientData,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Summary

Closes #61

Adds an explicit `InsufficientData` variant to `EpochClass` for sessions with fewer than 2 score history entries. Previously `StableSuccess` was used as a neutral default, which conflated "not enough data to classify" with "genuinely stable performance".

## Changes

- **`src/shared/evolution.rs`**: Add `InsufficientData` variant to `EpochClass` enum
- **`src/evolve/metrics.rs`**: `classify_epoch()` returns `InsufficientData` instead of `StableSuccess` when `recent.len() < 2`
- **`src/evolve/skills.rs`**: `update_meta_field()` early-returns on `InsufficientData` (skip meta update when classification is meaningless)
- Tests updated: single-entry test expects `InsufficientData`, added empty history test

## Semantics

| Value | Meaning |
|-------|---------|
| `None` (Option) | Epoch never classified (reflect session not run) |
| `Some(InsufficientData)` | Classification attempted but < 2 data points |
| `Some(StableSuccess)` | Genuinely stable, high-score, low-variance epoch |