### PR TITLE
docs(sync): README, AGENTS.md, CHANGELOG + i18n 9-locale sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,11 @@
 # epic-harness
 
-23 skills (9 pipeline + 14 quality) + self-evolving agent harness.
+26 skills (9 pipeline + 17 quality) + self-evolving agent harness.
 
 ## Structure
 
 - `registry/` — Seeding resources (embedded in Rust binary at compile time)
-  - `skills/` — 23 skills + _dispatch engine
+  - `skills/` — 26 skills + _dispatch engine
   - `presets/` — Cold-start skill templates
 - `hooks/` — Ring 0 automation + Ring 3 evolution loop
   - `hooks/bin/epic-harness` — Rust single binary
@@ -24,7 +24,7 @@
 
 - **Ring 0 (Autopilot)**: Hooks auto-maintain quality, restore sessions, learn
 - **Ring 1 (Pipeline)**: 9 skills that orchestrate multi-step workflows (discover → spec → go → audit → eval → ship, orbit, evolve, team)
-- **Ring 2 (Quality Gates)**: 14 skills that auto-trigger on context signals (tdd, debug, secure, verify, etc.)
+- **Ring 2 (Quality Gates)**: 17 skills that auto-trigger on context signals (tdd, debug, secure, threat-model, vuln-scan, triage, verify, etc.)
 - **Ring 3 (Evolve)**: Observe → Analyze → Evolve → Gate → Reload self-improvement loop
 
 ## /orbit — Autonomous Pipeline
