### PR TITLE
feat(skills): defending-code vulnerability pipeline + normalize skill descriptions

### DIFF
--- a/registry/skills/agent-introspection/SKILL.md
+++ b/registry/skills/agent-introspection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-introspection
-description: "Trigger: 3+ consecutive failures, circular retries, or overwhelming context. Breaks loops."
+description: "Loop-breaking self-diagnosis. Use when 3+ consecutive failures occur, circular retries persist, or context overwhelms the session."
 ---
 
 # Agent Introspection — Systematic Self-Diagnosis

--- a/registry/skills/commit/SKILL.md
+++ b/registry/skills/commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit
-description: "CC 1.0.0 commit generator. Trigger: commit/save. Stages relevant files, infers type(scope): desc, never --no-verify."
+description: "Conventional Commits 1.0 generator. Stages relevant files, infers type(scope): description, never uses --no-verify."
 ---
 
 # Commit — Conventional Commits Generator

--- a/registry/skills/context/SKILL.md
+++ b/registry/skills/context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: context
-description: "Context window manager. Trigger: context >70% or large new task. Snapshots state, compacts, resumes via hook."
+description: "Context window manager. Snapshots session state, compacts conversation, and resumes via hook. Use when context exceeds 70% or a large new task begins."
 ---
 
 # Context — Context Window Management

--- a/registry/skills/debug/SKILL.md
+++ b/registry/skills/debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug
-description: "Trigger: test failure, runtime error, or unexpected behavior. Systematic root-cause isolation."
+description: "Systematic root-cause isolation for test failures, runtime errors, or unexpected behavior. Narrow hypothesis → verify → fix."
 ---
 
 # Debug — Systematic Debugging

--- a/registry/skills/discover/SKILL.md
+++ b/registry/skills/discover/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: discover
-description: "Trigger: vague/unfocused request or solution-without-problem. Reframes goal before coding."
+description: "Problem discovery and reframing. Use when requests are vague, unfocused, or solution-first. Ensures the right problem is defined before coding."
 modes:
   - auto   # auto-triggered on vague/unfocused requests
   - /discover  # explicit invocation

--- a/registry/skills/document/SKILL.md
+++ b/registry/skills/document/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: document
-description: "Trigger: public API, function, or module added or changed — exports, signatures, new modules."
+description: "Documentation generator for public APIs, functions, and modules. Use when exports, signatures, or new modules are added or changed."
 ---
 
 # Document — Auto-Documentation

--- a/registry/skills/eval/SKILL.md
+++ b/registry/skills/eval/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: eval
-description: "Trigger: quality/performance regression check, baseline comparison, pre-ship eval. Sub-modes: correctness, performance, quality, regression. Outputs PASS/WARN/FAIL per dimension."
+description: "Quality and performance evaluation with baseline comparison. Sub-modes: correctness, performance, quality, regression. Outputs PASS/WARN/FAIL per dimension. Use for pre-ship evaluation or regression checks."
 ---
 
 # Eval — Quality & Regression Gate

--- a/registry/skills/evolve/SKILL.md
+++ b/registry/skills/evolve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: evolve
-description: "Ring 3 evolution engine: analyze session observations, generate/improve evolved skills, show metrics dashboard. Subcommands: status, history, rollback, reset. Trigger: /evolve, post-session review, skill improvement."
+description: "Ring 3 evolution engine. Analyzes session observations, generates and improves evolved skills, shows metrics dashboard. Subcommands: status, history, rollback, reset. Use for post-session review and skill improvement."
 ---
 
 # /evolve — Manual Evolution Trigger

--- a/registry/skills/orchestrate/SKILL.md
+++ b/registry/skills/orchestrate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orchestrate
-description: "Trigger: active multi-agent run. Manages inbox, dependency resolution, message formatting, and agent handoffs."
+description: "Multi-agent orchestrator. Manages inbox, dependency resolution, message formatting, and agent handoffs during active multi-agent runs."
 modes:
   - auto       # auto-triggered during active orchestration
   - status     # /status — read-only orchestration dashboard

