### PR TITLE
fix(store): project-scope metrics/evolution writers + composite-PK migration

### DIFF
--- a/src/hooks/reflect.rs
+++ b/src/hooks/reflect.rs
@@ -999,7 +999,8 @@ pub fn run(_input: &HookInput) -> i32 {
     // Write evolution record to SQLite (primary) + JSONL (fallback)
     let _ = crate::store::runtime::block_on(async {
         let pool = crate::store::pool::harness_pool().await?;
-        crate::store::evolution::insert_record_pool(&pool, &record).await
+        let slug = crate::shared::paths::project_slug();
+        crate::store::evolution::insert_record_pool(&pool, &record, &slug).await
     });
     append_jsonl(&evolution_file(), &record);
 
@@ -1082,7 +1083,8 @@ pub fn run(_input: &HookInput) -> i32 {
     // Save metrics to SQLite (primary) + JSON file (fallback)
     let _ = crate::store::runtime::block_on(async {
         let pool = crate::store::pool::harness_pool().await?;
-        crate::store::metrics::save_metrics_pool(&pool, &metrics).await
+        let slug = crate::shared::paths::project_slug();
+        crate::store::metrics::save_metrics_pool(&pool, &metrics, &slug).await
     });
     if let Ok(json) = serde_json::to_string_pretty(&metrics) {
         let _ = fs::write(metrics_file(), json);

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -878,7 +878,8 @@ fn handle_harness_cmd(cmd: &str, harness_dir: &std::path::Path, project: Option<
             // come from history alone.
             let history = crate::store::runtime::block_on(async {
                 let pool = crate::store::pool::harness_pool().await?;
-                crate::store::evolution::query_all_records_pool(&pool).await
+                crate::store::evolution::query_recent_records_scoped_pool(&pool, i64::MAX, project)
+                    .await
             })
             .unwrap_or_default();
             let landscape = crate::evolve::planner::build_landscape(&history, &[], 2);

--- a/src/store/evolution.rs
+++ b/src/store/evolution.rs
@@ -198,7 +198,9 @@ mod tests {
             manifests: vec![],
         };
 
-        insert_record_pool(&pool, &rec, "test-project").await.unwrap();
+        insert_record_pool(&pool, &rec, "test-project")
+            .await
+            .unwrap();
 
         let results = query_recent_records_pool(&pool, 10).await.unwrap();
         assert_eq!(results.len(), 1);
@@ -225,7 +227,9 @@ mod tests {
                 edit_type: ty.clone(),
                 manifests: vec![],
             };
-            insert_record_pool(&pool, &rec, "test-project").await.unwrap();
+            insert_record_pool(&pool, &rec, "test-project")
+                .await
+                .unwrap();
         }
 
         let results = query_recent_records_pool(&pool, 100).await.unwrap();

--- a/src/store/evolution.rs
+++ b/src/store/evolution.rs
@@ -7,8 +7,12 @@ use std::io;
 
 use crate::shared::evolution::EvolutionRecord;
 
-/// Insert an evolution record.
-pub async fn insert_record_pool(pool: &AnyPool, rec: &EvolutionRecord) -> io::Result<i64> {
+/// Insert an evolution record, scoped to `project`.
+pub async fn insert_record_pool(
+    pool: &AnyPool,
+    rec: &EvolutionRecord,
+    project: &str,
+) -> io::Result<i64> {
     let error_json = serde_json::to_string(&rec.error_patterns).unwrap_or_else(|_| "{}".into());
     let failure_json = serde_json::to_string(&rec.failure_patterns).unwrap_or_else(|_| "[]".into());
 
@@ -16,8 +20,8 @@ pub async fn insert_record_pool(pool: &AnyPool, rec: &EvolutionRecord) -> io::Re
         "INSERT INTO evolution_records
          (timestamp, observations, success_rate, avg_score, error_patterns,
           failure_patterns, skills_seeded, skills_rolled_back, total_evolved,
-          analysis_summary, edit_type)
-         VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+          analysis_summary, edit_type, project)
+         VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
     )
     .bind(&rec.timestamp)
     .bind(super::u64_to_i64(rec.observations))
@@ -30,6 +34,7 @@ pub async fn insert_record_pool(pool: &AnyPool, rec: &EvolutionRecord) -> io::Re
     .bind(super::u64_to_i64(rec.total_evolved))
     .bind(&rec.analysis_summary)
     .bind(rec.edit_type.as_str())
+    .bind(project)
     .execute(pool)
     .await
     .map_err(super::sqlx_err)?;
@@ -43,9 +48,10 @@ pub async fn insert_record_pool(pool: &AnyPool, rec: &EvolutionRecord) -> io::Re
 
 /// Standalone insert.
 pub fn insert_record(rec: &EvolutionRecord) -> io::Result<i64> {
+    let project = crate::shared::paths::project_slug().to_string();
     super::runtime::block_on(async {
         let pool = super::pool::harness_pool().await?;
-        insert_record_pool(&pool, rec).await
+        insert_record_pool(&pool, rec, &project).await
     })
 }
 
@@ -192,7 +198,7 @@ mod tests {
             manifests: vec![],
         };
 
-        insert_record_pool(&pool, &rec).await.unwrap();
+        insert_record_pool(&pool, &rec, "test-project").await.unwrap();
 
         let results = query_recent_records_pool(&pool, 10).await.unwrap();
         assert_eq!(results.len(), 1);
@@ -219,7 +225,7 @@ mod tests {
                 edit_type: ty.clone(),
                 manifests: vec![],
             };
-            insert_record_pool(&pool, &rec).await.unwrap();
+            insert_record_pool(&pool, &rec, "test-project").await.unwrap();
         }
 
         let results = query_recent_records_pool(&pool, 100).await.unwrap();

--- a/src/store/metrics.rs
+++ b/src/store/metrics.rs
@@ -164,8 +164,20 @@ pub async fn save_metrics_pool(pool: &AnyPool, m: &Metrics, project: &str) -> io
         Ok(())
     }
 
-    upsert(&mut tx, "total_sessions", &m.total_sessions.to_string(), project).await?;
-    upsert(&mut tx, "avg_success_rate", &m.avg_success_rate.to_string(), project).await?;
+    upsert(
+        &mut tx,
+        "total_sessions",
+        &m.total_sessions.to_string(),
+        project,
+    )
+    .await?;
+    upsert(
+        &mut tx,
+        "avg_success_rate",
+        &m.avg_success_rate.to_string(),
+        project,
+    )
+    .await?;
     upsert(
         &mut tx,
         "total_evolved_skills",
@@ -294,7 +306,13 @@ pub async fn save_metrics_direct(
     }
 
     upsert(tx, "total_sessions", &m.total_sessions.to_string(), project).await?;
-    upsert(tx, "avg_success_rate", &m.avg_success_rate.to_string(), project).await?;
+    upsert(
+        tx,
+        "avg_success_rate",
+        &m.avg_success_rate.to_string(),
+        project,
+    )
+    .await?;
     upsert(
         tx,
         "total_evolved_skills",
@@ -792,7 +810,10 @@ mod tests {
         let lb = load_metrics_scoped_pool(&pool, Some("proj-b"))
             .await
             .unwrap();
-        assert_eq!(la.total_sessions, 5, "proj-a must not be overwritten by proj-b");
+        assert_eq!(
+            la.total_sessions, 5,
+            "proj-a must not be overwritten by proj-b"
+        );
         assert_eq!(lb.total_sessions, 99);
     }
 

--- a/src/store/metrics.rs
+++ b/src/store/metrics.rs
@@ -140,59 +140,74 @@ pub fn load_metrics() -> io::Result<Metrics> {
 
 // ── Save ─────────────────────────────────────────────
 
-/// Save the full Metrics struct to SQLite.
-pub async fn save_metrics_pool(pool: &AnyPool, m: &Metrics) -> io::Result<()> {
+/// Save the full Metrics struct to SQLite, scoped to `project`.
+pub async fn save_metrics_pool(pool: &AnyPool, m: &Metrics, project: &str) -> io::Result<()> {
     let mut tx = pool.begin().await.map_err(super::sqlx_err)?;
 
-    // Scalar state — upsert each key
+    // Scalar state — upsert each key scoped to (key, project).
     async fn upsert(
         tx: &mut sqlx::Transaction<'_, sqlx::Any>,
         key: &str,
         value: &str,
+        project: &str,
     ) -> io::Result<()> {
-        sqlx::query("INSERT OR REPLACE INTO metrics_state (key, value) VALUES (?, ?)")
-            .bind(key)
-            .bind(value)
-            .execute(&mut **tx)
-            .await
-            .map_err(super::sqlx_err)?;
+        sqlx::query(
+            "INSERT INTO metrics_state (key, value, project) VALUES (?, ?, ?) \
+             ON CONFLICT (key, project) DO UPDATE SET value = excluded.value",
+        )
+        .bind(key)
+        .bind(value)
+        .bind(project)
+        .execute(&mut **tx)
+        .await
+        .map_err(super::sqlx_err)?;
         Ok(())
     }
 
-    upsert(&mut tx, "total_sessions", &m.total_sessions.to_string()).await?;
-    upsert(&mut tx, "avg_success_rate", &m.avg_success_rate.to_string()).await?;
+    upsert(&mut tx, "total_sessions", &m.total_sessions.to_string(), project).await?;
+    upsert(&mut tx, "avg_success_rate", &m.avg_success_rate.to_string(), project).await?;
     upsert(
         &mut tx,
         "total_evolved_skills",
         &m.total_evolved_skills.to_string(),
+        project,
     )
     .await?;
     if let Some(ref v) = m.last_session {
-        upsert(&mut tx, "last_session", v).await?;
+        upsert(&mut tx, "last_session", v, project).await?;
     }
     if let Some(v) = m.best_score {
-        upsert(&mut tx, "best_score", &v.to_string()).await?;
+        upsert(&mut tx, "best_score", &v.to_string(), project).await?;
     }
-    upsert(&mut tx, "best_session", &m.best_session).await?;
-    upsert(&mut tx, "trend", &m.trend).await?;
-    upsert(&mut tx, "stagnation_count", &m.stagnation_count.to_string()).await?;
+    upsert(&mut tx, "best_session", &m.best_session, project).await?;
+    upsert(&mut tx, "trend", &m.trend, project).await?;
+    upsert(
+        &mut tx,
+        "stagnation_count",
+        &m.stagnation_count.to_string(),
+        project,
+    )
+    .await?;
     if let Some(ref v) = m.last_error_context {
-        upsert(&mut tx, "last_error_context", v).await?;
+        upsert(&mut tx, "last_error_context", v, project).await?;
     }
     upsert(
         &mut tx,
         "reward_hacking_suspected",
         &m.reward_hacking_suspected.to_string(),
+        project,
     )
     .await?;
     if let Some(ref epoch) = m.epoch_class {
         if let Ok(s) = serde_json::to_string(epoch) {
-            upsert(&mut tx, "epoch_class", &s).await?;
+            upsert(&mut tx, "epoch_class", &s, project).await?;
         }
     }
 
-    // Score history — keep the most recent MAX_SCORE_HISTORY entries.
-    sqlx::query("DELETE FROM score_history")
+    // Score history — project-scoped: delete only this project's rows, then
+    // re-insert the most recent MAX_SCORE_HISTORY entries.
+    sqlx::query("DELETE FROM score_history WHERE project = ?")
+        .bind(project)
         .execute(&mut *tx)
         .await
         .map_err(super::sqlx_err)?;
@@ -206,7 +221,7 @@ pub async fn save_metrics_pool(pool: &AnyPool, m: &Metrics) -> io::Result<()> {
     for entry in entries.into_iter().rev() {
         sqlx::query(
             "INSERT INTO score_history (timestamp, success_rate, avg_score, observations,
-             dim_success, dim_quality, dim_cost) VALUES (?,?,?,?,?,?,?)",
+             dim_success, dim_quality, dim_cost, project) VALUES (?,?,?,?,?,?,?,?)",
         )
         .bind(&entry.timestamp)
         .bind(entry.success_rate)
@@ -215,12 +230,14 @@ pub async fn save_metrics_pool(pool: &AnyPool, m: &Metrics) -> io::Result<()> {
         .bind(entry.dimension_averages.tool_success)
         .bind(entry.dimension_averages.output_quality)
         .bind(entry.dimension_averages.execution_cost)
+        .bind(project)
         .execute(&mut *tx)
         .await
         .map_err(super::sqlx_err)?;
     }
 
-    // Skill attribution — UPSERT per skill
+    // Skill attribution — project column not yet in schema (tracked in a
+    // separate issue); left unscoped intentionally.
     for sa in m.skill_attribution.values() {
         sqlx::query(
             "INSERT OR REPLACE INTO skill_attribution
@@ -243,9 +260,10 @@ pub async fn save_metrics_pool(pool: &AnyPool, m: &Metrics) -> io::Result<()> {
 
 /// Standalone save.
 pub fn save_metrics(m: &Metrics) -> io::Result<()> {
+    let project = crate::shared::paths::project_slug().to_string();
     super::runtime::block_on(async {
         let pool = super::pool::harness_pool().await?;
-        save_metrics_pool(&pool, m).await
+        save_metrics_pool(&pool, m, &project).await
     })
 }
 
@@ -254,55 +272,70 @@ pub fn save_metrics(m: &Metrics) -> io::Result<()> {
 pub async fn save_metrics_direct(
     tx: &mut sqlx::Transaction<'_, sqlx::Any>,
     m: &Metrics,
+    project: &str,
 ) -> io::Result<()> {
     async fn upsert(
         tx: &mut sqlx::Transaction<'_, sqlx::Any>,
         key: &str,
         value: &str,
+        project: &str,
     ) -> io::Result<()> {
-        sqlx::query("INSERT OR REPLACE INTO metrics_state (key, value) VALUES (?, ?)")
-            .bind(key)
-            .bind(value)
-            .execute(&mut **tx)
-            .await
-            .map_err(super::sqlx_err)?;
+        sqlx::query(
+            "INSERT INTO metrics_state (key, value, project) VALUES (?, ?, ?) \
+             ON CONFLICT (key, project) DO UPDATE SET value = excluded.value",
+        )
+        .bind(key)
+        .bind(value)
+        .bind(project)
+        .execute(&mut **tx)
+        .await
+        .map_err(super::sqlx_err)?;
         Ok(())
     }
 
-    upsert(tx, "total_sessions", &m.total_sessions.to_string()).await?;
-    upsert(tx, "avg_success_rate", &m.avg_success_rate.to_string()).await?;
+    upsert(tx, "total_sessions", &m.total_sessions.to_string(), project).await?;
+    upsert(tx, "avg_success_rate", &m.avg_success_rate.to_string(), project).await?;
     upsert(
         tx,
         "total_evolved_skills",
         &m.total_evolved_skills.to_string(),
+        project,
     )
     .await?;
     if let Some(ref v) = m.last_session {
-        upsert(tx, "last_session", v).await?;
+        upsert(tx, "last_session", v, project).await?;
     }
     if let Some(v) = m.best_score {
-        upsert(tx, "best_score", &v.to_string()).await?;
+        upsert(tx, "best_score", &v.to_string(), project).await?;
     }
-    upsert(tx, "best_session", &m.best_session).await?;
-    upsert(tx, "trend", &m.trend).await?;
-    upsert(tx, "stagnation_count", &m.stagnation_count.to_string()).await?;
+    upsert(tx, "best_session", &m.best_session, project).await?;
+    upsert(tx, "trend", &m.trend, project).await?;
+    upsert(
+        tx,
+        "stagnation_count",
+        &m.stagnation_count.to_string(),
+        project,
+    )
+    .await?;
     if let Some(ref v) = m.last_error_context {
-        upsert(tx, "last_error_context", v).await?;
+        upsert(tx, "last_error_context", v, project).await?;
     }
     upsert(
         tx,
         "reward_hacking_suspected",
         &m.reward_hacking_suspected.to_string(),
+        project,
     )
     .await?;
     if let Some(ref epoch) = m.epoch_class {
         if let Ok(s) = serde_json::to_string(epoch) {
-            upsert(tx, "epoch_class", &s).await?;
+            upsert(tx, "epoch_class", &s, project).await?;
         }
     }
 
-    // Score history
-    sqlx::query("DELETE FROM score_history")
+    // Score history — project-scoped.
+    sqlx::query("DELETE FROM score_history WHERE project = ?")
+        .bind(project)
         .execute(&mut **tx)
         .await
         .map_err(super::sqlx_err)?;
@@ -316,7 +349,7 @@ pub async fn save_metrics_direct(
     for entry in entries.into_iter().rev() {
         sqlx::query(
             "INSERT INTO score_history (timestamp, success_rate, avg_score, observations,
-             dim_success, dim_quality, dim_cost) VALUES (?,?,?,?,?,?,?)",
+             dim_success, dim_quality, dim_cost, project) VALUES (?,?,?,?,?,?,?,?)",
         )
         .bind(&entry.timestamp)
         .bind(entry.success_rate)
@@ -325,6 +358,7 @@ pub async fn save_metrics_direct(
         .bind(entry.dimension_averages.tool_success)
         .bind(entry.dimension_averages.output_quality)
         .bind(entry.dimension_averages.execution_cost)
+        .bind(project)
         .execute(&mut **tx)
         .await
         .map_err(super::sqlx_err)?;
@@ -565,19 +599,12 @@ pub async fn load_metrics_scoped_pool(
         })
         .collect();
 
-    // Skill attribution — filter by project, or all.
-    let sa_rows = if let Some(p) = project {
-        sqlx::query(
-            "SELECT skill_name, sessions_active, avg_score_with, avg_score_without, first_seen
-             FROM skill_attribution WHERE project = ?",
-        )
-        .bind(p)
-    } else {
-        sqlx::query(
-            "SELECT skill_name, sessions_active, avg_score_with, avg_score_without, first_seen
-             FROM skill_attribution",
-        )
-    }
+    // Skill attribution — not yet project-scoped: the table has no project
+    // column yet (#91). Return all rows regardless of the requested project.
+    let sa_rows = sqlx::query(
+        "SELECT skill_name, sessions_active, avg_score_with, avg_score_without, first_seen
+         FROM skill_attribution",
+    )
     .fetch_all(pool)
     .await
     .map_err(super::sqlx_err)?;
@@ -675,7 +702,7 @@ mod tests {
     async fn save_and_load_metrics() {
         let pool = test_pool().await;
         let m = sample_metrics();
-        save_metrics_pool(&pool, &m).await.unwrap();
+        save_metrics_pool(&pool, &m, "test-project").await.unwrap();
 
         let loaded = load_metrics_pool(&pool).await.unwrap();
         assert_eq!(loaded.total_sessions, 10);
@@ -695,7 +722,7 @@ mod tests {
     async fn save_and_load_metrics_round_trips_reward_hacking_flag() {
         let pool = test_pool().await;
         let m = sample_metrics_reward_hacking();
-        save_metrics_pool(&pool, &m).await.unwrap();
+        save_metrics_pool(&pool, &m, "test-project").await.unwrap();
 
         let loaded = load_metrics_pool(&pool).await.unwrap();
         assert!(
@@ -730,7 +757,7 @@ mod tests {
                 dimension_averages: ScoreDimensions::default(),
             });
         }
-        save_metrics_pool(&pool, &m).await.unwrap();
+        save_metrics_pool(&pool, &m, "test-project").await.unwrap();
 
         let loaded = load_metrics_pool(&pool).await.unwrap();
         assert!(loaded.score_history.len() <= 50);
@@ -743,6 +770,56 @@ mod tests {
             first.observations >= 10,
             "expected observations >= 10, got {}",
             first.observations
+        );
+    }
+
+    #[tokio::test]
+    async fn metrics_state_isolates_by_project() {
+        // AC1: writers scoped to project; a scoped read returns only that
+        // project's rows. Requires the composite PK (key, project).
+        let pool = test_pool().await;
+        let mut a = sample_metrics();
+        a.total_sessions = 5;
+        save_metrics_pool(&pool, &a, "proj-a").await.unwrap();
+
+        let mut b = sample_metrics();
+        b.total_sessions = 99;
+        save_metrics_pool(&pool, &b, "proj-b").await.unwrap();
+
+        let la = load_metrics_scoped_pool(&pool, Some("proj-a"))
+            .await
+            .unwrap();
+        let lb = load_metrics_scoped_pool(&pool, Some("proj-b"))
+            .await
+            .unwrap();
+        assert_eq!(la.total_sessions, 5, "proj-a must not be overwritten by proj-b");
+        assert_eq!(lb.total_sessions, 99);
+    }
+
+    #[tokio::test]
+    async fn score_history_delete_is_project_scoped() {
+        // AC3: saving proj-a must not wipe proj-b's score_history.
+        let pool = test_pool().await;
+        let mut b = sample_metrics();
+        b.score_history.push(SessionScoreEntry {
+            timestamp: "2026-06-01T10:00:00Z".into(),
+            success_rate: 0.9,
+            avg_score: 0.85,
+            observations: 1,
+            dimension_averages: ScoreDimensions::default(),
+        });
+        save_metrics_pool(&pool, &b, "proj-b").await.unwrap();
+
+        let a = sample_metrics();
+        save_metrics_pool(&pool, &a, "proj-a").await.unwrap();
+
+        let lb = load_metrics_scoped_pool(&pool, Some("proj-b"))
+            .await
+            .unwrap();
+        assert_eq!(
+            lb.score_history.len(),
+            2,
+            "proj-b score_history must survive a proj-a save"
         );
     }
 }

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -36,6 +36,10 @@ pub async fn init_schema_pool(pool: &AnyPool) -> io::Result<()> {
     )
     .await?;
 
+    // Rebuild metrics_state PK (key) -> (key, project) for legacy databases.
+    // New databases already get the composite PK from DDL_SQLITE above.
+    migrate_metrics_state_pk(pool).await?;
+
     Ok(())
 }
 
@@ -69,6 +73,88 @@ async fn ensure_column(
             .await
             .map_err(super::sqlx_err)?;
     }
+    Ok(())
+}
+
+/// Migrate `metrics_state` primary key from `(key)` to `(key, project)`.
+///
+/// SQLite cannot ALTER an existing table's primary key, so for legacy
+/// databases we rebuild the table (create-copy-drop-rename) inside a
+/// transaction. New databases already get the composite PK from `DDL_SQLITE`.
+/// Idempotent: guarded by `_harness_meta.metrics_pk_v2` and a
+/// `pragma_table_info` PK-column count check.
+async fn migrate_metrics_state_pk(pool: &AnyPool) -> io::Result<()> {
+    let done: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM _harness_meta WHERE key = 'metrics_pk_v2' AND value = '1'",
+    )
+    .fetch_one(pool)
+    .await
+    .map_err(super::sqlx_err)?;
+
+    if done > 0 {
+        return Ok(());
+    }
+
+    // Number of columns participating in the PK: (key) = 1, (key, project) = 2.
+    let pk_cols: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM pragma_table_info('metrics_state') WHERE pk > 0")
+            .fetch_one(pool)
+            .await
+            .map_err(super::sqlx_err)?;
+
+    if pk_cols >= 2 {
+        // Already composite (new DB) — just stamp the guard.
+        sqlx::query(
+            "INSERT INTO _harness_meta (key, value) VALUES ('metrics_pk_v2', '1') \
+             ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+        )
+        .execute(pool)
+        .await
+        .map_err(super::sqlx_err)?;
+        return Ok(());
+    }
+
+    // Legacy single-PK table: rebuild to composite PK in one transaction.
+    let mut tx = pool.begin().await.map_err(super::sqlx_err)?;
+
+    sqlx::query(
+        "CREATE TABLE metrics_state_new (\
+            key TEXT NOT NULL, value TEXT NOT NULL, \
+            project TEXT NOT NULL DEFAULT '', \
+            PRIMARY KEY (key, project))",
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(super::sqlx_err)?;
+
+    sqlx::query(
+        "INSERT INTO metrics_state_new (key, value, project) \
+         SELECT key, value, COALESCE(project, '') FROM metrics_state \
+         ON CONFLICT (key, project) DO UPDATE SET value = excluded.value",
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(super::sqlx_err)?;
+
+    sqlx::query("DROP TABLE metrics_state")
+        .execute(&mut *tx)
+        .await
+        .map_err(super::sqlx_err)?;
+
+    sqlx::query("ALTER TABLE metrics_state_new RENAME TO metrics_state")
+        .execute(&mut *tx)
+        .await
+        .map_err(super::sqlx_err)?;
+
+    sqlx::query(
+        "INSERT INTO _harness_meta (key, value) VALUES ('metrics_pk_v2', '1') \
+         ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(super::sqlx_err)?;
+
+    tx.commit().await.map_err(super::sqlx_err)?;
     Ok(())
 }
 
@@ -140,9 +226,10 @@ pub(crate) const DDL_SQLITE: &str = r#"
     CREATE INDEX IF NOT EXISTS idx_evo_ts ON evolution_records(timestamp DESC);
 
     CREATE TABLE IF NOT EXISTS metrics_state (
-        key     TEXT PRIMARY KEY,
+        key     TEXT NOT NULL,
         value   TEXT NOT NULL,
-        project TEXT NOT NULL DEFAULT ''
+        project TEXT NOT NULL DEFAULT '',
+        PRIMARY KEY (key, project)
     );
 
     CREATE TABLE IF NOT EXISTS score_history (


### PR DESCRIPTION
## Summary
Close the project-scoping gap so the evolution dashboard reflects the selected project across the metrics/evolution panels. **Closes #84** (root cause); partially addresses **#83** (file-based reader arms tracked in **#91**).

## Changes
- `metrics_state` writers (`save_metrics_pool`/`save_metrics_direct`) bind `project`; `INSERT OR REPLACE` → `ON CONFLICT (key, project)`.
- `metrics_state` PK `(key)` → `(key, project)` via idempotent **table-rebuild migration** (`_harness_meta.metrics_pk_v2`, transaction-wrapped, `pragma_table_info` PK detection, DDL synced).
- `score_history`: scoped `DELETE ... WHERE project = ?` + `project` column bind (no cross-project wipe).
- `evolution_records` writer (`insert_record_pool`) binds `project`; `reflect.rs` callers pass `project_slug()`.
- `serve.rs` `get_adaptation_landscape` → scoped reader.
- `load_metrics_scoped_pool` skill_attribution query: drop `WHERE project` (column absent; tracked in #91).

## Spec / Pipeline
SPEC-20260619004500.md · PIPELINE-20260618165444 (orbit, council mode)

## Acceptance Criteria
AC1 ✅  AC2 ✅ (composite PK via isolation test)  AC3 ✅  AC4 ⚠ (landscape scoped; file-based arms → #91)  AC5 ✅

## Test Plan
- [x] cargo test --lib: 646 passed
- [x] cargo clippy --all-targets -- -D warnings: clean
- [ ] CI green

## Follow-ups
#91 — file-based reader arms (seesaw/variants/snapshot/manifests) + skill_attribution project column.