### PR TITLE
feat(audit): two-container trust boundary for reviewer/auditor isolation

### DIFF
--- a/registry/skills/audit/SKILL.md
+++ b/registry/skills/audit/SKILL.md
@@ -15,6 +15,17 @@ This skill has 3 internal modes that run in parallel:
 2. **audit:security** — OWASP Top 10 + performance (N+1, leaks)
 3. **audit:test** — Full test suite, AC verification, coverage delta
 
+### `--strict` Mode (Trust Boundary Isolation)
+
+When invoked with `--strict` (or when `.harness/engagement.md` has `mode: strict`), the audit enforces independence between verification agents to prevent reward hacking:
+
+- **Artifact-only delivery**: Each mode receives only the code diff and spec — no builder context, no session history, no prior agent conclusions.
+- **Cross-check independence**: `audit:code` and `audit:security` run without visibility into each other's findings. Results are combined only during synthesis (Step 4).
+- **Blind scoring**: No mode can see another mode's verdict until synthesis. This prevents anchoring bias where a clean code review inflates the security score.
+- **No self-review**: If the same agent built the code (via `/go`), a different agent instance must run audit. The builder's session ID is checked and excluded.
+
+Use `--strict` for security-sensitive projects, compliance requirements, or when the build phase had ambiguous outcomes.
+
 ---
 
 ## Process
@@ -54,6 +65,13 @@ git diff --name-only $(git merge-base HEAD main)
 ### Step 3: Run Checks in Parallel
 
 Launch all 3 modes with `run_in_background: true`.
+
+**`--strict` isolation protocol**: When strict mode is active, each mode agent must be launched with:
+- Only the diff output from Step 1 as input (no session context)
+- No access to other modes' intermediate or final results
+- A fresh context window containing only: spec, diff, and the mode-specific checklist
+
+This ensures each mode forms independent conclusions. Results are combined only in Step 4 synthesis.
 
 ---
 
@@ -206,6 +224,8 @@ Combine deduplicated findings into a single report:
 | "Tests are passing, that's enough" | Tests don't catch security or performance issues | Run all 3 modes |
 | "I'll fix the warnings later" | Later never comes | Fix blockers now, warnings before merge |
 | "Dedup is overkill for small audits" | Small audits can still have cross-mode overlap | Always dedup — the cost is trivial |
+| "Strict mode is overkill" | Without isolation, the builder can influence reviewers via shared context | Use `--strict` for security-sensitive or compliance-driven projects |
+| "The agents are independent enough" | Shared context creates anchoring bias — a clean code review inflates security scores | Strict mode ensures blind scoring until synthesis |
 
 ## Evidence Required
 


### PR DESCRIPTION
## Summary

Implements #45 Phase 1 — audit skill gains `--strict` mode for verification agent independence.

## Changes

- **`--strict` mode**: Opt-in flag that enforces artifact-only delivery to audit modes
- **Cross-check independence**: `audit:code`, `audit:security`, `audit:test` run blind — no visibility into each other's results until synthesis
- **Blind scoring**: Prevents anchoring bias where a clean code review inflates security scores
- **No self-review**: Builder session is excluded from audit agent selection
- **Activation**: `--strict` flag or `mode: strict` in engagement.md

## What This Doesn't Do (Phase 2+)

- Actual container/process isolation (requires Rust code changes to audit pipeline)
- Sandbox execution environment for audit agents
- Artifact serialization protocol between builder and auditor

These are architectural changes requiring deeper integration with the orbit pipeline.

## Test Plan

- [x] `cargo clippy -- -D warnings` clean (markdown-only change)
- [x] `--strict` mode documented with clear activation instructions
- [x] Anti-rationalization table updated with strict mode entries