--- a/registry/skills/perf/SKILL.md
+++ b/registry/skills/perf/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: perf
-description: "Trigger: loops, DB queries, rendering, or batch ops. Catches N+1, missing indexes, unnecessary re-renders."
+description: "Performance optimizer for loops, DB queries, rendering, and batch operations. Catches N+1 queries, missing indexes, and unnecessary re-renders."
 ---
 
 # Perf — Performance Review

--- a/registry/skills/secure/SKILL.md
+++ b/registry/skills/secure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: secure
-description: "Trigger: auth, DB, API, infra, or secrets code touched — security checklist with optional engagement scoping."
+description: "Security review checklist with optional engagement scoping. Use when auth, DB, API, infra, or secrets code is touched."
 ---
 
 # Secure — Security Review

--- a/registry/skills/simplify/SKILL.md
+++ b/registry/skills/simplify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: simplify
-description: "Trigger: file >200 lines, high complexity, or duplication — deep nesting, copy-paste, god functions."
+description: "Code simplification for high-complexity files. Targets deep nesting, copy-paste patterns, god functions, and files over 200 lines."
 ---
 
 # Simplify — Code Simplification

--- a/registry/skills/tdd/SKILL.md
+++ b/registry/skills/tdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tdd
-description: "Trigger: new feature or bug fix. Enforces Red→Green→Refactor. No prod code without failing test first."
+description: "Test-Driven Development enforcer. Red→Green→Refactor cycle with no production code without a failing test first. Use for new features and bug fixes."
 ---
 
 # TDD — Test-Driven Development

--- a/registry/skills/team/SKILL.md
+++ b/registry/skills/team/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team
-description: "Wrap `epic team` CLI — design or update org-level agent teams (cross-project, append-merge). Trigger: 'set up agents', 'design a team', /spec with 3+ requirements. Subcommands: list, show, sync, link, unlink, history."
+description: "Org-level agent team designer via `epic team` CLI (cross-project, append-merge). Subcommands: list, show, sync, link, unlink, history. Use when setting up agents, designing teams, or /spec yields 3+ requirements."
 ---
 
 # /team — Agent Team Design

