### PR TITLE
feat(security): engagement context scoping for authorized assessments

### DIFF
--- a/docs/references/engagement.md
+++ b/docs/references/engagement.md
@@ -1,0 +1,82 @@
+# Engagement Context — Security Assessment Scoping
+
+## Overview
+
+An engagement context file (`.harness/engagement.md`) defines the authorized scope for security assessments. When present, the `secure` skill and `audit:security` mode auto-load it to constrain checks to the approved scope.
+
+**Opt-in**: Without this file, existing OWASP checklist behavior applies unchanged.
+
+## File Location
+
+Place in your project root: `.harness/engagement.md`
+
+## Template
+
+```markdown
+# Security Engagement Context
+
+## Authorization
+- **Approved by**: <name or team>
+- **Date**: YYYY-MM-DD
+- **Reference**: <ticket/issue/JIRA link>
+
+## Scope
+### In Scope
+- <system or component 1>
+- <system or component 2>
+- <specific endpoints or services>
+
+### Out of Scope
+- <excluded systems>
+- <excluded endpoints>
+
+## Constraints
+- **Method**: <black-box / white-box / grey-box>
+- **Rules of engagement**: <rate limits, no-DoS, no-exfil, etc.>
+- **Disclosure path**: <where to report findings>
+
+## Environment
+- **Target environment**: <staging / production / dev>
+- **Credentials provided**: <yes/no — if yes, stored in secrets vault>
+- **Network access**: <VPN / direct / restricted>
+
+## Exclusions
+- <Known issues that should not be flagged>
+- <Third-party services not under assessment>
+```
+
+## Auto-Loading
+
+When `epic secure` or `audit:security` runs:
+
+1. Check for `.harness/engagement.md` in project root
+2. If found:
+   - Load scope, constraints, and exclusions
+   - Restrict security checks to in-scope components
+   - Skip findings matching exclusion patterns
+   - Enforce rules of engagement (e.g., no active exploitation if grey-box)
+   - Include authorization reference in audit report header
+3. If not found:
+   - Apply full OWASP Top 10 checklist (default behavior)
+   - No scope restrictions
+
+## Report Integration
+
+When engagement context is active, the security audit report includes:
+
+```
+## Security Audit (Engagement Context)
+- Engagement: <reference from engagement.md>
+- Scope: <in-scope summary>
+- Method: <black-box/white-box/grey-box>
+- Findings restricted to authorized scope
+
+<standard security findings>
+```
+
+## Safety
+
+- Engagement context is **advisory** — it guides where to look, not whether to report
+- CRITICAL findings in out-of-scope areas are still reported (as informational)
+- Engagement file is **never** committed to public repos (add `.harness/engagement.md` to `.gitignore`)
+- If engagement.md contains conflicting or malformed sections, fall back to full OWASP checklist with a warning

--- a/registry/skills/secure/SKILL.md
+++ b/registry/skills/secure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: secure
-description: "Trigger: auth, DB, API, infra, or secrets code touched — security checklist."
+description: "Trigger: auth, DB, API, infra, or secrets code touched — security checklist with optional engagement scoping."
 ---
 
 # Secure — Security Review
@@ -11,10 +11,36 @@ NO DEPLOYMENT WITHOUT SECURITY REVIEW OF ALL CHANGED FILES. Every code change is
 
 ## Process
 
-1. Identify security-relevant changes from the diff (auth, DB, API, infra, secrets)
-2. Run the Checklist below, marking each item as pass, fail, or N/A with reason
-3. For each failure, cite the file and line number with severity (CRITICAL/HIGH/MEDIUM)
-4. Report findings using the Evidence Required section
+### Step 0: Load Engagement Context (Optional)
+
+Check for engagement scoping:
+```bash
+cat .harness/engagement.md 2>/dev/null
+```
+
+If `.harness/engagement.md` exists:
+1. Parse the **Scope**, **Constraints**, and **Exclusions** sections
+2. Restrict security checks to in-scope components
+3. Apply rules of engagement (method, rate limits, no-exfil rules)
+4. Skip findings matching exclusion patterns
+5. Include engagement reference in report header
+
+If not found: apply full OWASP Top 10 checklist (default behavior). No scope restrictions.
+
+See `references/engagement.md` for the engagement file format.
+
+### Step 1: Identify Security-Relevant Changes
+
+Identify security-relevant changes from the diff (auth, DB, API, infra, secrets).
+
+### Step 2: Run Checklist
+
+Run the Checklist below, marking each item as pass, fail, or N/A with reason.
+
+### Step 3: Report
+
+For each failure, cite the file and line number with severity (CRITICAL/HIGH/MEDIUM).
+Report findings using the Evidence Required section.
 
 ## When to Trigger
 - Authentication or authorization code changed
@@ -61,6 +87,7 @@ See `references/security.md` for the full OWASP Top 10 checklist.
 | "We'll harden it before production" | Security bolted on later is always incomplete. | Build it secure now. Retrofitting misses edge cases. |
 | "It's an internal API, no one will abuse it" | Lateral movement attacks start from internal APIs. | Internal does not mean trusted. Validate and authorize every request. |
 | "I'll just disable CORS for development" | Dev shortcuts leak into production. | Use a proper CORS allow-list from day one. |
+| "Engagement scoping is bureaucratic overhead" | Unscoped assessments waste time on irrelevant surface area. | Define scope once, get focused results. Opt-in only. |
 
 ## Evidence Required
 
@@ -71,6 +98,7 @@ Before claiming security review is complete, show ALL applicable:
 - [ ] Parameterized queries used: show the query code (no string concat)
 - [ ] Auth checks present on new endpoints: show the middleware/guard
 - [ ] `.env` in `.gitignore`: confirmed
+- [ ] Engagement context loaded (or confirmed absent): scope applied to findings
 
 **A blank checklist is not a review. Each item needs a pass or N/A.**
 
@@ -78,3 +106,5 @@ Before claiming security review is complete, show ALL applicable:
 - Storing secrets in code or config files committed to git
 - Using `HTTP` instead of `HTTPS` for sensitive data
 - `eval()` or string-concatenated SQL anywhere
+- Skipping engagement scope when `.harness/engagement.md` is present
+- Reporting findings outside authorized scope as blockers (informational only)


### PR DESCRIPTION
Closes #48

## Changes

### New: `docs/references/engagement.md`
Engagement context file format specification with template:
- **Authorization**: approver, date, reference ticket
- **Scope**: in-scope/out-of-scope systems and endpoints
- **Constraints**: method (black/white/grey-box), rules of engagement
- **Environment**: target env, credentials, network access
- **Exclusions**: known issues to skip, third-party services

### Updated: `secure` SKILL.md
- New Step 0: check for `.harness/engagement.md`, load scope if present
- Restrict security checks to in-scope components when engaged
- CRITICAL out-of-scope findings reported as informational (not blockers)
- Anti-rationalization + evidence checklist updated

### Design decisions
- **Opt-in**: without `.harness/engagement.md`, existing OWASP checklist behavior preserved
- **Safety**: CRITICAL findings always reported even out-of-scope
- **Privacy**: engagement.md should be in `.gitignore` (not committed to public repos)
- **Fallback**: malformed/missing sections → full OWASP checklist with warning