### PR TITLE
fix(codex): detect plugin install path and accept modern hooks=true key

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -1303,6 +1303,39 @@ fn generate_canonical_files(tool: &str) -> Vec<(String, String)> {
     files
 }
 
+// ── Codex hooks detection ────────────────────────────────────────────────────
+
+/// Subset of Codex's `~/.codex/config.toml` needed to detect hook enablement.
+/// `#[serde(default)]` keeps deserialization resilient to unknown keys.
+#[derive(serde::Deserialize)]
+struct CodexConfig {
+    #[serde(default)]
+    features: CodexFeatures,
+}
+
+#[derive(Default, serde::Deserialize)]
+struct CodexFeatures {
+    #[serde(default)]
+    hooks: Option<bool>,
+}
+
+/// Whether Codex hooks are enabled in `config.toml` content.
+///
+/// Accepts the legacy `codex_hooks` key (anywhere in the file) or the modern
+/// `hooks = true` inside a `[features]` block (Codex renamed the key). Parsed
+/// as real TOML so trailing comments, missing spaces, and quoted-string
+/// variants are handled correctly. Invalid TOML falls back to `false` — the
+/// only consequence is a (harmless) install warning.
+fn codex_hooks_enabled(config: &str) -> bool {
+    if config.contains("codex_hooks") {
+        return true;
+    }
+    match toml::from_str::<CodexConfig>(config) {
+        Ok(c) => c.features.hooks == Some(true),
+        Err(_) => false,
+    }
+}
+
 // ── Install a single tool ─────────────────────────────────────────────────────
 
 fn install_tool(tool: &str, local: bool, dry_run: bool) -> i32 {
@@ -1378,31 +1411,13 @@ fn install_tool(tool: &str, local: bool, dry_run: bool) -> i32 {
     }
 
     // Codex-specific: warn if config.toml exists but hooks are not enabled.
-    // Accepts either the legacy `codex_hooks = true` flag or the modern
-    // `hooks = true` in a `[features]` block (Codex renamed the key).
+    // Detection logic (legacy `codex_hooks` or modern `[features] hooks = true`)
+    // lives in `codex_hooks_enabled` below so it can be unit-tested.
     if tool == "codex" {
         let config_path = target_dir.join("config.toml");
         if config_path.exists() {
             let ok = fs::read_to_string(&config_path)
-                .map(|s| {
-                    // Legacy: `codex_hooks` anywhere in the file.
-                    if s.contains("codex_hooks") {
-                        return true;
-                    }
-                    // Modern: `hooks = true` inside a [features] block.
-                    let mut in_features = false;
-                    for line in s.lines() {
-                        let t = line.trim();
-                        if t.starts_with('[') {
-                            in_features = t == "[features]";
-                            continue;
-                        }
-                        if in_features && t == "hooks = true" {
-                            return true;
-                        }
-                    }
-                    false
-                })
+                .map(|s| codex_hooks_enabled(&s))
                 .unwrap_or(false);
             if !ok {
                 eprintln!();
@@ -2075,5 +2090,29 @@ Run all tests.
         // 패닉 없이 종료되어야 함
         sync_plugin_cache(&home_str, true);
         let _ = fs::remove_dir_all(base_dir);
+    }
+
+    #[test]
+    fn test_codex_hooks_enabled_detects_all_forms() {
+        // Legacy `codex_hooks` key, anywhere in the file.
+        assert!(codex_hooks_enabled("codex_hooks = true\n"));
+        assert!(codex_hooks_enabled("other = 1\ncodex_hooks = true\n"));
+
+        // Modern `[features] hooks = true`.
+        assert!(codex_hooks_enabled("[features]\nhooks = true\n"));
+
+        // Robust to formatting the hand-rolled parser used to miss.
+        assert!(codex_hooks_enabled(
+            "[features]\nhooks = true  # enable all\n"
+        ));
+        assert!(codex_hooks_enabled("[features]\nhooks=true\n"));
+
+        // Explicitly disabled or absent → not enabled.
+        assert!(!codex_hooks_enabled("[features]\nhooks = false\n"));
+        assert!(!codex_hooks_enabled(""));
+        assert!(!codex_hooks_enabled("[other]\nhooks = true\n")); // wrong table
+
+        // Garbage TOML → false, no panic.
+        assert!(!codex_hooks_enabled("not valid toml !!! [[["));
     }
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -1377,12 +1377,32 @@ fn install_tool(tool: &str, local: bool, dry_run: bool) -> i32 {
         eprintln!("[harness] dry-run: would inject mcpServers.harness-mem into {tool} settings");
     }
 
-    // Codex-specific: warn if config.toml exists but codex_hooks is not enabled.
+    // Codex-specific: warn if config.toml exists but hooks are not enabled.
+    // Accepts either the legacy `codex_hooks = true` flag or the modern
+    // `hooks = true` in a `[features]` block (Codex renamed the key).
     if tool == "codex" {
         let config_path = target_dir.join("config.toml");
         if config_path.exists() {
             let ok = fs::read_to_string(&config_path)
-                .map(|s| s.contains("codex_hooks"))
+                .map(|s| {
+                    // Legacy: `codex_hooks` anywhere in the file.
+                    if s.contains("codex_hooks") {
+                        return true;
+                    }
+                    // Modern: `hooks = true` inside a [features] block.
+                    let mut in_features = false;
+                    for line in s.lines() {
+                        let t = line.trim();
+                        if t.starts_with('[') {
+                            in_features = t == "[features]";
+                            continue;
+                        }
+                        if in_features && t == "hooks = true" {
+                            return true;
+                        }
+                    }
+                    false
+                })
                 .unwrap_or(false);
             if !ok {
                 eprintln!();
@@ -1392,7 +1412,7 @@ fn install_tool(tool: &str, local: bool, dry_run: bool) -> i32 {
                 eprintln!("[harness] Hooks are OFF by default. Add these lines to enable them:");
                 eprintln!();
                 eprintln!("    [features]");
-                eprintln!("    codex_hooks = true");
+                eprintln!("    hooks = true");
                 eprintln!();
                 eprintln!("[harness] Then restart Codex for the change to take effect.");
             }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -767,7 +767,25 @@ fn handle_harness_cmd(cmd: &str, harness_dir: &std::path::Path) -> String {
             serde_json::to_string(&all).unwrap_or_else(|_| "[]".into())
         }
         "get_integration_status" => {
-            let home = std::env::var("HOME").unwrap_or_default();
+            let home = std::env::var("HOME")
+                .or_else(|_| std::env::var("USERPROFILE"))
+                .unwrap_or_default();
+            // Codex: detect either the legacy `~/.codex/hooks.json` install path
+            // (written by `epic install codex`) OR the modern plugin marketplace
+            // install (Codex's own `codex plugin install epic@epicsagas`), which
+            // unpacks the plugin under `~/.codex/plugins/cache/epicsagas/`.
+            let codex_legacy = std::path::Path::new(&home)
+                .join(".codex/hooks.json")
+                .exists();
+            let codex_plugin = std::path::Path::new(&home)
+                .join(".codex/plugins/cache/epicsagas")
+                .exists();
+            let codex_installed = codex_legacy || codex_plugin;
+            let codex_config_path = if codex_plugin {
+                "~/.codex/plugins/cache/epicsagas/"
+            } else {
+                "~/.codex/hooks.json"
+            };
             let integrations = serde_json::json!([
                 {
                     "name": "Claude Code",
@@ -785,7 +803,12 @@ fn handle_harness_cmd(cmd: &str, harness_dir: &std::path::Path) -> String {
                     "config_path": "~/.gemini/config/mcp_config.json",
                     "version": null
                 },
-                { "name": "Codex",  "installed": false, "config_path": null, "version": null },
+                {
+                    "name": "Codex",
+                    "installed": codex_installed,
+                    "config_path": codex_config_path,
+                    "version": null
+                },
                 { "name": "Cursor", "installed": false, "config_path": null, "version": null },
                 { "name": "Cline",  "installed": false, "config_path": null, "version": null },
                 { "name": "Aider",  "installed": false, "config_path": null, "version": null }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -781,10 +781,14 @@ fn handle_harness_cmd(cmd: &str, harness_dir: &std::path::Path) -> String {
                 .join(".codex/plugins/cache/epicsagas")
                 .exists();
             let codex_installed = codex_legacy || codex_plugin;
-            let codex_config_path = if codex_plugin {
-                "~/.codex/plugins/cache/epicsagas/"
+            // null when not installed — matches Cursor/Cline/Aider so the
+            // dashboard never shows a phantom path for an absent Codex.
+            let codex_config_path: Option<&str> = if !codex_installed {
+                None
+            } else if codex_plugin {
+                Some("~/.codex/plugins/cache/epicsagas/")
             } else {
-                "~/.codex/hooks.json"
+                Some("~/.codex/hooks.json")
             };
             let integrations = serde_json::json!([
                 {


### PR DESCRIPTION
## Summary

Two related fixes for Codex integration tracking. The dashboard reported Codex as "Not installed" even when the plugin was correctly installed via Codex's own plugin marketplace.

## Problems

### 1. Dashboard hardcoded `installed: false` for Codex

`src/serve.rs` `get_integration_status` only performed real filesystem checks for Claude Code and Antigravity. Codex, Cursor, Cline, and Aider were hardcoded as `installed: false`:

```rust
{ "name": "Codex",  "installed": false, "config_path": null, "version": null },
```

The recommended Codex install path (`codex plugin install epic@epicsagas`, per the README) unpacks the plugin under `~/.codex/plugins/cache/epicsagas/` — a location the dashboard never inspected.

### 2. Stale `codex_hooks` check in installer warning

`src/install.rs` warned that "hooks are OFF" whenever `~/.codex/config.toml` did not contain the literal string `codex_hooks`. Codex renamed the key to `hooks` (under `[features]`), so existing users with `hooks = true` still got the misleading warning suggesting they add the legacy `codex_hooks = true`.

## Fixes

### `src/serve.rs`

- Add `USERPROFILE` fallback to the home-dir lookup so detection works on Windows where `HOME` is typically unset.
- Detect Codex via either path:
  - `~/.codex/hooks.json` (legacy `epic install codex`)
  - `~/.codex/plugins/cache/epicsagas/` (modern plugin marketplace install)
- Surface the matching path in `config_path` so the dashboard shows where the install was detected.

### `src/install.rs`

Accept either form of hook enablement in `~/.codex/config.toml`:
- Legacy: `codex_hooks` anywhere in the file
- Modern: `hooks = true` inside a `[features]` block

The warning message now suggests `hooks = true` (the current key).

## Verification

- Built and installed locally on Windows (`cargo build --release`, 5m58s).
- Dashboard now reports Codex as `installed: true` with `config_path: ~/.codex/plugins/cache/epicsagas/`.
- `epic install codex --dry-run` no longer emits the stale warning against an existing config with `hooks = true`.
- `cargo build --release` clean; `git diff` is 48 insertions / 5 deletions across two files.

## Scope

Cursor / Cline / Aider detection is still hardcoded `false` — out of scope for this PR, which is focused on Codex. Happy to follow up with a separate PR for the others if useful.

## Checklist

- [x] Patches compile cleanly
- [x] No new warnings introduced
- [x] No sensitive info in diff (names, paths, tokens, IPs, emails scanned)
- [x] Conventional Commits message format
