### PR TITLE
feat(ship): add tiered verification ladder T0-T3 before merge

### DIFF
--- a/registry/skills/ship/SKILL.md
+++ b/registry/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: "Ship phase. Isolated integration test in fresh worktree, PR creation, CI monitoring, auto-fix on failure."
+description: "Ship phase. Tiered verification (T0-T3) in fresh worktree, PR creation, CI monitoring, auto-fix on failure."
 ---
 
 # Ship — Ship It
@@ -18,16 +18,58 @@ ls -t $HARNESS_DIR/specs/SPEC-*.md | head -1
 
 **Gate: audit must have passed.** If no audit report exists, invoke the **audit** skill before continuing.
 
-### Step 1: Pre-ship Verification
+### Step 1: Tiered Verification Ladder
 
-**1a. Isolated Integration Test**
-Launch an agent with `isolation: "worktree"` to verify in a clean environment:
-- Run full build from scratch (`cargo build --release` / `npm run build` / etc.)
-- Run complete test suite
-- Run linter and formatter checks
-- Verify no uncommitted artifacts
+Launch an agent with `isolation: "worktree"` to verify in a clean environment.
+Each tier must pass before advancing. T1/T2 failures auto-retry up to 3 times.
 
-**Gate:** If isolated test fails → STOP. **"Fix with `/go`, then re-run `/audit` before shipping."**
+#### T0 — Build (mandatory)
+
+```bash
+cargo build --release   # or: npm run build, go build ./...
+```
+
+**Gate:** Build must succeed. No retry — build failures require code fixes.
+If T0 fails → STOP. **"Fix with `/go`, then re-run `/audit` before shipping."**
+
+#### T1 — Tests (mandatory, auto-retry ≤3)
+
+```bash
+cargo test              # or: npm test, go test ./...
+cargo clippy -- -D warnings   # or: eslint, golangci-lint
+cargo fmt --check       # or: prettier --check
+```
+
+**Gate:** All tests pass, linter clean, formatter clean.
+If T1 fails → diagnose, apply fix, retry from T0. After 3 failures → STOP and report.
+**"T1 failed 3 times. Fix with `/go`, then re-run `/ship`."**
+
+#### T2 — Audit AC Verification (mandatory, auto-retry ≤3)
+
+Load the spec and verify every Acceptance Criterion is demonstrably met:
+```bash
+ls -t $HARNESS_DIR/specs/SPEC-*.md | head -1
+```
+
+For each AC, confirm one of:
+- A test explicitly covers it (cite test name)
+- The diff directly implements it (cite file + line)
+- Manual verification was performed (describe what was checked)
+
+**Gate:** All ACs verified. Any unverified AC is a failure.
+If T2 fails → fix with `/go`, then re-run `/audit`. After 3 failures → STOP and report.
+
+#### T3 — Security Assessment (optional)
+
+Only runs when:
+- `.harness/engagement.md` exists in the project, OR
+- The diff touches auth, crypto, DB, or secrets code
+
+Uses the **secure** skill checklist. Reports CRITICAL/HIGH findings only.
+- CRITICAL findings → block ship
+- HIGH findings → warn, ask user
+
+**Gate:** No CRITICAL findings. HIGH findings require user acknowledgment.
 
 ### Step 2: Git Hygiene
 
@@ -52,6 +94,12 @@ gh pr create --title "<goal from spec>" --body "$(cat <<'EOF'
 ## Acceptance Criteria Verified
 - AC1: ✅
 - AC2: ✅
+
+## Verification Ladder
+- T0 (Build): ✅
+- T1 (Tests): ✅ (N retries)
+- T2 (AC Verified): ✅
+- T3 (Security): ✅ / N/A
 
 ## Audit Report
 <paste full Audit Report>
@@ -78,6 +126,7 @@ If CI fails, diagnose and fix automatically. Retry up to 2 times.
 ## Ship Report
 - Spec: SPEC-{timestamp} ({goal_slug})
 - PR: <URL>
+- Verification: T0 ✅ T1 ✅ (N retries) T2 ✅ T3 ✅/N/A
 - CI: [PASS/FAIL/N/A]
 - Ready to merge: [YES/NO]
 - Action needed: <if any>
@@ -91,21 +140,28 @@ If CI fails, diagnose and fix automatically. Retry up to 2 times.
 
 | Excuse | Rebuttal | What to do instead |
 |--------|----------|-------------------|
-| "CI will catch it" | CI doesn't catch everything | Run isolated test locally first |
-| "The PR description doesn't matter" | It's the permanent record of why | Include spec + audit report |
+| "CI will catch it" | CI doesn't catch everything | Run tiered verification locally first |
+| "The PR description doesn't matter" | It's the permanent record of why | Include spec + audit report + ladder results |
 | "I'll merge without CI" | CI is a safety net | Wait for CI, fix failures |
+| "T3 is overkill" | One CRITICAL vuln is a breach | Run T3 when security-scope is detected |
+| "3 retries is too many" | Flaky tests exist; retry distinguishes flaky from broken | Track retry count — 3 consecutive = real failure |
 
 ## Evidence Required
 
-- [ ] Isolated test passed in clean worktree
-- [ ] PR created with spec + audit report in body
+- [ ] T0 passed: clean build in isolated worktree
+- [ ] T1 passed: full test suite + linter + formatter
+- [ ] T2 passed: every AC verified with evidence
+- [ ] T3 passed or N/A (with justification)
+- [ ] PR created with spec + audit report + ladder results in body
 - [ ] CI status checked (PASS, FAIL with fix, or N/A)
 - [ ] All Conventional Commits applied
 
 ## Red Flags
 
 - Shipping without a PASS audit report
+- Skipping T1 because "tests are slow"
+- Marking T2 PASS without citing specific evidence per AC
 - PR description that says "various fixes" or "updates"
 - Force-pushing to main
 - Merging with failing CI
-- PR body missing the Audit Report section
+- PR body missing the Verification Ladder section


### PR DESCRIPTION
Closes #46

## Changes

Adds a 4-tier verification ladder to the `/ship` skill, replacing the flat pre-ship verification step.

### Tier Structure

| Tier | Check | Mandatory | Auto-retry |
|------|-------|-----------|------------|
| T0 | Build (release) | Yes | No — requires code fix |
| T1 | Tests + Lint + Format | Yes | ≤3 retries |
| T2 | AC Verification (spec coverage) | Yes | ≤3 retries |
| T3 | Security Assessment | Only when security-scope detected | N/A |

### Key improvements
- **Progressive gating**: each tier must pass before advancing
- **T1/T2 auto-retry**: distinguishes flaky from broken (3 consecutive failures = real)
- **T3 conditional**: only runs when `.harness/engagement.md` exists or diff touches auth/crypto/DB/secrets
- **PR body**: now includes Verification Ladder section with per-tier results
- **Anti-rationalization table**: expanded with T3-specific excuses