--- a/registry/skills/threat-model/SKILL.md
+++ b/registry/skills/threat-model/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: threat-model
+description: "Threat modeling and attack surface analysis. Use when assessing security boundaries, modeling threat actors, or generating threat scenarios."
+---
+
+# Threat Model — Attack Surface Analysis
+
+## Iron Law
+
+Every system has an attack surface. If you haven't identified it, you haven't secured it.
+
+## Process
+
+### Step 0: Load Engagement Context
+
+Check for `.harness/engagement.md` in the project root. If present, load the scope (in-scope/out-of-scope) and constraints. Skip threat modeling for explicitly out-of-scope components.
+
+Without engagement context, proceed with full-surface analysis.
+
+### Step 1: Identify Trust Boundaries
+
+Map every boundary where data crosses a trust level:
+
+1. **External → Internal**: API endpoints, webhooks, file uploads, user input
+2. **Internal → Privileged**: DB queries, file system access, shell execution
+3. **Service → Service**: Inter-service communication, message queues, shared state
+4. **Client → Server**: Auth tokens, session state, CORS origins
+
+For each boundary, document:
+- Data flow direction
+- Input validation present (yes/no/partial)
+- Authentication required (yes/no)
+- Encryption in transit (yes/no)
+
+### Step 2: Enumerate Threat Actors
+
+| Actor | Motivation | Capability | Target |
+|-------|-----------|------------|--------|
+| Anonymous user | Exploration | Low | Public endpoints |
+| Authenticated user | Data access | Medium | Own data + IDOR targets |
+| Malicious insider | Data exfiltration | High | All internal systems |
+| Compromised dependency | Supply chain | Variable | Build/deploy pipeline |
+
+### Step 3: Generate Threat Scenarios
+
+For each trust boundary × threat actor combination, generate:
+
+1. **Attack vector**: How the boundary is crossed maliciously
+2. **Impact**: What is compromised (CIA triad — Confidentiality, Integrity, Availability)
+3. **Likelihood**: High/Medium/Low based on exposure and complexity
+4. **Existing mitigations**: What already prevents this
+5. **Gap**: What is missing
+
+### Step 4: Produce Output
+
+Write `THREAT_MODEL.md`:
+
+```markdown
+# Threat Model — {project}
+
+## Scope
+- In-scope: {from engagement.md or full codebase}
+- Out-of-scope: {from engagement.md or none}
+- Date: {ISO date}
+
+## Trust Boundaries
+| # | Boundary | Direction | Validation | Auth | Encryption |
+|---|----------|-----------|------------|------|------------|
+| 1 | ... | ... | ... | ... | ... |
+
+## Threat Scenarios
+| ID | Boundary | Actor | Vector | Impact | Likelihood | Mitigated | Gap |
+|----|----------|-------|--------|--------|------------|-----------|-----|
+| T1 | ... | ... | ... | ... | ... | Partial | ... |
+
+## Priority Remediation
+1. [CRITICAL] {highest risk gap}
+2. [HIGH] {next gap}
+3. [MEDIUM] {remaining gaps}
+
+## Assumptions
+- {list all assumptions made during analysis}
+```
+
+### Step 5: Feed into vuln-scan
+
+After producing the threat model, suggest:
+**"Run `/vuln-scan` to validate threat scenarios against the codebase."**
+
+## Anti-Rationalization
+
+| Excuse | Rebuttal | What to do instead |
+|--------|----------|-------------------|
+| "We don't have any external-facing components" | Internal trust boundaries are attack surfaces too. Lateral movement starts inside. | Model internal boundaries with the same rigor. |
+| "Threat modeling is overkill for a small project" | Small projects get breached too. The model is proportional to the codebase. | Run the process. It takes 10 minutes. A breach takes months. |
+| "We already have a threat model" | Threat models expire. Every code change can invalidate assumptions. | Update the model when significant changes land. |
+| "The framework handles security" | Frameworks don't model YOUR business logic threats. | Add application-layer threat scenarios on top of framework defaults. |
+
+## Evidence Required
+
+- [ ] Every trust boundary in the codebase identified
+- [ ] At least 2 threat scenarios per boundary
+- [ ] Each scenario has impact, likelihood, and gap assessment
+- [ ] Priority remediation list ordered by risk
+- [ ] Assumptions explicitly listed (not hidden)
+
+## Red Flags
+
+- Skipping boundaries because they're "internal"
+- Listing only one threat scenario per boundary
+- Marking all scenarios as "already mitigated" without evidence
+- No assumptions section — means assumptions are hidden, not absent
+- Threat model that doesn't reference actual code paths