@@ -165,6 +165,36 @@ Three deep learning-inspired techniques adapted from [SkillOpt](https://arxiv.or
 - Epoch classification via linear regression over last 5 sessions: `Improving` / `Regressing` / `PersistentFailure` / `StableSuccess`
 - `meta.json` per evolved skill tracks `slow_updates` array (capped at 20)
 - Auto-eviction: `sessions_active ≥ 3 && avg_score_with < avg_score_without - 0.02` → remove + add to rejected buffer
+
+### Prompt Auto-Tuning
+- Underperforming evolved skills (where `avg_score_with < avg_score_without`) receive targeted tuning guidance
+- Tuning sections appended after `<!-- auto-tuned -->` delimiter in SKILL.md — original content never modified
+- Auto-rollback: 3 consecutive declining sessions → tuning stripped, history cleared
+- History tracked in `SkillMeta.prompt_tuning_history` (capped at 10 entries per skill)
+- Entry point: `auto_tune_skills(metrics)` in `src/evolve/skills.rs`
+
+## Security Pipeline (Ring 2)
+
+Three security assessment skills ported from [defending-code](https://github.com/anthropics/defending-code-reference-harness):
+
+1. **threat-model**: Trust boundary enumeration, threat actor analysis, threat scenario generation → `THREAT_MODEL.md`
+2. **vuln-scan**: 4-dimension systematic scanner (injection, auth, data exposure, dependencies) → `VULN-FINDINGS.json`
+3. **triage**: Adversarial validation with severity adjustment, chaining analysis, root-cause grouping → `TRIAGE.json`
+
+Pipeline flow: `/threat-model` → `/vuln-scan` → `/triage`
+
+### Audit `--strict` Mode
+- Artifact-only delivery: audit modes receive only diff + spec, no builder context
+- Cross-check independence: code/security/test modes run blind until synthesis
+- Blind scoring: prevents anchoring bias between modes
+- No self-review: builder session excluded from audit agent selection
+- Activation: `--strict` flag or `mode: strict` in `.harness/engagement.md`
+
+### Engagement Context
+- Optional `.harness/engagement.md` in project root for security assessment scoping
+- Defines: Authorization, Scope (in/out), Constraints, Environment, Exclusions
+- `secure` skill checks for engagement context and loads scope if present
+- Reference template: `docs/references/engagement.md`
 
 ## Polish → Observe Feedback
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Security pipeline (Ring 2)**: three new skills ported from [defending-code](https://github.com/anthropics/defending-code-reference-harness)
+  - **threat-model**: trust boundary analysis, threat actor enumeration, threat scenario generation → `THREAT_MODEL.md`
+  - **vuln-scan**: 4-dimension systematic scanner (injection, auth, data exposure, dependencies) → `VULN-FINDINGS.json`
+  - **triage**: adversarial validation with severity adjustment, chaining analysis, root-cause grouping → `TRIAGE.json`
+  - Pipeline flow: `/threat-model` → `/vuln-scan` → `/triage`
+- **Prompt auto-tuning for evolved skills**: underperforming skills receive targeted tuning guidance based on A/B score gaps
+  - Tuning sections appended after `<!-- auto-tuned -->` delimiter — original content never modified
+  - Auto-rollback after 3 consecutive declining sessions (`TUNING_DECLINE_LIMIT`)
+  - History tracked in `SkillMeta.prompt_tuning_history` (capped at 10 entries)
+  - New functions: `auto_tune_skills()`, `append_tuning_section()`, `strip_tuning_sections()`, `build_tuning_section()`
+  - 10 new unit tests covering serialization, scoring, decline counting
+- **Audit `--strict` mode**: trust boundary isolation for reviewer/auditor independence
+  - Artifact-only delivery: audit modes receive only diff + spec, no builder context
+  - Cross-check independence: code/security/test modes run blind until synthesis
+  - Blind scoring: prevents anchoring bias between modes
+  - No self-review: builder session excluded from audit agent selection
+  - Activation: `--strict` flag or `mode: strict` in `.harness/engagement.md`
+- **Engagement context**: optional `.harness/engagement.md` for security assessment scoping
+  - Defines: Authorization, Scope (in/out), Constraints, Environment, Exclusions
+  - `secure` skill checks for engagement context and loads scope if present
+  - Reference template: `docs/references/engagement.md`
+- **Tiered verification ladder** in `/ship`: T0 (build) → T1 (tests+lint+fmt) → T2 (AC verification) → T3 (security)
+  - T1/T2 auto-retry ≤3 times
+  - T3 conditional on engagement.md or security-scope diff
+- **Semantic deduplication** in `/audit`: cross-mode finding dedup between parallel checks and synthesis
+  - NEW/DUP_BETTER/DUP_SKIP classification
+  - Severity reassessment across modes (highest severity wins)
 - **SkillOpt-inspired evolution optimization**: three deep learning-inspired techniques adapted from [SkillOpt](https://arxiv.org/abs/2605.23904) for natural language skill evolution
   - **Negative Feedback Buffer**: persists rejected skill proposals with TTL-based expiry to prevent re-generating known-bad skills
   - **Minibatch Reflection**: decomposes observations into fixed-size batches for structural pattern extraction, catching micro-patterns hidden by session averages
@@ -23,6 +50,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - LLM-as-judge integration in SKILL.md for quality dimension (deferred to LLM session)
   - Orbit integration: Step 5.5 Eval phase inserted automatically when eval.yaml exists
   - New modules: `src/eval/{mod,config,runner,baseline,report}.rs`
+
+### Changed
+- **Skill descriptions normalized**: removed `Trigger:` prefix from all 14 skill descriptions, applied consistent `[What it does]. [When to use]` pattern
+- Skill count: 23 → 26 (9 pipeline + 17 quality gates)
 
 ## [0.5.0]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Epic Harness</h1>
 
-<blockquote><p align="center">A multi-tool AI agent harness that learns from every session — 22 skills, autonomous pipelines, and a self-evolving engine.</p></blockquote>
+<blockquote><p align="center">A multi-tool AI agent harness that learns from every session — 26 skills, autonomous pipelines, and a self-evolving engine.</p></blockquote>
 
 <p align="center"><b>One harness, six AI tools. Autonomous from spec to PR. Smarter every session.</b></p>
 
@@ -22,7 +22,7 @@
   <a href="https://buymeacoffee.com/epicsaga"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/buy_me_a_coffee-FFDD00?style=for-the-badge&labelColor=0d1117&logo=buymeacoffee&logoColor=black" /></a>
 </p>
 
-A multi-tool AI agent harness with **23 skills (9 pipeline + 14 quality gates)**, a **self-evolving engine**, **unified memory**, and a **single-command autonomous pipeline** (`/orbit`). Works with Claude Code, Codex, Cursor, OpenCode, and Cline — all sharing the same `~/.harness/` data directory. After each session, the evolve loop analyzes failures, generates targeted skills, and loads them next time.
+A multi-tool AI agent harness with **26 skills (9 pipeline + 17 quality gates)**, a **self-evolving engine**, **unified memory**, and a **single-command autonomous pipeline** (`/orbit`). Works with Claude Code, Codex, Cursor, OpenCode, and Cline — all sharing the same `~/.harness/` data directory. After each session, the evolve loop analyzes failures, generates targeted skills, and loads them next time.
 
 <p align="center">
   <img src="./assets/features.png" alt="epic harness features" width="100%" />
@@ -49,7 +49,7 @@ port = 7700       # set to 0 to disable auto-launch
 auto_open = true  # open browser on first session
 ```
 
-Screens: **Dashboard** · /orbit Pipeline · Skills (22) · Live Agents · Eval & Evolve · Hooks (6) · Integrations (6) · harness-mem · Settings
+Screens: **Dashboard** · /orbit Pipeline · Skills (26) · Live Agents · Eval & Evolve · Hooks (6) · Integrations (6) · harness-mem · Settings
 
 ---
 
@@ -187,7 +187,7 @@ Inside a Claude Code session: `/evolve status`
 | `/discover` | Problem discovery — 5 Whys, JTBD, Socratic questioning |
 | `/spec` | Define requirements — converts to numbered R + AC document |
 | `/go` | Build phase — auto-plan → TDD sub-agents → parallel execution → AC verification |
-| `/audit` | Audit phase — parallel code review + security audit + tests |
+| `/audit` | Audit phase — parallel code review + security audit + tests. Supports `--strict` mode for trust boundary isolation |
 | `/eval` | Eval phase — 4-dimension quality & regression check (correctness, performance, quality, regression) |
 | `/ship` | Shipping phase — isolated test → PR with full audit report → CI watch |
 | `/evolve` | Manual evolution trigger — analyze sessions, view dashboard, rollback |
@@ -238,13 +238,16 @@ State persisted in `$HARNESS_DIR/orbit/PIPELINE-{timestamp}.json` — survives c
 
 ## Quality Gates (Ring 2)
 
-14 skills that auto-trigger based on context. You don't invoke them.
+17 skills that auto-trigger based on context. You don't invoke them.
 
 | Skill | Triggers when |
 |-------|--------------|
 | **tdd** | New feature implementation or bug fix |
 | **debug** | Test failure or runtime error |
 | **secure** | Auth / DB / API / secrets code touched |
+| **threat-model** | Security assessment, attack surface analysis needed |
+| **vuln-scan** | Vulnerability scanning across injection, auth, exposure, dependencies |
+| **triage** | Adversarial validation of security findings, severity adjustment |
 | **perf** | Loops, queries, rendering, batch operations |
 | **simplify** | File > 200 lines or high cyclomatic complexity |
 | **document** | Public API added or signature changed |
@@ -256,7 +259,7 @@ State persisted in `$HARNESS_DIR/orbit/PIPELINE-{timestamp}.json` — survives c
 | **reflect** | On-demand `/reflect`: evidence-based human self-assessment — "Am I using AI as a thought amplifier?" Scores 5 dimensions from hook-collected data |
 | **commit** | Conventional Commits generation — auto-generates from git diff |
 
-> **Token budget note:** Claude Code loads skill descriptions into every session context. epic's 23 skills fit within the default `skillListingBudgetFraction: 0.01` (1%). If you install additional skills (e.g. episteme, alcove, obscura), the combined total may exceed the budget and trigger a "descriptions dropped" warning. Add this to `~/.claude/settings.json` to fix it:
+> **Token budget note:** Claude Code loads skill descriptions into every session context. epic's 26 skills fit within the default `skillListingBudgetFraction: 0.01` (1%). If you install additional skills (e.g. episteme, alcove, obscura), the combined total may exceed the budget and trigger a "descriptions dropped" warning. Add this to `~/.claude/settings.json` to fix it:
 >
 > ```json
 > "skillListingBudgetFraction": 0.02
@@ -320,6 +323,14 @@ Three deep learning-inspired techniques applied to natural language skill evolut
 Adapted from [SkillOpt (arXiv 2605.23904)](https://arxiv.org/abs/2605.23904). Configurable via `rejected_buffer_ttl` and `minibatch_size` in `[evolution]`.
 
 Stagnation: 3 sessions without 5% improvement → auto-rollback to best checkpoint.
+
+### Prompt Auto-Tuning
+
+Underperforming evolved skills (where `avg_score_with < avg_score_without`) receive targeted tuning guidance appended to their SKILL.md. The original content is never modified — tuning sections live behind an `<!-- auto-tuned -->` delimiter.
+
+- **Auto-rollback**: after 3 consecutive sessions of declining scores, tuning is stripped and history cleared
+- **History cap**: 10 tuning entries per skill, tracked in `meta.json`
+- **Gap-driven guidance**: severity of tuning matches the A/B score gap (minor → significant → major)
 
 ### Skill Effectiveness
 
@@ -473,9 +484,9 @@ flowchart TB
         c8("/evolve (manual)")
     end
 
-    subgraph R2["Ring 2 — Quality Gates (14, context-triggered)"]
+    subgraph R2["Ring 2 — Quality Gates (17, context-triggered)"]
         direction LR
-        s1(tdd) --- s2(debug) --- s3(secure) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council)
+        s1(tdd) --- s2(debug) --- s3(secure) --- s3b(threat-model) --- s3c(vuln-scan) --- s3d(triage) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council)
     end
 
     subgraph R3["Ring 3 — Evolve (self-improving)"]
@@ -740,6 +751,7 @@ Hooks look for the binary in two places: `hooks/bin/epic-harness` (plugin local)
 ## Acknowledgments
 
 - [SkillOpt](https://arxiv.org/abs/2605.23904) — Deep learning-inspired skill optimization (negative feedback buffer, minibatch reflection, slow/meta updates)
+- [defending-code](https://github.com/anthropics/defending-code-reference-harness) — Security assessment patterns (threat modeling, vulnerability scanning, adversarial triage, two-container trust boundary)
 - [a-evolve](https://github.com/A-EVO-Lab/a-evolve) — Automated evolution and benchmark patterns
 - [agent-skills](https://github.com/addyosmani/agent-skills) — Claude Code agent skill system
 - [everything-claude-code](https://github.com/affaan-m/everything-claude-code) — Comprehensive Claude Code patterns

--- a/i18n/de/README.md
+++ b/i18n/de/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Epic Harness</h1>
 
-<blockquote><p align="center">Ein Multi-Tool-KI-Agenten-Harness, das aus jeder Session lernt — 23 Skills, autonome Pipelines und eine selbstentwickelnde Engine.</p></blockquote>
+<blockquote><p align="center">Ein Multi-Tool-KI-Agenten-Harness, das aus jeder Session lernt — 26 Skills, autonome Pipelines und eine selbstentwickelnde Engine.</p></blockquote>
 
 <p align="center"><b>Ein Harness, sechs KI-Tools. Autonom von Spec bis PR. Intelligenter nach jeder Session.</b></p>
 
@@ -22,7 +22,7 @@
   <a href="https://buymeacoffee.com/epicsaga"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/buy_me_a_coffee-FFDD00?style=for-the-badge&labelColor=0d1117&logo=buymeacoffee&logoColor=black" /></a>
 </p>
 
-Ein Multi-Tool-KI-Agenten-Harness mit **23 Skills (9 Pipeline + 14 Quality Gates)**, einer **selbstentwickelnden Engine**, **einheitlichem Speicher** und einer **autonomen Ein-Befehl-Pipeline** (`/orbit`). Funktioniert mit Claude Code, Codex, Cursor, OpenCode und Cline — alle teilen dasselbe `~/.harness/` Datenverzeichnis. Nach jeder Session analysiert die Evolve-Schleife Fehler, generiert gezielte Skills und lädt sie beim nächsten Mal.
+Ein Multi-Tool-KI-Agenten-Harness mit **26 Skills (9 Pipeline + 17 Quality Gates)**, einer **selbstentwickelnden Engine**, **einheitlichem Speicher** und einer **autonomen Ein-Befehl-Pipeline** (`/orbit`). Funktioniert mit Claude Code, Codex, Cursor, OpenCode und Cline — alle teilen dasselbe `~/.harness/` Datenverzeichnis. Nach jeder Session analysiert die Evolve-Schleife Fehler, generiert gezielte Skills und lädt sie beim nächsten Mal.
 
 <p align="center">
   <img src="../../assets/features.png" alt="Epic Harness Funktionen" width="100%" />
@@ -90,7 +90,7 @@ Installiert das Binary automatisch und registriert alle Hooks in einem Schritt.
 codex plugin marketplace add epicsagas/plugins
 ```
 
-Installiert automatisch alle 23 Skills und registriert Hooks. Sofort verfügbar — keine weiteren Schritte erforderlich. Aktualisierungen mit `codex plugin update epic@epicsagas`.
+Installiert automatisch alle 26 Skills und registriert Hooks. Sofort verfügbar — keine weiteren Schritte erforderlich. Aktualisierungen mit `codex plugin update epic@epicsagas`.
 
 ### macOS / Linux
 
@@ -231,6 +231,9 @@ Skills werden automatisch basierend auf dem Kontext ausgelöst. Sie rufen sie ni
 | **tdd** | Neues Feature-Implementation oder Bug-Fix |
 | **debug** | Testfehler oder Laufzeitfehler |
 | **secure** | Auth / DB / API / Secrets-Code wird berührt |
+| **threat-model** | Sicherheitsbewertung, Angriffsflächenanalyse erforderlich |
+| **vuln-scan** | Schwachstellen-Scan über Injection, Auth, Datenexposition, Abhängigkeiten |
+| **triage** | Adversariele Validierung von Sicherheitsfunden, Schweregradanpassung |
 | **perf** | Schleifen, Abfragen, Rendering, Batch-Operationen |
 | **simplify** | Datei > 200 Zeilen oder hohe zyklomatische Komplexität |
 | **document** | Öffentliche API hinzugefügt oder Signatur geändert |
@@ -297,6 +300,14 @@ Drei vom Deep Learning inspirierte Techniken, angewendet auf die Evolution natü
 Angelehnt an [SkillOpt (arXiv 2605.23904)](https://arxiv.org/abs/2605.23904). Konfigurierbar über `rejected_buffer_ttl` und `minibatch_size` in `[evolution]`.
 
 Stagnation: 3 Sessions ohne 5% Verbesserung → automatischer Rollback zum besten Checkpoint.
+
+### Prompt-Auto-Tuning
+
+Unterperformende evolvierte Skills (bei denen `avg_score_with < avg_score_without`) erhalten gezielte Tuning-Anleitung, die an ihre SKILL.md angehängt wird. Der Originalinhalt wird nie modifiziert — Tuning-Abschnitte leben hinter einem `<!-- auto-tuned -->`-Trennzeichen.
+
+- **Automatischer Rollback**: nach 3 aufeinanderfolgenden Sessions mit sinkenden Scores wird das Tuning entfernt und der Verlauf gelöscht
+- **Verlaufsbegrenzung**: 10 Tuning-Einträge pro Skill, verfolgt in `meta.json`
+- **Lückengesteuerte Anleitung**: Schweregrad des Tunings entspricht der A/B-Score-Lücke (minor → significant → major)
 
 ### Skill-Effektivität
 
@@ -420,8 +431,8 @@ Alle Tools teilen dasselbe `~/.harness/projects/{slug}/`-Datenverzeichnis.
 
 | Tool | Ring 0 Hooks | Skills | Agents |
 |------|-------------|--------|--------|
-| **Claude Code** | ✓ Vollständig | ✓ 23 Skills | Live |
-| **Codex CLI** | ✓ Vollständig¹ | ✓ 23 | — |
+| **Claude Code** | ✓ Vollständig | ✓ 26 Skills | Live |
+| **Codex CLI** | ✓ Vollständig¹ | ✓ 26 | — |
 | **Cursor** | ✓ Vollständig² | ✓ über Rules | Live |
 | **OpenCode** | ✓ Teilweise³ | — | — |
 | **Cline** | ✓ Vollständig⁴ | — | — |
@@ -450,9 +461,9 @@ flowchart TB
         c8("/evolve (manuell)")
     end
 
-    subgraph R2["Ring 2 — Quality Gates (14, kontextgesteuert)"]
+    subgraph R2["Ring 2 — Quality Gates (17, kontextgesteuert)"]
         direction LR
-        s1(tdd) --- s2(debug) --- s3(secure) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council)
+        s1(tdd) --- s2(debug) --- s3(secure) --- s3b(threat-model) --- s3c(vuln-scan) --- s3d(triage) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council)
     end
 
     subgraph R3["Ring 3 — Evolve (selbstverbessernd)"]
@@ -705,6 +716,7 @@ Hooks suchen das Binary an zwei Orten: `hooks/bin/epic-harness` (Plugin-lokal) �
 ## Danksagung
 
 - [SkillOpt](https://arxiv.org/abs/2605.23904) — Deep-Learning-inspirierte Skill-Optimierung (Negative-Feedback-Puffer, Minibatch-Reflexion, Slow/Meta-Updates)
+- [defending-code](https://github.com/anthropics/defending-code-reference-harness) — Sicherheitsbewertungsmuster (Bedrohungsmodellierung, Schwachstellen-Scan, adversarielles Triage, Two-Container-Vertrauensgrenze)
 - [a-evolve](https://github.com/A-EVO-Lab/a-evolve) — Automatisierte Evolution und Benchmark-Muster
 - [agent-skills](https://github.com/addyosmani/agent-skills) — Claude Code Agent-Skill-System
 - [everything-claude-code](https://github.com/affaan-m/everything-claude-code) — Umfassende Claude Code-Muster

--- a/i18n/es/README.md
+++ b/i18n/es/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Epic Harness</h1>
 
-<blockquote><p align="center">Un arnés de agente IA multiherramienta que aprende de cada sesión — 23 skills, pipelines autónomos y motor autoevolutivo.</p></blockquote>
+<blockquote><p align="center">Un arnés de agente IA multiherramienta que aprende de cada sesión — 26 skills, pipelines autónomos y motor autoevolutivo.</p></blockquote>
 
 <p align="center"><b>Un arnés, seis herramientas IA. Autónomo del spec al PR. Más inteligente cada sesión.</b></p>
 
@@ -22,7 +22,7 @@
   <a href="https://buymeacoffee.com/epicsaga"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/buy_me_a_coffee-FFDD00?style=for-the-badge&labelColor=0d1117&logo=buymeacoffee&logoColor=black" /></a>
 </p>
 
-Un arnés de agente IA multiherramienta con **23 skills (9 pipeline + 14 quality gates)**, un **motor autoevolutivo**, **memoria unificada** y una **pipeline autónoma de un solo comando** (`/orbit`). Funciona con Claude Code, Codex, Cursor, OpenCode y Cline — todos compartiendo el mismo directorio `~/.harness/`. Después de cada sesión, el bucle de evolución analiza fallos, genera skills dirigidos y los carga en la próxima sesión.
+Un arnés de agente IA multiherramienta con **26 skills (9 pipeline + 17 quality gates)**, un **motor autoevolutivo**, **memoria unificada** y una **pipeline autónoma de un solo comando** (`/orbit`). Funciona con Claude Code, Codex, Cursor, OpenCode y Cline — todos compartiendo el mismo directorio `~/.harness/`. Después de cada sesión, el bucle de evolución analiza fallos, genera skills dirigidos y los carga en la próxima sesión.
 
 <p align="center">
   <img src="../../assets/features.png" alt="características de epic harness" width="100%" />
@@ -90,7 +90,7 @@ Instala automáticamente el binario y registra todos los hooks en un solo paso.
 codex plugin marketplace add epicsagas/plugins
 ```
 
-Instala automáticamente las 23 habilidades y registra los hooks. Disponibles inmediatamente — no se necesitan pasos adicionales.
+Instala automáticamente las 26 habilidades y registra los hooks. Disponibles inmediatamente — no se necesitan pasos adicionales.
 Se actualiza con `codex plugin update epic@epicsagas`.
 
 ### macOS / Linux
@@ -230,6 +230,9 @@ Las habilidades se activan automáticamente según el contexto. No las invocas t
 | **tdd** | Implementación de nueva funcionalidad o corrección de errores |
 | **debug** | Fallo de prueba o error en tiempo de ejecución |
 | **secure** | Código de auth / BD / API / secrets modificado |
+| **threat-model** | Evaluación de seguridad, análisis de superficie de ataque necesario |
+| **vuln-scan** | Escaneo de vulnerabilidades — inyección, autenticación, exposición de datos, dependencias |
+| **triage** | Validación adversarial de hallazgos de seguridad, ajuste de severidad |
 | **perf** | Bucles, consultas, renderizado, operaciones por lotes |
 | **simplify** | Archivo > 200 líneas o alta complejidad ciclomática |
 | **verify** | Antes de completar `/go` o `/ship` |
@@ -297,6 +300,14 @@ Tres técnicas inspiradas en el aprendizaje profundo aplicadas a la evolución d
 Adaptado de [SkillOpt (arXiv 2605.23904)](https://arxiv.org/abs/2605.23904). Configurable mediante `rejected_buffer_ttl` y `minibatch_size` en `[evolution]`.
 
 Estancamiento: 3 sesiones sin una mejora del 5% → rollback automático al mejor punto de control.
+
+### Autoajuste de Prompts
+
+Las habilidades evolucionadas con bajo rendimiento (donde `avg_score_with < avg_score_without`) reciben orientación de ajuste dirigida añadida a su SKILL.md. El contenido original nunca se modifica — las secciones de ajuste viven detrás de un delimitador `<!-- auto-tuned -->`.
+
+- **Reversión automática**: después de 3 sesiones consecutivas con puntajes decrecientes, el ajuste se elimina y el historial se borra
+- **Límite de historial**: 10 entradas de ajuste por habilidad, rastreadas en `meta.json`
+- **Orientación basada en brecha**: la severidad del ajuste coincide con la brecha de puntajes A/B (menor → significativo → mayor)
 
 ### Efectividad de Habilidades
 
@@ -420,8 +431,8 @@ Todas las herramientas comparten el mismo directorio de datos `~/.harness/projec
 
 | Herramienta | Ring 0 Hooks | Habilidades | Agentes |
 |-------------|-------------|-------------|---------|
-| **Claude Code** | ✓ Completo | ✓ 23 habilidades | Live |
-| **Codex CLI** | ✓ Completo¹ | ✓ 23 | — |
+| **Claude Code** | ✓ Completo | ✓ 26 habilidades | Live |
+| **Codex CLI** | ✓ Completo¹ | ✓ 26 | — |
 | **Cursor** | ✓ Completo³ | ✓ vía rules | Live |
 | **OpenCode** | ✓ Parcial⁴ | — | — |
 | **Cline** | ✓ Completo⁵ | — | — |
@@ -450,9 +461,9 @@ flowchart TB
         c8("/evolve (manual)")
     end
 
-    subgraph R2["Ring 2 — Quality Gates (14, context-triggered)"]
+    subgraph R2["Ring 2 — Quality Gates (17, context-triggered)"]
         direction LR
-        s1(tdd) --- s2(debug) --- s3(secure) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council) --- s8(document) --- s9(context) --- s10(orchestrate) --- s11(commit) --- s12(agent-introspection) --- s13(reflect) --- s14(discover)
+        s1(tdd) --- s2(debug) --- s3(secure) --- s3b(threat-model) --- s3c(vuln-scan) --- s3d(triage) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council)
     end
 
     subgraph R3["Ring 3 — Evolve (self-improving)"]
@@ -705,6 +716,7 @@ Los hooks buscan el binario en dos lugares: `hooks/bin/epic-harness` (plugin loc
 ## Agradecimientos
 
 - [SkillOpt](https://arxiv.org/abs/2605.23904) — Optimización de habilidades inspirada en aprendizaje profundo (búfer de retroalimentación negativa, reflexión por minilotes, actualizaciones lentas/meta)
+- [defending-code](https://github.com/anthropics/defending-code-reference-harness) — Patrones de evaluación de seguridad (modelado de amenazas, escaneo de vulnerabilidades, triaje adversarial, límite de confianza de dos contenedores)
 - [a-evolve](https://github.com/A-EVO-Lab/a-evolve) — Patrones de evolución automatizada y benchmarks
 - [agent-skills](https://github.com/addyosmani/agent-skills) — Sistema de habilidades de agente de Claude Code
 - [everything-claude-code](https://github.com/affaan-m/everything-claude-code) — Patrones exhaustivos de Claude Code

--- a/i18n/fr/README.md
+++ b/i18n/fr/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Epic Harness</h1>
 
-<blockquote><p align="center">Un harnais d'agent IA multi-outil qui apprend de chaque session — 23 skills, pipelines autonomes et moteur auto-evolutif.</p></blockquote>
+<blockquote><p align="center">Un harnais d'agent IA multi-outil qui apprend de chaque session — 26 skills, pipelines autonomes et moteur auto-evolutif.</p></blockquote>
 
 <p align="center"><b>Un harnais, cinq outils IA. Autonome du spec au PR. Plus intelligent a chaque session.</b></p>
 
@@ -22,7 +22,7 @@
   <a href="https://buymeacoffee.com/epicsaga"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/buy_me_a_coffee-FFDD00?style=for-the-badge&labelColor=0d1117&logo=buymeacoffee&logoColor=black" /></a>
 </p>
 
-Un harnais d'agent IA multi-outil avec **23 skills (9 pipeline + 14 quality gates)**, un **moteur auto-evolutif**, une **memoire unifiee** et une **pipeline autonome en une commande** (`/orbit`). Compatible avec Claude Code, Codex, Cursor, OpenCode et Cline — tous partageant le meme repertoire `~/.harness/`. Apres chaque session, la boucle d'evolution analyse les echecs, genere des skills cibles et les charge pour la prochaine session.
+Un harnais d'agent IA multi-outil avec **26 skills (9 pipeline + 17 quality gates)**, un **moteur auto-evolutif**, une **memoire unifiee** et une **pipeline autonome en une commande** (`/orbit`). Compatible avec Claude Code, Codex, Cursor, OpenCode et Cline — tous partageant le meme repertoire `~/.harness/`. Apres chaque session, la boucle d'evolution analyse les echecs, genere des skills cibles et les charge pour la prochaine session.
 
 <p align="center">
   <img src="./assets/features.png" alt="fonctionnalites epic harness" width="100%" />
@@ -90,7 +90,7 @@ Installe automatiquement le binaire et enregistre tous les hooks en une seule et
 codex plugin marketplace add epicsagas/plugins
 ```
 
-Installe automatiquement les 23 competences et enregistre les hooks. Disponible immediatement — aucune etape supplementaire necessaire.
+Installe automatiquement les 26 competences et enregistre les hooks. Disponible immediatement — aucune etape supplementaire necessaire.
 Mise a jour avec `codex plugin update epic@epicsagas`.
 
 ### macOS / Linux
@@ -228,6 +228,9 @@ Les competences se declenchent automatiquement en fonction du contexte. Vous ne 
 | **tdd** | Implementation d'une nouvelle fonctionnalite ou correction de bug |
 | **debug** | Echec de test ou erreur d'execution |
 | **secure** | Code d'auth / BDD / API / secrets modifie |
+| **threat-model** | Évaluation de sécurité, analyse de surface d'attaque nécessaire |
+| **vuln-scan** | Scan de vulnérabilités — injection, auth, exposition de données, dépendances |
+| **triage** | Validation adverse des résultats de sécurité, ajustement de sévérité |
 | **perf** | Boucles, requetes, rendu, operations par lot |
 | **simplify** | Fichier > 200 lignes ou complexite cyclomatique elevee |
 | **verify** | Avant de completer `/go` ou `/ship` |
@@ -295,6 +298,14 @@ Trois techniques inspirees de l'apprentissage profond appliquees a l'evolution d
 Adapte de [SkillOpt (arXiv 2605.23904)](https://arxiv.org/abs/2605.23904). Configurable via `rejected_buffer_ttl` et `minibatch_size` dans `[evolution]`.
 
 Stagnation : 3 sessions sans 5 % d'amelioration → retour automatique au meilleur point de controle.
+
+### Réglage automatique des prompts
+
+Les compétences évoluées sous-performantes (où `avg_score_with < avg_score_without`) reçoivent des conseils de réglage ciblés ajoutés à leur SKILL.md. Le contenu original n'est jamais modifié — les sections de réglage se trouvent derrière un délimiteur `<!-- auto-tuned -->`.
+
+- **Retour automatique** : après 3 sessions consécutives de scores décroissants, le réglage est supprimé et l'historique effacé
+- **Limite d'historique** : 10 entrées de réglage par compétence, suivies dans `meta.json`
+- **Guidage basé sur l'écart** : la sévérité du réglage correspond à l'écart de scores A/B (mineur → significatif → majeur)
 
 ### Efficacite des competences
 
@@ -418,9 +429,9 @@ Tous les outils partagent le meme repertoire de donnees `~/.harness/projects/{sl
 
 | Outil | Hooks Ring 0 | Competences | Agents |
 |-------|-------------|-------------|--------|
-| **Claude Code** | ✓ Complet | ✓ 23 competences | Live |
-| **Codex CLI** | ✓ Complet¹ | ✓ 23 | — |
-| **Cursor** | ✓ Complet² | ✓ 23 | Live |
+| **Claude Code** | ✓ Complet | ✓ 26 competences | Live |
+| **Codex CLI** | ✓ Complet¹ | ✓ 26 | — |
+| **Cursor** | ✓ Complet² | ✓ 26 | Live |
 | **OpenCode** | ✓ Partiel³ | — | — |
 | **Cline** | ✓ Complet⁴ | — | — |
 | **Aider** | —⁵ | — | — |
@@ -448,9 +459,9 @@ flowchart TB
         c8("/evolve (manuel)")
     end
 
-    subgraph R2["Ring 2 — Quality Gates (14, context-triggered)"]
+    subgraph R2["Ring 2 — Quality Gates (17, context-triggered)"]
         direction LR
-        s1(tdd) --- s2(debug) --- s3(secure) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council)
+        s1(tdd) --- s2(debug) --- s3(secure) --- s3b(threat-model) --- s3c(vuln-scan) --- s3d(triage) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council)
     end
 
     subgraph R3["Ring 3 — Evolve (auto-amelioration)"]
@@ -703,6 +714,7 @@ Les hooks cherchent le binaire a deux endroits : `hooks/bin/epic-harness` (local
 ## Remerciements
 
 - [SkillOpt](https://arxiv.org/abs/2605.23904) — Optimisation des competences inspiree de l'apprentissage profond (tampon de retroaction negative, reflexion par mini-lot, mises a jour lentes/meta)
+- [defending-code](https://github.com/anthropics/defending-code-reference-harness) — Modèles d'évaluation de sécurité (modélisation des menaces, scan de vulnérabilités, triage adverse, frontière de confiance à deux conteneurs)
 - [a-evolve](https://github.com/A-EVO-Lab/a-evolve) — Evolution automatisee et schemas de benchmark
 - [agent-skills](https://github.com/addyosmani/agent-skills) — Systeme de competences d'agent Claude Code
 - [everything-claude-code](https://github.com/affaan-m/everything-claude-code) — Patterns complets Claude Code

--- a/i18n/hi/README.md
+++ b/i18n/hi/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Epic Harness</h1>
 
-<blockquote><p align="center">हर सेशन से सीखने वाला मल्टी-टूल AI एजेंट हार्नेस — 23 स्किल्स, स्वायत्त पाइपलाइन, और स्व-विकास इंजन।</p></blockquote>
+<blockquote><p align="center">हर सेशन से सीखने वाला मल्टी-टूल AI एजेंट हार्नेस — 26 स्किल्स, स्वायत्त पाइपलाइन, और स्व-विकास इंजन।</p></blockquote>
 
 <p align="center"><b>एक हार्नेस, छह AI टूल। स्पेक से PR तक स्वायत्त। हर सेशन के साथ और स्मार्ट।</b></p>
 
@@ -22,7 +22,7 @@
   <a href="https://buymeacoffee.com/epicsaga"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/buy_me_a_coffee-FFDD00?style=for-the-badge&labelColor=0d1117&logo=buymeacoffee&logoColor=black" /></a>
 </p>
 
-एक मल्टी-टूल AI एजेंट हार्नेस जिसमें **23 स्किल्स (9 पाइपलाइन + 14 क्वालिटी गेट्स)**, **स्व-विकास इंजन**, **एकीकृत मेमोरी**, और **एकल-कमांड स्वायत्त पाइपलाइन** (`/orbit`) है। Claude Code, Codex, Cursor, OpenCode और Cline के साथ काम करता है — सभी एक ही `~/.harness/` डेटा डायरेक्टरी साझा करते हैं। हर सेशन के बाद, evolve लूप विफलताओं का विश्लेषण करता है, लक्षित स्किल्स उत्पन्न करता है, और अगली बार लोड करता है।
+एक मल्टी-टूल AI एजेंट हार्नेस जिसमें **26 स्किल्स (9 पाइपलाइन + 17 क्वालिटी गेट्स)**, **स्व-विकास इंजन**, **एकीकृत मेमोरी**, और **एकल-कमांड स्वायत्त पाइपलाइन** (`/orbit`) है। Claude Code, Codex, Cursor, OpenCode और Cline के साथ काम करता है — सभी एक ही `~/.harness/` डेटा डायरेक्टरी साझा करते हैं। हर सेशन के बाद, evolve लूप विफलताओं का विश्लेषण करता है, लक्षित स्किल्स उत्पन्न करता है, और अगली बार लोड करता है।
 
 <p align="center">
   <img src="../../assets/features.png" alt="epic harness features" width="100%" />
@@ -90,7 +90,7 @@ Auth या DB छू रहे हैं?   → secure ट्रिगर (OWAS
 codex plugin marketplace add epicsagas/plugins
 ```
 
-सभी 23 स्किल्स ऑटो-इंस्टॉल होती हैं और hooks रजिस्टर हो जाते हैं। तुरंत उपलब्ध — कोई अतिरिक्त चरण आवश्यक नहीं। `codex plugin update epic@epicsagas` से अपडेट करें।
+सभी 26 स्किल्स ऑटो-इंस्टॉल होती हैं और hooks रजिस्टर हो जाते हैं। तुरंत उपलब्ध — कोई अतिरिक्त चरण आवश्यक नहीं। `codex plugin update epic@epicsagas` से अपडेट करें।
 
 ### macOS / Linux
 
@@ -226,6 +226,9 @@ flowchart TD
 | **tdd** | नई फीचर इम्प्लीमेंटेशन या बग फिक्स |
 | **debug** | टेस्ट विफलता या runtime error |
 | **secure** | Auth / DB / API / secrets कोड छूा गया |
+| **threat-model** | सुरक्षा मूल्यांकन, हमले की सतह विश्लेषण आवश्यक |
+| **vuln-scan** | कमजोरी स्कैनिंग — इंजेक्शन, प्रमाणीकरण, डेटा एक्सपोजर, निर्भरताएँ |
+| **triage** | सुरक्षा निष्कर्षों का प्रतिकूल सत्यापन, गंभीरता समायोजन |
 | **perf** | लूप, क्वेरी, रेंडरिंग, batch operations |
 | **simplify** | फ़ाइल > 200 लाइनें या उच्च cyclomatic complexity |
 | **verify** | `/go` या `/ship` पूरा करने से पहले |
@@ -293,6 +296,14 @@ Reload (अगला सेशन — resume विकसित स्किल�
 [SkillOpt (arXiv 2605.23904)](https://arxiv.org/abs/2605.23904) से अनुकूलित। `[evolution]` में `rejected_buffer_ttl` और `minibatch_size` के माध्यम से कॉन्फ़िगर करने योग्य।
 
 स्थिरता: 5% सुधार के बिना 3 सेशन → best checkpoint पर ऑटो-rollback।
+
+### प्रॉम्प्ट ऑटो-ट्यूनिंग
+
+कम प्रदर्शन वाले विकसित स्किल्स (जहाँ `avg_score_with < avg_score_without`) को उनके SKILL.md में लक्षित ट्यूनिंग मार्गदर्शन प्राप्त होता है। मूल सामग्री कभी संशोधित नहीं होती — ट्यूनिंग अनुभाग `<!-- auto-tuned -->` सीमांकक के पीछे होते हैं।
+
+- **स्वतः रोलबैक**: लगातार 3 सत्रों में घटते स्कोर के बाद, ट्यूनिंग हटा दी जाती है और इतिहास साफ़ होता है
+- **इतिहास सीमा**: प्रति स्किल 10 ट्यूनिंग प्रविष्टियाँ, `meta.json` में ट्रैक की गई
+- **अंतर-आधारित मार्गदर्शन**: ट्यूनिंग की गंभीरता A/B स्कोर अंतर से मेल खाती है (मामूली → महत्वपूर्ण → प्रमुख)
 
 ### स्किल प्रभावशीलता
 
@@ -416,8 +427,8 @@ Merge रणनीति: बदले गए एजेंट prompt करत�
 
 | टूल | Ring 0 Hooks | स्किल्स | एजेंट |
 |------|-------------|--------|--------|
-| **Claude Code** | ✓ पूर्ण | ✓ 23 स्किल्स | Live |
-| **Codex CLI** | ✓ पूर्ण¹ | ✓ 23 | — |
+| **Claude Code** | ✓ पूर्ण | ✓ 26 स्किल्स | Live |
+| **Codex CLI** | ✓ पूर्ण¹ | ✓ 26 | — |
 | **Cursor** | ✓ पूर्ण³ | ✓ rules के माध्यम से | Live |
 | **OpenCode** | ✓ आंशिक⁴ | — | — |
 | **Cline** | ✓ पूर्ण⁵ | — | — |
@@ -446,9 +457,9 @@ flowchart TB
         c8("/evolve (manual)")
     end
 
-    subgraph R2["Ring 2 — Quality Gates (14, context-triggered)"]
+    subgraph R2["Ring 2 — Quality Gates (17, context-triggered)"]
         direction LR
-        s1(tdd) --- s2(debug) --- s3(secure) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council) --- s8(document) --- s9(context) --- s10(agent-introspection) --- s11(reflect) --- s12(orchestrate) --- s13(commit)
+        s1(tdd) --- s2(debug) --- s3(secure) --- s3b(threat-model) --- s3c(vuln-scan) --- s3d(triage) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council)
     end
 
     subgraph R3["Ring 3 — Evolve (self-improving)"]
@@ -701,6 +712,7 @@ Hooks binary दो जगहों पर ढूंढते हैं: `hooks/
 ## आभार
 
 - [SkillOpt](https://arxiv.org/abs/2605.23904) — डीप लर्निंग-प्रेरित कौशल अनुकूलन (नेगेटिव फीडबैक बफर, मिनीबैच प्रतिबिंब, स्लो/मेटा अपडेट)
+- [defending-code](https://github.com/anthropics/defending-code-reference-harness) — सुरक्षा मूल्यांकन पैटर्न (खतरे का मॉडलिंग, कमजोरी स्कैनिंग, प्रतिकूल ट्रायेज, दो-कंटेनर विश्वास सीमा)
 - [a-evolve](https://github.com/A-EVO-Lab/a-evolve) — स्वचालित एवोल्यूशन और benchmark patterns
 - [agent-skills](https://github.com/addyosmani/agent-skills) — Claude Code एजेंट skill system
 - [everything-claude-code](https://github.com/affaan-m/everything-claude-code) — व्यापक Claude Code patterns

--- a/i18n/ja/README.md
+++ b/i18n/ja/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Epic Harness</h1>
 
-<blockquote><p align="center">すべてのセッションから学習するマルチツールAIエージェントハーネス — 23のスキル、自律パイプライン、自己進化エンジン。</p></blockquote>
+<blockquote><p align="center">すべてのセッションから学習するマルチツールAIエージェントハーネス — 26のスキル、自律パイプライン、自己進化エンジン。</p></blockquote>
 
 <p align="center"><b>1つのハーネス、6つのAIツール。スペックからPRまで自律実行。セッションを重ねるほどスマートに。</b></p>
 
@@ -22,7 +22,7 @@
   <a href="https://buymeacoffee.com/epicsaga"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/buy_me_a_coffee-FFDD00?style=for-the-badge&labelColor=0d1117&logo=buymeacoffee&logoColor=black" /></a>
 </p>
 
-**23のスキル（9パイプライン + 14品質ゲート）**、**自己進化エンジン**、**統合メモリ**、**単一コマンド自律パイプライン**（`/orbit`）を備えたマルチツールAIエージェントハーネス。Claude Code、Codex、Cursor、OpenCode、Clineに対応し、すべてのツールが同じ `~/.harness/` データディレクトリを共有します。各セッション終了後、evolveループが失敗を分析し、ターゲットを絞ったスキルを生成して次回のセッションに読み込みます。
+**26のスキル（9パイプライン + 17品質ゲート）**、**自己進化エンジン**、**統合メモリ**、**単一コマンド自律パイプライン**（`/orbit`）を備えたマルチツールAIエージェントハーネス。Claude Code、Codex、Cursor、OpenCode、Clineに対応し、すべてのツールが同じ `~/.harness/` データディレクトリを共有します。各セッション終了後、evolveループが失敗を分析し、ターゲットを絞ったスキルを生成して次回のセッションに読み込みます。
 
 <p align="center">
   <img src="../../assets/features.png" alt="epic harness features" width="100%" />
@@ -90,7 +90,7 @@ auth/DB を変更?          → secure 発火 (OWASPチェックリスト、近�
 codex plugin marketplace add epicsagas/plugins
 ```
 
-23のスキルをすべて自動インストールし、フックを登録します。追加の手順なしですぐに利用可能です。`codex plugin update epic@epicsagas` で更新できます。
+26のスキルをすべて自動インストールし、フックを登録します。追加の手順なしですぐに利用可能です。`codex plugin update epic@epicsagas` で更新できます。
 
 ### macOS / Linux
 
@@ -229,6 +229,9 @@ flowchart TD
 | **tdd** | 新機能の実装またはバグ修正 |
 | **debug** | テスト失敗またはランタイムエラー |
 | **secure** | auth / DB / API / シークレットのコードに触れた場合 |
+| **threat-model** | セキュリティ評価、攻撃表面分析が必要な場合 |
+| **vuln-scan** | インジェクション、認証、データ露出、依存関係の脆弱性スキャン |
+| **triage** | セキュリティ発見事項の敵対的検証、重大度調整 |
 | **perf** | ループ、クエリ、レンダリング、バッチ操作 |
 | **simplify** | ファイルが200行超または高サイクロマティック複雑度 |
 | **verify** | `/go` または `/ship` 完了前 |
@@ -290,6 +293,14 @@ Reload (next session — resume loads evolved skills)
 [SkillOpt (arXiv 2605.23904)](https://arxiv.org/abs/2605.23904)より適用。`[evolution]`の`rejected_buffer_ttl`と`minibatch_size`で設定可能。
 
 停滞: 5%改善なしで3セッション → ベストチェックポイントに自動ロールバック。
+
+### プロンプト自動チューニング
+
+パフォーマンスの低い進化スキル（avg_score_with < avg_score_without）は、SKILL.mdにターゲットを絞ったチューニングガイダンスが追加されます。元のコンテンツは変更されず、チューニングセクションは `<!-- auto-tuned -->` デリミタの後に配置されます。
+
+- **自動ロールバック**: 3セッション連続でスコアが低下した場合、チューニングを削除し履歴をクリア
+- **履歴上限**: スキルあたり10件のチューニングエントリ、`meta.json` で追跡
+- **ギャップベースのガイダンス**: チューニングの重大度はA/Bスコアギャップに一致（minor → significant → major）
 
 ### スキル有効性
 
@@ -413,8 +424,8 @@ epic team delete backend --global      # orgストアから永久に削除
 
 | ツール | Ring 0 フック | スキル | エージェント |
 |------|-------------|--------|----------|
-| **Claude Code** | ✓ フル | ✓ 23スキル | Live |
-| **Codex CLI** | ✓ フル¹ | ✓ 23 | — |
+| **Claude Code** | ✓ フル | ✓ 26スキル | Live |
+| **Codex CLI** | ✓ フル¹ | ✓ 26 | — |
 | **Cursor** | ✓ フル³ | ✓ ルール経由 | Live |
 | **OpenCode** | ✓ 部分⁴ | — | — |
 | **Cline** | ✓ フル⁵ | — | — |
@@ -443,9 +454,9 @@ flowchart TB
         c8("/evolve (manual)")
     end
 
-    subgraph R2["Ring 2 — Quality Gates (14, context-triggered)"]
+    subgraph R2["Ring 2 — Quality Gates (17, context-triggered)"]
         direction LR
-        s1(tdd) --- s2(debug) --- s3(secure) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council)
+        s1(tdd) --- s2(debug) --- s3(secure) --- s3b(threat-model) --- s3c(vuln-scan) --- s3d(triage) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council)
     end
 
     subgraph R3["Ring 3 — Evolve (self-improving)"]
@@ -698,6 +709,7 @@ cargo test                                                    # テスト
 ## 謝辞
 
 - [SkillOpt](https://arxiv.org/abs/2605.23904) — ディープラーニングに基づくスキル最適化(ネガティブフィードバックバッファ、ミニバッチリフレクション、スロー/メタアップデート)
+- [defending-code](https://github.com/anthropics/defending-code-reference-harness) — セキュリティ評価パターン（脅威モデリング、脆弱性スキャン、敵対的トリアージ、ツーコンテナ信頼境界）
 - [a-evolve](https://github.com/A-EVO-Lab/a-evolve) — 自動進化とベンチマークパターン
 - [agent-skills](https://github.com/addyosmani/agent-skills) — Claude Codeエージェントスキルシステム
 - [everything-claude-code](https://github.com/affaan-m/everything-claude-code) — 包括的なClaude Codeパターン

--- a/i18n/ko/README.md
+++ b/i18n/ko/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Epic Harness</h1>
 
-<blockquote><p align="center">모든 세션에서 학습하는 멀티툴 AI 에이전트 하네스 — 23개 스킬, 자율 파이프라인, 자기 진화 엔진.</p></blockquote>
+<blockquote><p align="center">모든 세션에서 학습하는 멀티툴 AI 에이전트 하네스 — 26개 스킬, 자율 파이프라인, 자기 진화 엔진.</p></blockquote>
 
 <p align="center"><b>하나의 하네스, 6개 AI 툴. 스펙에서 PR까지 자율 실행. 세션이 반복될수록 더 똑똑해집니다.</b></p>
 
@@ -22,7 +22,7 @@
   <a href="https://buymeacoffee.com/epicsaga"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/buy_me_a_coffee-FFDD00?style=for-the-badge&labelColor=0d1117&logo=buymeacoffee&logoColor=black" /></a>
 </p>
 
-**23개 스킬(9 파이프라인 + 14 품질 게이트)**, **자기 진화 엔진**, **통합 메모리**, **단일 명령 자율 파이프라인**(`/orbit`)을 갖춘 멀티툴 AI 에이전트 하네스입니다. Claude Code, Codex, Cursor, OpenCode, Cline을 지원하며, 모든 툴이 동일한 `~/.harness/` 데이터 디렉토리를 공유합니다. 세션이 끝날 때마다 evolve 루프가 실패를 분석하고, 타겟팅된 스킬을 생성해 다음 세션에 로드합니다.
+**26개 스킬(9 파이프라인 + 17 품질 게이트)**, **자기 진화 엔진**, **통합 메모리**, **단일 명령 자율 파이프라인**(`/orbit`)을 갖춘 멀티툴 AI 에이전트 하네스입니다. Claude Code, Codex, Cursor, OpenCode, Cline을 지원하며, 모든 툴이 동일한 `~/.harness/` 데이터 디렉토리를 공유합니다. 세션이 끝날 때마다 evolve 루프가 실패를 분석하고, 타겟팅된 스킬을 생성해 다음 세션에 로드합니다.
 
 <p align="center">
   <img src="../../assets/features.png" alt="epic harness 기능" width="100%" />
@@ -90,7 +90,7 @@ auth/DB 코드를 수정했나요?   → secure 발동 (OWASP 체크리스트, �
 codex plugin marketplace add epicsagas/plugins
 ```
 
-23개 스킬 전체를 자동 설치하고 훅을 등록합니다. 추가 설정 없이 바로 사용할 수 있습니다.
+26개 스킬 전체를 자동 설치하고 훅을 등록합니다. 추가 설정 없이 바로 사용할 수 있습니다.
 
 `codex plugin update epic@epicsagas`로 업데이트합니다.
 
@@ -231,6 +231,9 @@ flowchart TD
 | **tdd** | 새로운 기능 구현 또는 버그 수정 |
 | **debug** | 테스트 실패 또는 런타임 에러 |
 | **secure** | 인증/DB/API/시크릿 코드 수정 시 |
+| **threat-model** | 보안 평가, 공격 표면 분석 필요 시 |
+| **vuln-scan** | 인젝션, 인증, 데이터 노출, 의존성 전체 취약점 스캔 |
+| **triage** | 보안 발견 사항의 적대적 검증, 심각도 조정 |
 | **perf** | 루프, 쿼리, 렌더링, 배치 작업 |
 | **simplify** | 파일이 200줄 초과이거나 순환 복잡도가 높을 때 |
 | **verify** | `/go` 또는 `/ship` 완료 전 |
@@ -298,6 +301,14 @@ Reload (다음 세션 — resume이 진화 스킬 로드)
 [SkillOpt (arXiv 2605.23904)](https://arxiv.org/abs/2605.23904)에서 차용. `[evolution]`의 `rejected_buffer_ttl`과 `minibatch_size`로 설정 가능.
 
 정체: 3세션 동안 5% 개선 없음 → 최적 체크포인트로 자동 롤백.
+
+### 프롬프트 자동 튜닝
+
+성과가 낮은 진화 스킬(avg_score_with < avg_score_without)은 SKILL.md에 타겟팅된 튜닝 가이드가 추가됩니다. 원본 콘텐츠는 수정되지 않으며, 튜닝 섹션은 `<!-- auto-tuned -->` 구분자 뒤에 위치합니다.
+
+- **자동 롤백**: 3회 연속 점수 하락 시 튜닝 제거 및 이력 초기화
+- **이력 상한**: 스킬당 10개 튜닝 엔트리, `meta.json`에 추적
+- **격차 기반 가이드**: 튜닝 심각도가 A/B 점수 격차에 일치 (minor → significant → major)
 
 ### 스킬 효과
 
@@ -421,8 +432,8 @@ epic team delete backend --global      # 조직 저장소에서 영구 삭제
 
 | 도구 | Ring 0 훅 | 스킬 | 에이전트 |
 |------|-----------|------|---------|
-| **Claude Code** | ✓ 전체 | ✓ 23개 스킬 | Live |
-| **Codex CLI** | ✓ 전체¹ | ✓ 23개 | — |
+| **Claude Code** | ✓ 전체 | ✓ 26개 스킬 | Live |
+| **Codex CLI** | ✓ 전체¹ | ✓ 26개 | — |
 | **Cursor** | ✓ 전체³ | ✓ 규칙 경유 | Live |
 | **OpenCode** | ✓ 부분⁴ | — | — |
 | **Cline** | ✓ 전체⁵ | — | — |
@@ -451,9 +462,9 @@ flowchart TB
         c8("/evolve (manual)")
     end
 
-    subgraph R2["Ring 2 — 품질 게이트 (14, context-triggered)"]
+    subgraph R2["Ring 2 — 품질 게이트 (17, context-triggered)"]
         direction LR
-        s1(tdd) --- s2(debug) --- s3(secure) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council)
+        s1(tdd) --- s2(debug) --- s3(secure) --- s3b(threat-model) --- s3c(vuln-scan) --- s3d(triage) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council)
     end
 
     subgraph R3["Ring 3 — 진화 (자기 개선)"]
@@ -706,6 +717,7 @@ cargo test                                                    # 테스트
 ## 감사의 말
 
 - [SkillOpt](https://arxiv.org/abs/2605.23904) — 딥러닝 기반 스킬 최적화 (네거티브 피드백 버퍼, 미니배치 리플렉션, 슬로우/메타 업데이트)
+- [defending-code](https://github.com/anthropics/defending-code-reference-harness) — 보안 평가 패턴 (위협 모델링, 취약점 스캔, 적대적 트리아지, 투 컨테이너 신뢰 경계)
 - [a-evolve](https://github.com/A-EVO-Lab/a-evolve) — 자동화된 진화 및 벤치마크 패턴
 - [agent-skills](https://github.com/addyosmani/agent-skills) — Claude Code 에이전트 스킬 시스템
 - [everything-claude-code](https://github.com/affaan-m/everything-claude-code) — 종합 Claude Code 패턴

--- a/i18n/pt-BR/README.md
+++ b/i18n/pt-BR/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Epic Harness</h1>
 
-<blockquote><p align="center">Um harness de agente IA multi-ferramenta que aprende com cada sessão — 23 skills, pipelines autônomos e motor autoevolutivo.</p></blockquote>
+<blockquote><p align="center">Um harness de agente IA multi-ferramenta que aprende com cada sessão — 26 skills, pipelines autônomos e motor autoevolutivo.</p></blockquote>
 
 <p align="center"><b>Um harness, cinco ferramentas IA. Autônomo do spec ao PR. Mais inteligente a cada sessão.</b></p>
 
@@ -22,7 +22,7 @@
   <a href="https://buymeacoffee.com/epicsaga"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/buy_me_a_coffee-FFDD00?style=for-the-badge&labelColor=0d1117&logo=buymeacoffee&logoColor=black" /></a>
 </p>
 
-Um harness de agente IA multi-ferramenta com **23 skills (9 pipeline + 14 quality gates)**, um **motor autoevolutivo**, **memória unificada** e uma **pipeline autônoma de comando único** (`/orbit`). Funciona com Claude Code, Codex, Cursor, OpenCode e Cline — todos compartilhando o mesmo diretório `~/.harness/`. Após cada sessão, o loop de evolução analisa falhas, gera skills direcionados e os carrega na próxima sessão.
+Um harness de agente IA multi-ferramenta com **26 skills (9 pipeline + 17 quality gates)**, um **motor autoevolutivo**, **memória unificada** e uma **pipeline autônoma de comando único** (`/orbit`). Funciona com Claude Code, Codex, Cursor, OpenCode e Cline — todos compartilhando o mesmo diretório `~/.harness/`. Após cada sessão, o loop de evolução analisa falhas, gera skills direcionados e os carrega na próxima sessão.
 
 <p align="center">
   <img src="../../assets/features.png" alt="funcionalidades do epic harness" width="100%" />
@@ -90,7 +90,7 @@ Instala automaticamente o binário e registra todos os hooks em uma única etapa
 codex plugin marketplace add epicsagas/plugins
 ```
 
-Instala automaticamente todas as 23 habilidades e registra os hooks. Disponível imediatamente — sem etapas adicionais. Atualiza com `codex plugin update epic@epicsagas`.
+Instala automaticamente todas as 26 habilidades e registra os hooks. Disponível imediatamente — sem etapas adicionais. Atualiza com `codex plugin update epic@epicsagas`.
 
 ### macOS / Linux
 
@@ -223,13 +223,16 @@ Estado persistido em `$HARNESS_DIR/orbit/PIPELINE-{timestamp}.json` — sobreviv
 
 ## Quality Gates (Ring 2)
 
-14 habilidades ativadas automaticamente com base no contexto. Você não as invoca.
+17 habilidades ativadas automaticamente com base no contexto. Você não as invoca.
 
 | Habilidade | Ativa quando |
 |------------|-------------|
 | **tdd** | Implementação de nova funcionalidade ou correção de bug |
 | **debug** | Falha de teste ou erro em tempo de execução |
 | **secure** | Código de Auth / DB / API / secrets modificado |
+| **threat-model** | Avaliação de segurança, análise de superfície de ataque necessária |
+| **vuln-scan** | Escaneamento de vulnerabilidades — injeção, autenticação, exposição de dados, dependências |
+| **triage** | Validação adversarial de descobertas de segurança, ajuste de severidade |
 | **perf** | Loops, consultas, renderização, operações em lote |
 | **simplify** | Arquivo com mais de 200 linhas ou alta complexidade ciclomática |
 | **verify** | Antes de completar `/go` ou `/ship` |
@@ -297,6 +300,14 @@ Três técnicas inspiradas em aprendizado profundo aplicadas à evolução de ha
 Adaptado do [SkillOpt (arXiv 2605.23904)](https://arxiv.org/abs/2605.23904). Configurável via `rejected_buffer_ttl` e `minibatch_size` em `[evolution]`.
 
 Estagnação: 3 sessões sem melhoria de 5% → rollback automático para o melhor checkpoint.
+
+### Autoajuste de Prompts
+
+Skills evoluídos com baixo desempenho (onde `avg_score_with < avg_score_without`) recebem orientação de ajuste direcionada adicionada ao seu SKILL.md. O conteúdo original nunca é modificado — as seções de ajuste vivem atrás de um delimitador `<!-- auto-tuned -->`.
+
+- **Reversão automática**: após 3 sessões consecutivas com pontuações decrescentes, o ajuste é removido e o histórico é limpo
+- **Limite de histórico**: 10 entradas de ajuste por skill, rastreadas em `meta.json`
+- **Orientação baseada em lacuna**: a severidade do ajuste corresponde à lacuna de pontuações A/B (menor → significativo → maior)
 
 ### Efetividade das Habilidades
 
@@ -420,8 +431,8 @@ Todas as ferramentas compartilham o mesmo diretório de dados `~/.harness/projec
 
 | Ferramenta | Ring 0 Hooks | Habilidades | Agentes |
 |------------|-------------|-------------|---------|
-| **Claude Code** | ✓ Completo | ✓ 23 habilidades | Live |
-| **Codex CLI** | ✓ Completo¹ | ✓ 23 | — |
+| **Claude Code** | ✓ Completo | ✓ 26 habilidades | Live |
+| **Codex CLI** | ✓ Completo¹ | ✓ 26 | — |
 | **Cursor** | ✓ Completo² | ✓ via rules | Live |
 | **OpenCode** | ✓ Parcial³ | — | — |
 | **Cline** | ✓ Completo⁴ | — | — |
@@ -450,9 +461,9 @@ flowchart TB
         c8("/evolve (manual)")
     end
 
-    subgraph R2["Ring 2 — Quality Gates (14, context-triggered)"]
+    subgraph R2["Ring 2 — Quality Gates (17, context-triggered)"]
         direction LR
-        s1(tdd) --- s2(debug) --- s3(secure) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council)
+        s1(tdd) --- s2(debug) --- s3(secure) --- s3b(threat-model) --- s3c(vuln-scan) --- s3d(triage) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council)
     end
 
     subgraph R3["Ring 3 — Evolve (self-improving)"]
@@ -705,6 +716,7 @@ Os hooks procuram o binário em dois lugares: `hooks/bin/epic-harness` (plugin l
 ## Agradecimentos
 
 - [SkillOpt](https://arxiv.org/abs/2605.23904) — Otimização de habilidades inspirada em aprendizado profundo (buffer de feedback negativo, reflexão por mini-lote, atualizações lentas/meta)
+- [defending-code](https://github.com/anthropics/defending-code-reference-harness) — Padrões de avaliação de segurança (modelagem de ameaças, escaneamento de vulnerabilidades, triagem adversarial, limite de confiança de dois contêineres)
 - [a-evolve](https://github.com/A-EVO-Lab/a-evolve) — Padrões de evolução automatizada e benchmarks
 - [agent-skills](https://github.com/addyosmani/agent-skills) — Sistema de habilidades de agente do Claude Code
 - [everything-claude-code](https://github.com/affaan-m/everything-claude-code) — Padrões abrangentes do Claude Code

--- a/i18n/zh-CN/README.md
+++ b/i18n/zh-CN/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Epic Harness</h1>
 
-<blockquote><p align="center">从每次会话中学习的多工具 AI 智能体框架 — 23 个技能、自主流水线、自我进化引擎。</p></blockquote>
+<blockquote><p align="center">从每次会话中学习的多工具 AI 智能体框架 — 26 个技能、自主流水线、自我进化引擎。</p></blockquote>
 
 <p align="center"><b>一个框架，五个 AI 工具。从规格到 PR 自主执行。每次会话都更智能。</b></p>
 
@@ -22,7 +22,7 @@
   <a href="https://buymeacoffee.com/epicsaga"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/buy_me_a_coffee-FFDD00?style=for-the-badge&labelColor=0d1117&logo=buymeacoffee&logoColor=black" /></a>
 </p>
 
-一个多工具 AI 智能体框架，拥有 **23 个技能（9 流水线 + 14 质量门）**、**自我进化引擎**、**统一记忆系统**和 **单命令自主流水线**（`/orbit`）。支持 Claude Code、Codex、Cursor、OpenCode 和 Cline — 所有工具共享同一个 `~/.harness/` 数据目录。每次会话结束后，evolve 循环会分析失败、生成针对性技能，并在下次会话时加载。
+一个多工具 AI 智能体框架，拥有 **26 个技能（9 流水线 + 17 质量门）**、**自我进化引擎**、**统一记忆系统**和 **单命令自主流水线**（`/orbit`）。支持 Claude Code、Codex、Cursor、OpenCode 和 Cline — 所有工具共享同一个 `~/.harness/` 数据目录。每次会话结束后，evolve 循环会分析失败、生成针对性技能，并在下次会话时加载。
 
 <p align="center">
   <img src="./assets/features.png" alt="epic harness 功能特性" width="100%" />
@@ -90,7 +90,7 @@ $ /orbit "为登录 API 添加 JWT 认证"
 codex plugin marketplace add epicsagas/plugins
 ```
 
-自动安装全部 23 个技能并注册 hooks。立即生效 — 无需额外步骤。使用 `codex plugin update epic@epicsagas` 更新。
+自动安装全部 26 个技能并注册 hooks。立即生效 — 无需额外步骤。使用 `codex plugin update epic@epicsagas` 更新。
 
 ### macOS / Linux
 
@@ -228,6 +228,9 @@ flowchart TD
 | **tdd** | 新功能实现或 Bug 修复 |
 | **debug** | 测试失败或运行时错误 |
 | **secure** | 涉及认证 / 数据库 / API / 密钥代码 |
+| **threat-model** | 安全评估、攻击面分析需要时 |
+| **vuln-scan** | 注入、认证、数据暴露、依赖项漏洞扫描 |
+| **triage** | 安全发现的对立验证，严重性调整 |
 | **perf** | 循环、查询、渲染、批量操作 |
 | **simplify** | 文件超过 200 行或圈复杂度过高 |
 | **document** | 公共 API 新增或签名变更 |
@@ -293,6 +296,14 @@ Reload（下次会话 — resume 加载进化技能）
 改编自 [SkillOpt (arXiv 2605.23904)](https://arxiv.org/abs/2605.23904)。可通过 `[evolution]` 中的 `rejected_buffer_ttl` 和 `minibatch_size` 配置。
 
 停滞：连续 3 次会话无 5% 提升 → 自动回滚到最佳检查点。
+
+### 提示词自动调优
+
+表现不佳的进化技能（avg_score_with < avg_score_without）会在其SKILL.md中添加针对性的调优指导。原始内容不会被修改——调优部分位于 `<!-- auto-tuned -->` 分隔符之后。
+
+- **自动回滚**：连续3次会话分数下降后，调优被移除，历史记录清空
+- **历史上限**：每个技能10条调优记录，在 `meta.json` 中跟踪
+- **差距驱动指导**：调优严重程度与A/B分数差距匹配（轻微 → 显著 → 重大）
 
 ### 技能效果
 
@@ -416,7 +427,7 @@ epic team delete backend --global      # 从组织存储中永久删除
 
 | 工具 | Ring 0 Hooks | 技能 | 智能体 |
 |------|-------------|--------|--------|
-| **Claude Code** | ✓ 完整 | ✓ 23 个技能（含 /orbit） | Live |
+| **Claude Code** | ✓ 完整 | ✓ 26 个技能（含 /orbit） | Live |
 | **Codex CLI** | ✓ 完整¹ | ✓ 7 | — |
 | **Cursor** | ✓ 完整² | ✓ 通过 rules | Live |
 | **OpenCode** | ✓ 部分³ | — | — |
@@ -446,9 +457,9 @@ flowchart TB
         c8("/evolve (manual)")
     end
 
-    subgraph R2["Ring 2 — Quality Gates (14, context-triggered)"]
+    subgraph R2["Ring 2 — Quality Gates (17, context-triggered)"]
         direction LR
-        s1(tdd) --- s2(debug) --- s3(secure) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council)
+        s1(tdd) --- s2(debug) --- s3(secure) --- s3b(threat-model) --- s3c(vuln-scan) --- s3d(triage) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council)
     end
 
     subgraph R3["Ring 3 — Evolve (self-improving)"]
@@ -701,6 +712,7 @@ Hooks 在两个位置查找二进制文件：`hooks/bin/epic-harness`（插件�
 ## 致谢
 
 - [SkillOpt](https://arxiv.org/abs/2605.23904) — 受深度学习启发的技能优化（负反馈缓冲区、小批量反思、慢速/元更新）
+- [defending-code](https://github.com/anthropics/defending-code-reference-harness) — 安全评估模式（威胁建模、漏洞扫描、对抗性分诊、双容器信任边界）
 - [a-evolve](https://github.com/A-EVO-Lab/a-evolve) — 自动进化和基准测试模式
 - [agent-skills](https://github.com/addyosmani/agent-skills) — Claude Code 智能体技能系统
 - [everything-claude-code](https://github.com/affaan-m/everything-claude-code) — 综合 Claude Code 模式

--- a/i18n/zh-TW/README.md
+++ b/i18n/zh-TW/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Epic Harness</h1>
 
-<blockquote><p align="center">從每次工作階段中學習的多工具 AI 智慧型代理框架 — 23 個技能、自主流水線、自我進化引擎。</p></blockquote>
+<blockquote><p align="center">從每次工作階段中學習的多工具 AI 智慧型代理框架 — 26 個技能、自主流水線、自我進化引擎。</p></blockquote>
 
 <p align="center"><b>一個框架，六個 AI 工具。從規格到 PR 自主執行。每次工作階段都更智慧。</b></p>
 
@@ -22,7 +22,7 @@
   <a href="https://buymeacoffee.com/epicsaga"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/buy_me_a_coffee-FFDD00?style=for-the-badge&labelColor=0d1117&logo=buymeacoffee&logoColor=black" /></a>
 </p>
 
-一個多工具 AI 智慧型代理框架，擁有 **23 個技能（9 流水線 + 14 品質門）**、**自我進化引擎**、**統一記憶系統**和 **單命令自主流水線**（`/orbit`）。支援 Claude Code、Codex、Cursor、OpenCode 和 Cline — 所有工具共享同一個 `~/.harness/` 資料目錄。每次工作階段結束後，evolve 迴圈會分析失敗、生成針對性技能，並在下次工作階段時載入。
+一個多工具 AI 智慧型代理框架，擁有 **26 個技能（9 流水線 + 17 品質門）**、**自我進化引擎**、**統一記憶系統**和 **單命令自主流水線**（`/orbit`）。支援 Claude Code、Codex、Cursor、OpenCode 和 Cline — 所有工具共享同一個 `~/.harness/` 資料目錄。每次工作階段結束後，evolve 迴圈會分析失敗、生成針對性技能，並在下次工作階段時載入。
 
 <p align="center">
   <img src="../../assets/features.png" alt="epic harness 功能" width="100%" />
@@ -90,7 +90,7 @@ $ /orbit "為登入 API 新增 JWT 驗證"
 codex plugin marketplace add epicsagas/plugins
 ```
 
-自動安裝全部 23 個技能並註冊掛鉤。安裝後立即可用，無需額外步驟。
+自動安裝全部 26 個技能並註冊掛鉤。安裝後立即可用，無需額外步驟。
 使用 `codex plugin update epic@epicsagas` 進行更新。
 
 ### macOS / Linux
@@ -230,6 +230,9 @@ flowchart TD
 | **tdd** | 新功能實作或錯誤修復 |
 | **debug** | 測試失敗或執行時期錯誤 |
 | **secure** | 涉及 Auth / DB / API / secrets 的程式碼 |
+| **threat-model** | 安全評估、攻擊面分析需要時 |
+| **vuln-scan** | 注入、認證、資料暴露、依賴項漏洞掃描 |
+| **triage** | 安全發現的對立驗證，嚴重性調整 |
 | **perf** | 迴圈、查詢、渲染、批次操作 |
 | **simplify** | 檔案超過 200 行或圈複雜度過高 |
 | **document** | 新增或修改了公開 API 簽名 |
@@ -297,6 +300,14 @@ Reload (next session — resume loads evolved skills)
 改編自 [SkillOpt (arXiv 2605.23904)](https://arxiv.org/abs/2605.23904)。可透過 `[evolution]` 中的 `rejected_buffer_ttl` 和 `minibatch_size` 設定。
 
 停滯處理：連續 3 個工作階段無 5% 改善 → 自動回滾到最佳檢查點。
+
+### 提示詞自動調優
+
+表現不佳的進化技能（avg_score_with < avg_score_without）會在其SKILL.md中添加針對性的調優指導。原始內容不會被修改——調優部分位於 `<!-- auto-tuned -->` 分隔符之後。
+
+- **自動回滾**：連續3次工作階段分數下降後，調優被移除，歷史記錄清空
+- **歷史上限**：每個技能10條調優記錄，在 `meta.json` 中追蹤
+- **差距驅動指導**：調優嚴重程度與A/B分數差距匹配（輕微 → 顯著 → 重大）
 
 ### 技能有效性
 
@@ -420,7 +431,7 @@ epic team delete backend --global      # 從組織儲存中永久刪除
 
 | 工具 | Ring 0 掛鉤 | 技能 | 智能體 |
 |------|-------------|--------|--------|
-| **Claude Code** | ✓ 完整 | ✓ 23 個技能 | Live |
+| **Claude Code** | ✓ 完整 | ✓ 26 個技能 | Live |
 | **Codex CLI** | ✓ 完整¹ | ✓ 23 | — |
 | **Cursor** | ✓ 完整³ | ✓ 23 | Live |
 | **OpenCode** | ✓ 部分⁴ | — | — |
@@ -450,9 +461,9 @@ flowchart TB
         c8("/evolve (manual)")
     end
 
-    subgraph R2["Ring 2 — Quality Gates (14, context-triggered)"]
+    subgraph R2["Ring 2 — Quality Gates (17, context-triggered)"]
         direction LR
-        s1(tdd) --- s2(debug) --- s3(secure) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council)
+        s1(tdd) --- s2(debug) --- s3(secure) --- s3b(threat-model) --- s3c(vuln-scan) --- s3d(triage) --- s4(perf) --- s5(simplify) --- s6(verify) --- s7(council)
     end
 
     subgraph R3["Ring 3 — Evolve (self-improving)"]
@@ -705,6 +716,7 @@ cargo test                                                    # 測試
 ## 致謝
 
 - [SkillOpt](https://arxiv.org/abs/2605.23904) — 受深度學習啟發的技能最佳化（負回饋緩衝區、小批量反思、慢速/元更新）
+- [defending-code](https://github.com/anthropics/defending-code-reference-harness) — 安全評估模式（威脅建模、漏洞掃描、對抗性分診、雙容器信任邊界）
 - [a-evolve](https://github.com/A-EVO-Lab/a-evolve) — 自動化進化與基準測試模式
 - [agent-skills](https://github.com/addyosmani/agent-skills) — Claude Code 智能體技能系統
 - [everything-claude-code](https://github.com/affaan-m/everything-claude-code) — 全面的 Claude Code 模式

--- a/src/orchestrate/mod.rs
+++ b/src/orchestrate/mod.rs
@@ -387,6 +387,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn run_pre_returns_0_when_disabled() {
         with_env(None, || {
             let input = HookInput {
@@ -399,6 +400,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn run_post_returns_0_when_disabled() {
         with_env(None, || {
             let input = HookInput::default();


### PR DESCRIPTION
## Changes

README.md, AGENTS.md, CHANGELOG.md 및 9개 로케일 i18n README 동기화

### README.md
- 스킬 수 23→26, Quality Gates 14→17
- 3개 보안 스킬(threat-model, vuln-scan, triage) 추가
- Prompt Auto-Tuning 섹션 추가
- Architecture diagram Ring 2 노드 업데이트
- Acknowledgments에 defending-code 추가

### AGENTS.md
- Prompt Auto-Tuning, Security Pipeline, Audit --strict, Engagement Context 섹션 추가

### CHANGELOG.md
- [Unreleased] 섹션에 모든 병합된 PR 변경사항 종합

### i18n (9 locales)
- ko, ja, de, fr, es, pt-BR, zh-CN, zh-TW, hi 전체 동기화
- 각 로케일에 스킬 수, 보안 스킬, 자동 튜닝, 아키텍처, 감사 인원 업데이트