--- a/registry/skills/triage/SKILL.md
+++ b/registry/skills/triage/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: triage
+description: "Adversarial validation of vulnerability findings. Use when triaging security findings, validating vulnerabilities, or prioritizing remediation."
+---
+
+# Triage — Adversarial Vulnerability Validation
+
+## Iron Law
+
+A vulnerability finding is not confirmed until an adversary would agree it's exploitable. Unvalidated findings are noise.
+
+## Process
+
+### Step 0: Load Inputs
+
+Required inputs (in order of preference):
+1. `VULN-FINDINGS.json` from `/vuln-scan`
+2. Raw findings from `/audit --security`
+3. User-provided finding list
+
+Optional:
+- `THREAT_MODEL.md` for threat scenario context
+- `.harness/engagement.md` for scope constraints
+
+If no findings input exists, suggest:
+**"Run `/vuln-scan` first to generate findings to triage."**
+
+### Step 1: Adversarial Review
+
+For each finding, challenge it from an attacker's perspective:
+
+#### Exploitability Check
+1. **Can input reach the vulnerable code?** Trace the data flow from entry point to vulnerability.
+2. **Can the attacker control the input?** Distinguish between user-controlled vs. system-generated data.
+3. **Is there a path to impact?** Connecting the vulnerability to a security consequence (data leak, code exec, DoS).
+4. **Are there bypasses for existing mitigations?** WAF, input validation, CSP — all have bypass techniques.
+
+#### Severity Validation
+| Criteria | Adjust |
+|----------|--------|
+| Requires authentication | Lower by 1 level |
+| Requires specific permissions | Lower by 1 level |
+| Chained with another finding | Raise by 1 level |
+| Affects all users | Raise by 1 level |
+| No mitigation in place | Raise by 1 level |
+| Defense-in-depth exists | Lower by 1 level |
+
+#### Classification
+| Class | Meaning |
+|-------|---------|
+| `CONFIRMED` | Exploitable with demonstrated path |
+| `LIKELY` | Exploitable with high confidence, minor gaps in proof |
+| `POSSIBLE` | Theoretical, needs more investigation |
+| `FALSE_POSITIVE` | Not exploitable with justification |
+| `ACCEPTED_RISK` | Known, documented, accepted by team |
+
+### Step 2: Dependency Analysis
+
+Check if findings chain together:
+
+1. **Find pairs** where finding A enables finding B (e.g., IDOR → data exposure)
+2. **Mark chains** — chained findings are more severe than individual findings
+3. **Identify root causes** — multiple findings from the same root cause should be grouped
+
+### Step 3: Produce Output
+
+Write `TRIAGE.json`:
+
+```json
+{
+  "triage_date": "ISO-8601",
+  "source": "VULN-FINDINGS.json | audit | manual",
+  "findings": [
+    {
+      "id": "V1",
+      "classification": "CONFIRMED | LIKELY | POSSIBLE | FALSE_POSITIVE | ACCEPTED_RISK",
+      "original_severity": "CRITICAL",
+      "adjusted_severity": "HIGH",
+      "severity_adjustments": ["requires auth (-1)", "no mitigation (+1)"],
+      "exploit_path": ["entry point → vulnerable function → impact"],
+      "chains_with": ["V3"],
+      "root_cause_group": "RC1",
+      "remediation": "specific fix instruction",
+      "effort": "low | medium | high",
+      "validation_notes": "why this classification was chosen"
+    }
+  ],
+  "root_cause_groups": [
+    {
+      "id": "RC1",
+      "description": "shared root cause",
+      "findings": ["V1", "V2"],
+      "fix_once": "single fix that resolves all findings in group"
+    }
+  ],
+  "chains": [
+    {
+      "findings": ["V1", "V3"],
+      "combined_severity": "CRITICAL",
+      "description": "V1 enables V3, creating..."
+    }
+  ],
+  "summary": {
+    "total_input": 10,
+    "confirmed": 3,
+    "likely": 2,
+    "possible": 1,
+    "false_positive": 2,
+    "accepted_risk": 2,
+    "root_cause_groups": 3,
+    "chains": 1
+  },
+  "action_items": [
+    {
+      "priority": 1,
+      "severity": "CRITICAL",
+      "finding_ids": ["V1"],
+      "action": "specific remediation step",
+      "effort": "low"
+    }
+  ]
+}
+```
+
+### Step 4: Report
+
+Present prioritized remediation plan:
+
+```
+## Triage Report
+
+### Summary
+- Input: N findings
+- Confirmed: X | Likely: Y | False positives: Z
+- Root cause groups: K (fix-once opportunities)
+- Chained findings: C
+
+### Priority Actions
+1. [CRITICAL] V1: {description} — {effort} effort
+   Fix: {remediation}
+2. [HIGH] V2+V3 (chain): {description} — {effort} effort
+   Fix: {remediation}
+
+### Accepted Risks
+- V7: {description} — {justification}
+
+### Suggested Next Steps
+- Fix priority 1-3 before merge
+- Run `/vuln-scan` after fixes to verify
+```
+
+## Anti-Rationalization
+
+| Excuse | Rebuttal | What to do instead |
+|--------|----------|-------------------|
+| "All findings are real, no need to triage" | False positives waste fix time and erode trust in the process. | Validate every finding. Noise reduces signal. |
+| "Triaging takes too long" | Fixing false positives takes longer than triaging them. | Triage first, fix only confirmed findings. |
+| "It's obviously a vulnerability" | "Obvious" vulnerabilities are often mitigated by context you haven't checked. | Trace the exploit path before confirming. |
+| "We can just fix them all" | Not all findings need fixing. Some are accepted risks. | Prioritize by confirmed severity and effort. |
+| "Chaining is theoretical" | Real-world breaches use chained vulnerabilities. | Check for chains — they change severity. |
+
+## Evidence Required
+
+- [ ] Every finding classified (CONFIRMED/LIKELY/POSSIBLE/FALSE_POSITIVE/ACCEPTED_RISK)
+- [ ] Each CONFIRMED finding has a traced exploit path
+- [ ] Each FALSE_POSITIVE has justification for dismissal
+- [ ] Severity adjustments documented per finding
+- [ ] Root cause groups identified where applicable
+- [ ] Chained findings identified and combined severity assessed
+- [ ] TRIAGE.json written with action items
+- [ ] Priority actions ordered by severity × effort
+
+## Red Flags
+
+- All findings marked CONFIRMED without exploit paths
+- All findings marked FALSE_POSITIVE without justification
+- No severity adjustments — original severity is almost never perfect
+- Ignoring finding chains — individual severity ≠ chain severity
+- Skipping dependency analysis between findings
+- TRIAGE.json action items not ordered by priority

--- a/registry/skills/verify/SKILL.md
+++ b/registry/skills/verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify
-description: "Trigger: before marking done or /ship. Build + test + lint must all pass."
+description: "Pre-merge verification gate. Build, test, and lint must all pass before marking done or shipping."
 ---
 
 # Verify — Pre-Completion Check

--- a/registry/skills/vuln-scan/SKILL.md
+++ b/registry/skills/vuln-scan/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: vuln-scan
+description: "Systematic vulnerability scanner across injection, auth, data exposure, and dependencies. Use when scanning for vulnerabilities, reviewing security, or validating threat models."
+---
+
+# Vuln Scan — Systematic Vulnerability Scanner
+
+## Iron Law
+
+Code you haven't scanned for vulnerabilities has vulnerabilities you haven't found.
+
+## Process
+
+### Step 0: Load Engagement Context
+
+Check for `.harness/engagement.md`. If present, load scope constraints — only scan in-scope paths and respect exclusions.
+
+Check for `THREAT_MODEL.md` from a previous `/threat-model` run. If present, use its threat scenarios as scan targets. If absent, run full-surface scan.
+
+### Step 1: Scope the Scan
+
+```bash
+# Gather changed files (for incremental scans)
+git diff --name-only $(git merge-base HEAD main)
+
+# Or scan entire codebase
+find . -type f \( -name "*.rs" -o -name "*.ts" -o -name "*.js" -o -name "*.py" -o -name "*.go" \) \
+  | grep -v node_modules | grep -v target | grep -v vendor
+```
+
+### Step 2: Run Scan Dimensions (Parallel)
+
+Launch all dimensions concurrently:
+
+#### Dimension 1: Injection Scan
+
+Search patterns:
+```
+eval(              exec(              system(
+string concat SQL  format!.*query     raw_query
+innerHTML          dangerouslySetInnerHTML
+```
+
+For each match:
+- File, line number, surrounding context (5 lines)
+- Severity: CRITICAL (eval/exec), HIGH (SQL concat), MEDIUM (DOM injection)
+
+#### Dimension 2: Auth & Session Scan
+
+Search patterns:
+```
+password           secret             api_key
+token              credential         private_key
+Bearer             Authorization
+session            cookie
+```
+
+For each match:
+- Check: hardcoded value vs. config/env reference
+- Check: logged or exposed in error messages
+- Severity: CRITICAL (hardcoded secret), HIGH (secret in log), MEDIUM (weak session config)
+
+#### Dimension 3: Data Exposure Scan
+
+Search patterns:
+```
+console\.log.*token    println!.*secret       log\.info.*password
+\.env                  DEBUG.*=.*true         stacktrace
+err\.message           error\.response
+```
+
+For each match:
+- Check: sensitive data in log/output paths
+- Check: error messages revealing internals
+- Severity: HIGH (PII in logs), MEDIUM (verbose errors in production)
+
+#### Dimension 4: Dependency Scan
+
+```bash
+# Rust
+cargo audit 2>/dev/null || echo "cargo-audit not installed"
+
+# Node.js
+npm audit 2>/dev/null || echo "npm audit not available"
+```
+
+For each CVE found:
+- Severity from advisory
+- Is a fix available?
+- Is the vulnerable path actually reachable?
+
+### Step 3: Validate Findings
+
+For each finding, apply adversarial validation:
+
+1. **Is the code path reachable?** Dead code with `eval()` is INFO, not CRITICAL.
+2. **Is input actually attacker-controlled?** Internal-only calls with trusted input are lower risk.
+3. **Are mitigations already in place?** Parameterized queries behind string concat patterns = false positive.
+
+### Step 4: Produce Output
+
+Write `VULN-FINDINGS.json`:
+
+```json
+{
+  "scan_date": "ISO-8601",
+  "scope": "full | incremental",
+  "threat_model_ref": "THREAT_MODEL.md | null",
+  "findings": [
+    {
+      "id": "V1",
+      "dimension": "injection | auth | exposure | dependency",
+      "severity": "CRITICAL | HIGH | MEDIUM | LOW | INFO",
+      "file": "path/to/file",
+      "line": 42,
+      "pattern": "matched pattern",
+      "description": "what was found",
+      "validated": true,
+      "false_positive": false,
+      "reachable": true,
+      "mitigated": false,
+      "threat_scenario": "T1 | null",
+      "remediation": "one-line fix hint"
+    }
+  ],
+  "summary": {
+    "total": 10,
+    "critical": 1,
+    "high": 3,
+    "medium": 4,
+    "low": 2,
+    "false_positives": 0
+  }
+}
+```
+
+### Step 5: Feed into Triage
+
+After producing findings, suggest:
+**"Run `/triage` to validate findings with adversarial review."**
+
+## Anti-Rationalization
+
+| Excuse | Rebuttal | What to do instead |
+|--------|----------|-------------------|
+| "Static scanning has too many false positives" | False positives are filtered in Step 3. Unfiltered findings are better than missed vulnerabilities. | Run the scan, then validate. Skipping scan guarantees missed vulns. |
+| "We use a framework that prevents injection" | Frameworks prevent generic injection. Business-logic injection is framework-agnostic. | Scan for application-layer patterns too. |
+| "Dependencies are vetted" | Transitive dependencies aren't. `cargo audit` / `npm audit` exist for a reason. | Run dependency scanning every time Cargo.lock or package-lock.json changes. |
+| "The code is too new to have vulnerabilities" | New code has the most vulnerabilities. Old code has had time to be tested. | New code is the highest-priority scan target. |
+
+## Evidence Required
+
+- [ ] All 4 scan dimensions completed (injection, auth, exposure, dependency)
+- [ ] Each finding validated: reachable, not false positive, severity confirmed
+- [ ] VULN-FINDINGS.json written with summary
+- [ ] If THREAT_MODEL.md exists: each threat scenario mapped to findings
+- [ ] No CRITICAL/HIGH finding dismissed without explicit justification
+
+## Red Flags
+
+- Skipping dependency scanning because "we just updated"
+- Marking findings as false positives without validation
+- Scanning only changed files when full-surface scan was requested
+- Not checking if code paths are reachable
+- VULN-FINDINGS.json with zero findings on a non-trivial codebase — scan was likely incomplete


### PR DESCRIPTION
## Summary

Implements #50 Phase 1 — ports defending-code's security expertise into 3 new Ring 2 skills, plus normalizes all skill descriptions.

## New Skills

| Skill | Purpose | Output |
|-------|---------|--------|
| `threat-model` | Trust boundary analysis, threat actor enumeration, threat scenario generation | `THREAT_MODEL.md` |
| `vuln-scan` | 4-dimension systematic scanner (injection, auth, data exposure, dependencies) | `VULN-FINDINGS.json` |
| `triage` | Adversarial validation with severity adjustment, chaining analysis, root-cause grouping | `TRIAGE.json` |

Pipeline flow: `/threat-model` → `/vuln-scan` → `/triage`

## Description Normalization

Removed `Trigger:` prefix from 14 skill descriptions across the registry. Applied consistent `[What it does]. [When to use]` pattern for better dispatch matching.

## Changes

- 3 new SKILL.md files (threat-model, vuln-scan, triage) with full Process/Anti-Rationalization/Evidence Required/Red Flags sections
- 15 existing SKILL.md description fields normalized
- No Rust code changes — skills are markdown-only

## Test Plan

- [x] `cargo clippy -- -D warnings` clean (no Rust changes, markdown only)
- [x] All 23 skill descriptions follow consistent pattern
- [x] Zero `Trigger:` prefixes remaining in registry