### PR TITLE
feat(dashboard): project-scope file-based readers + skill_attribution (#91)

### DIFF
--- a/src/evolve/seesaw.rs
+++ b/src/evolve/seesaw.rs
@@ -29,7 +29,13 @@ pub const DEFAULT_TOLERANCE: f64 = 0.1;
 
 /// Load the solved-task registry from disk, or return an empty one.
 pub fn load_registry() -> SolvedTaskRegistry {
-    let path = crate::shared::paths::project_seesaw_path();
+    load_registry_for(None)
+}
+
+/// Project-scoped load: reads `seesaw.json` from the requested project's dir
+/// (None/empty = CWD project, the pre-existing behavior).
+pub fn load_registry_for(project: Option<&str>) -> SolvedTaskRegistry {
+    let path = crate::shared::paths::project_seesaw_path_for(project);
     match std::fs::read_to_string(&path) {
         Ok(s) => serde_json::from_str(&s).unwrap_or_default(),
         Err(_) => SolvedTaskRegistry::default(),

--- a/src/evolve/snapshot.rs
+++ b/src/evolve/snapshot.rs
@@ -18,9 +18,8 @@ use serde_json::Value;
 use crate::config::CONFIG;
 use crate::shared::evolution::{ConfigSummary, HarnessSnapshot, MetricsSummary};
 use crate::shared::helpers::list_dirs;
-use crate::shared::paths::{evolved_dir, guard_rules_file, project_slug};
+use crate::shared::paths::{evolved_dir_for, guard_rules_file, project_slug};
 use crate::shared::types::current_hook_profile;
-use crate::store::metrics::load_metrics;
 
 /// Recursively collect every leaf value in a JSON tree as dotted "path=value"
 /// strings, sorted canonically. Used so the hash is insensitive to map key
@@ -123,16 +122,23 @@ fn read_guard_rule_lines() -> Vec<String> {
 
 /// Build a MetricsSummary from the project's metrics, defaulting gracefully
 /// when the DB has no data yet (cold start).
-fn metrics_summary() -> MetricsSummary {
-    match load_metrics() {
-        Ok(m) => MetricsSummary {
+/// Project-scoped metrics summary via the scoped loader (None/empty = CWD).
+fn metrics_summary_for(project: Option<&str>) -> MetricsSummary {
+    let m = crate::store::runtime::block_on(async {
+        let pool = crate::store::pool::harness_pool().await.ok()?;
+        crate::store::metrics::load_metrics_scoped_pool(&pool, project)
+            .await
+            .ok()
+    });
+    match m {
+        Some(m) => MetricsSummary {
             total_sessions: m.total_sessions,
             best_score: m.best_score,
             trend: m.trend,
             total_evolved: m.total_evolved_skills,
             stagnation_count: m.stagnation_count,
         },
-        Err(_) => MetricsSummary::default(),
+        None => MetricsSummary::default(),
     }
 }
 
@@ -155,7 +161,13 @@ fn config_summary() -> ConfigSummary {
 /// Pure read: touches only `evolved_dir`, `guard_rules_file`, the metrics DB,
 /// and the resolved CONFIG. Never mutates state.
 pub fn build_snapshot() -> HarnessSnapshot {
-    let evolved = evolved_dir();
+    build_snapshot_for(None)
+}
+
+/// Project-scoped snapshot: reads the evolved dir + metrics for the requested
+/// project (None/empty = CWD project, the pre-existing behavior).
+pub fn build_snapshot_for(project: Option<&str>) -> HarnessSnapshot {
+    let evolved = evolved_dir_for(project);
     // `evolved_dir` holds auto-evolved skills; treat those as both the active
     // and evolved skill sets (static skills ship in the binary and are not
     // per-project state). Listing the same dir for both is intentional — it
@@ -166,7 +178,7 @@ pub fn build_snapshot() -> HarnessSnapshot {
 
     let guard_rules = read_guard_rule_lines();
     let config = config_summary();
-    let metrics = metrics_summary();
+    let metrics = metrics_summary_for(project);
 
     // ISO-8601-ish UTC timestamp (stdlib only — no chrono dep required).
     let timestamp = {
@@ -177,7 +189,10 @@ pub fn build_snapshot() -> HarnessSnapshot {
         format!("{secs}")
     };
 
-    let project_slug = project_slug();
+    let project_slug = match project {
+        Some(p) if !p.is_empty() => p.to_string(),
+        _ => project_slug(),
+    };
 
     // Compute hash from a snapshot with empty placeholder hash/timestamp so the
     // hash field does not feed into itself.

--- a/src/evolve/snapshot.rs
+++ b/src/evolve/snapshot.rs
@@ -166,6 +166,10 @@ pub fn build_snapshot() -> HarnessSnapshot {
 
 /// Project-scoped snapshot: reads the evolved dir + metrics for the requested
 /// project (None/empty = CWD project, the pre-existing behavior).
+///
+/// Scope note: only `evolved_dir` and `metrics_summary` vary by project.
+/// `guard_rules` (project-tree/global file) and `config_summary` (global
+/// CONFIG) are intentionally project-independent.
 pub fn build_snapshot_for(project: Option<&str>) -> HarnessSnapshot {
     let evolved = evolved_dir_for(project);
     // `evolved_dir` holds auto-evolved skills; treat those as both the active

--- a/src/evolve/variants.rs
+++ b/src/evolve/variants.rs
@@ -52,7 +52,13 @@ impl VariantPool {
     /// `variants.json` must NOT panic — it resets to an empty pool so the
     /// session degrades gracefully rather than crashing every dispatch.
     pub fn load() -> VariantPool {
-        let path = crate::shared::paths::variant_pool_path();
+        VariantPool::load_for(None)
+    }
+
+    /// Project-scoped load: reads `variants.json` from the requested project's
+    /// dir (None/empty = CWD project, the pre-existing behavior).
+    pub fn load_for(project: Option<&str>) -> VariantPool {
+        let path = crate::shared::paths::variant_pool_path_for(project);
         match std::fs::read_to_string(&path) {
             Ok(s) => serde_json::from_str(&s).unwrap_or_default(),
             Err(_) => VariantPool::default(),

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -859,15 +859,15 @@ fn handle_harness_cmd(cmd: &str, harness_dir: &std::path::Path, project: Option<
         // adaptation-landscape state. Each is a thin reader; computation
         // stays in the evolve modules.
         "get_seesaw_registry" => {
-            let reg = crate::evolve::seesaw::load_registry();
+            let reg = crate::evolve::seesaw::load_registry_for(project);
             serde_json::to_string(&reg).unwrap_or_else(|_| "null".into())
         }
         "get_variant_pool" => {
-            let pool = crate::evolve::variants::VariantPool::load();
+            let pool = crate::evolve::variants::VariantPool::load_for(project);
             serde_json::to_string(&pool).unwrap_or_else(|_| "null".into())
         }
         "get_harness_snapshot" => {
-            let snap = crate::evolve::snapshot::build_snapshot();
+            let snap = crate::evolve::snapshot::build_snapshot_for(project);
             serde_json::to_string(&snap).unwrap_or_else(|_| "null".into())
         }
         "get_adaptation_landscape" => {
@@ -888,7 +888,7 @@ fn handle_harness_cmd(cmd: &str, harness_dir: &std::path::Path, project: Option<
         "get_manifests" => {
             // Tail-read the falsifiability ledger sidecar (manifests.jsonl).
             // Cap at the most recent 50 to bound payload size.
-            let path = crate::shared::paths::manifests_file();
+            let path = crate::shared::paths::manifests_file_for(project);
             let mut items: Vec<serde_json::Value> = Vec::new();
             if let Ok(text) = std::fs::read_to_string(&path) {
                 for line in text.lines().rev().take(50) {

--- a/src/shared/paths.rs
+++ b/src/shared/paths.rs
@@ -187,6 +187,31 @@ pub fn manifests_file() -> PathBuf {
     harness_dir().join("manifests.jsonl")
 }
 
+/// Resolve the per-project harness dir for a request. Falls back to the
+/// CWD-derived dir when `project` is `None`/empty (preserves existing callers
+/// that don't pass a project). Used by the dashboard read-path to scope
+/// file-backed readers (seesaw/variants/snapshot/manifests) to the selected
+/// project.
+pub fn resolve_harness_dir(project: Option<&str>) -> PathBuf {
+    match project {
+        Some(p) if !p.is_empty() => harness_dir_for_slug(p),
+        _ => harness_dir(),
+    }
+}
+
+pub fn project_seesaw_path_for(project: Option<&str>) -> PathBuf {
+    resolve_harness_dir(project).join("seesaw.json")
+}
+pub fn variant_pool_path_for(project: Option<&str>) -> PathBuf {
+    resolve_harness_dir(project).join("variants.json")
+}
+pub fn evolved_dir_for(project: Option<&str>) -> PathBuf {
+    resolve_harness_dir(project).join("evolved")
+}
+pub fn manifests_file_for(project: Option<&str>) -> PathBuf {
+    resolve_harness_dir(project).join("manifests.jsonl")
+}
+
 /// guard-rules.yaml stays in the project tree only if the user/team explicitly
 /// created it there. Otherwise, we default to the per-project global directory
 /// to keep the project tree clean.

--- a/src/shared/paths.rs
+++ b/src/shared/paths.rs
@@ -295,3 +295,24 @@ pub fn claude_plugin_cache_dir() -> PathBuf {
     }
     claude_config_dir().join("plugins")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_path_helpers_resolve_by_slug() {
+        // AC1: file-backed reader paths scope to the requested project.
+        // Distinct slugs → distinct dirs; None/"" fall back to the CWD default.
+        let a = project_seesaw_path_for(Some("proj-a"));
+        let b = project_seesaw_path_for(Some("proj-b"));
+        assert_ne!(a, b);
+        assert!(a.to_string_lossy().contains("proj-a"));
+        assert!(b.to_string_lossy().contains("proj-b"));
+        // None and "" both resolve to the CWD harness_dir.
+        assert_eq!(
+            project_seesaw_path_for(None),
+            project_seesaw_path_for(Some(""))
+        );
+    }
+}

--- a/src/store/metrics.rs
+++ b/src/store/metrics.rs
@@ -861,4 +861,56 @@ mod tests {
             "proj-b score_history must survive a proj-a save"
         );
     }
+
+    #[tokio::test]
+    async fn skill_attribution_isolates_by_project() {
+        // AC2: skill_attribution rows are scoped to (skill_name, project).
+        let pool = test_pool().await;
+        let mut a = sample_metrics();
+        a.skill_attribution.clear();
+        a.skill_attribution.insert(
+            "skill-a".into(),
+            SkillAttribution {
+                skill_name: "skill-a".into(),
+                sessions_active: 1,
+                avg_score_with: 0.8,
+                avg_score_without: 0.5,
+                first_seen: "2026-06-19".into(),
+            },
+        );
+        save_metrics_pool(&pool, &a, "proj-a").await.unwrap();
+
+        let mut b = sample_metrics();
+        b.skill_attribution.clear();
+        b.skill_attribution.insert(
+            "skill-b".into(),
+            SkillAttribution {
+                skill_name: "skill-b".into(),
+                sessions_active: 2,
+                avg_score_with: 0.7,
+                avg_score_without: 0.4,
+                first_seen: "2026-06-19".into(),
+            },
+        );
+        save_metrics_pool(&pool, &b, "proj-b").await.unwrap();
+
+        let la = load_metrics_scoped_pool(&pool, Some("proj-a"))
+            .await
+            .unwrap();
+        let lb = load_metrics_scoped_pool(&pool, Some("proj-b"))
+            .await
+            .unwrap();
+        assert!(la.skill_attribution.contains_key("skill-a"));
+        assert!(!la.skill_attribution.contains_key("skill-b"));
+        assert!(lb.skill_attribution.contains_key("skill-b"));
+        assert!(!lb.skill_attribution.contains_key("skill-a"));
+    }
+
+    #[tokio::test]
+    async fn init_schema_pool_is_idempotent() {
+        // AC2: re-running init (and thus both PK migrations) must be a no-op.
+        let pool = super::super::pool::test_memory_pool().await;
+        super::super::schema::init_schema_pool(&pool).await.unwrap();
+        super::super::schema::init_schema_pool(&pool).await.unwrap();
+    }
 }

--- a/src/store/metrics.rs
+++ b/src/store/metrics.rs
@@ -248,19 +248,24 @@ pub async fn save_metrics_pool(pool: &AnyPool, m: &Metrics, project: &str) -> io
         .map_err(super::sqlx_err)?;
     }
 
-    // Skill attribution — project column not yet in schema (tracked in a
-    // separate issue); left unscoped intentionally.
+    // Skill attribution — scoped to (skill_name, project).
     for sa in m.skill_attribution.values() {
         sqlx::query(
-            "INSERT OR REPLACE INTO skill_attribution
-             (skill_name, sessions_active, avg_score_with, avg_score_without, first_seen)
-             VALUES (?,?,?,?,?)",
+            "INSERT INTO skill_attribution
+             (skill_name, sessions_active, avg_score_with, avg_score_without, first_seen, project)
+             VALUES (?,?,?,?,?,?)
+             ON CONFLICT (skill_name, project) DO UPDATE SET
+                sessions_active = excluded.sessions_active,
+                avg_score_with = excluded.avg_score_with,
+                avg_score_without = excluded.avg_score_without,
+                first_seen = excluded.first_seen",
         )
         .bind(&sa.skill_name)
         .bind(super::u64_to_i64(sa.sessions_active))
         .bind(sa.avg_score_with)
         .bind(sa.avg_score_without)
         .bind(&sa.first_seen)
+        .bind(project)
         .execute(&mut *tx)
         .await
         .map_err(super::sqlx_err)?;
@@ -382,18 +387,24 @@ pub async fn save_metrics_direct(
         .map_err(super::sqlx_err)?;
     }
 
-    // Skill attribution
+    // Skill attribution — scoped to (skill_name, project).
     for sa in m.skill_attribution.values() {
         sqlx::query(
-            "INSERT OR REPLACE INTO skill_attribution
-             (skill_name, sessions_active, avg_score_with, avg_score_without, first_seen)
-             VALUES (?,?,?,?,?)",
+            "INSERT INTO skill_attribution
+             (skill_name, sessions_active, avg_score_with, avg_score_without, first_seen, project)
+             VALUES (?,?,?,?,?,?)
+             ON CONFLICT (skill_name, project) DO UPDATE SET
+                sessions_active = excluded.sessions_active,
+                avg_score_with = excluded.avg_score_with,
+                avg_score_without = excluded.avg_score_without,
+                first_seen = excluded.first_seen",
         )
         .bind(&sa.skill_name)
         .bind(super::u64_to_i64(sa.sessions_active))
         .bind(sa.avg_score_with)
         .bind(sa.avg_score_without)
         .bind(&sa.first_seen)
+        .bind(project)
         .execute(&mut **tx)
         .await
         .map_err(super::sqlx_err)?;
@@ -617,12 +628,19 @@ pub async fn load_metrics_scoped_pool(
         })
         .collect();
 
-    // Skill attribution — not yet project-scoped: the table has no project
-    // column yet (#91). Return all rows regardless of the requested project.
-    let sa_rows = sqlx::query(
-        "SELECT skill_name, sessions_active, avg_score_with, avg_score_without, first_seen
-         FROM skill_attribution",
-    )
+    // Skill attribution — scoped by project (Some), or all (None).
+    let sa_rows = if let Some(p) = project {
+        sqlx::query(
+            "SELECT skill_name, sessions_active, avg_score_with, avg_score_without, first_seen
+             FROM skill_attribution WHERE project = ?",
+        )
+        .bind(p)
+    } else {
+        sqlx::query(
+            "SELECT skill_name, sessions_active, avg_score_with, avg_score_without, first_seen
+             FROM skill_attribution",
+        )
+    }
     .fetch_all(pool)
     .await
     .map_err(super::sqlx_err)?;

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -39,6 +39,7 @@ pub async fn init_schema_pool(pool: &AnyPool) -> io::Result<()> {
     // Rebuild metrics_state PK (key) -> (key, project) for legacy databases.
     // New databases already get the composite PK from DDL_SQLITE above.
     migrate_metrics_state_pk(pool).await?;
+    migrate_skill_attribution_pk(pool).await?;
 
     Ok(())
 }
@@ -83,6 +84,85 @@ async fn ensure_column(
 /// transaction. New databases already get the composite PK from `DDL_SQLITE`.
 /// Idempotent: guarded by `_harness_meta.metrics_pk_v2` and a
 /// `pragma_table_info` PK-column count check.
+async fn migrate_skill_attribution_pk(pool: &AnyPool) -> io::Result<()> {
+    let done: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM _harness_meta WHERE key = 'skill_attribution_pk_v2' AND value = '1'",
+    )
+    .fetch_one(pool)
+    .await
+    .map_err(super::sqlx_err)?;
+    if done > 0 {
+        return Ok(());
+    }
+
+    let pk_cols: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info('skill_attribution') WHERE pk > 0",
+    )
+    .fetch_one(pool)
+    .await
+    .map_err(super::sqlx_err)?;
+
+    if pk_cols >= 2 {
+        sqlx::query(
+            "INSERT INTO _harness_meta (key, value) VALUES ('skill_attribution_pk_v2', '1') \
+             ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+        )
+        .execute(pool)
+        .await
+        .map_err(super::sqlx_err)?;
+        return Ok(());
+    }
+
+    // Legacy single-PK table: rebuild to composite PK in one transaction.
+    let mut tx = pool.begin().await.map_err(super::sqlx_err)?;
+
+    sqlx::query(
+        "CREATE TABLE skill_attribution_new (\
+            skill_name TEXT NOT NULL, sessions_active INTEGER NOT NULL DEFAULT 0, \
+            avg_score_with REAL NOT NULL DEFAULT 0.0, avg_score_without REAL NOT NULL DEFAULT 0.0, \
+            first_seen TEXT NOT NULL, project TEXT NOT NULL DEFAULT '', \
+            PRIMARY KEY (skill_name, project))",
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(super::sqlx_err)?;
+
+    sqlx::query(
+        "INSERT INTO skill_attribution_new \
+            (skill_name, sessions_active, avg_score_with, avg_score_without, first_seen, project) \
+         SELECT skill_name, sessions_active, avg_score_with, avg_score_without, first_seen, '' \
+         FROM skill_attribution \
+         ON CONFLICT (skill_name, project) DO UPDATE SET \
+            sessions_active = excluded.sessions_active, \
+            avg_score_with = excluded.avg_score_with, \
+            avg_score_without = excluded.avg_score_without, \
+            first_seen = excluded.first_seen",
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(super::sqlx_err)?;
+
+    sqlx::query("DROP TABLE skill_attribution")
+        .execute(&mut *tx)
+        .await
+        .map_err(super::sqlx_err)?;
+    sqlx::query("ALTER TABLE skill_attribution_new RENAME TO skill_attribution")
+        .execute(&mut *tx)
+        .await
+        .map_err(super::sqlx_err)?;
+
+    sqlx::query(
+        "INSERT INTO _harness_meta (key, value) VALUES ('skill_attribution_pk_v2', '1') \
+         ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(super::sqlx_err)?;
+
+    tx.commit().await.map_err(super::sqlx_err)?;
+    Ok(())
+}
+
 async fn migrate_metrics_state_pk(pool: &AnyPool) -> io::Result<()> {
     let done: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM _harness_meta WHERE key = 'metrics_pk_v2' AND value = '1'",
@@ -245,11 +325,13 @@ pub(crate) const DDL_SQLITE: &str = r#"
     );
 
     CREATE TABLE IF NOT EXISTS skill_attribution (
-        skill_name        TEXT PRIMARY KEY,
+        skill_name        TEXT NOT NULL,
         sessions_active   INTEGER NOT NULL DEFAULT 0,
         avg_score_with    REAL NOT NULL DEFAULT 0.0,
         avg_score_without REAL NOT NULL DEFAULT 0.0,
-        first_seen        TEXT NOT NULL
+        first_seen        TEXT NOT NULL,
+        project           TEXT NOT NULL DEFAULT '',
+        PRIMARY KEY (skill_name, project)
     );
 
     CREATE TABLE IF NOT EXISTS orch_runs (

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -84,6 +84,12 @@ async fn ensure_column(
 /// transaction. New databases already get the composite PK from `DDL_SQLITE`.
 /// Idempotent: guarded by `_harness_meta.metrics_pk_v2` and a
 /// `pragma_table_info` PK-column count check.
+/// Migrate `skill_attribution` PK `(skill_name)` → `(skill_name, project)`.
+///
+/// Legacy rows are attributed to `project=''` (single-project assumption —
+/// the writer had no project binding before this change). A multi-project
+/// legacy DB would collapse pre-existing rows to one `(skill_name, '')`, which
+/// is acceptable since pre-#92 data was CWD-only.
 async fn migrate_skill_attribution_pk(pool: &AnyPool) -> io::Result<()> {
     let done: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM _harness_meta WHERE key = 'skill_attribution_pk_v2' AND value = '1'",


### PR DESCRIPTION
## Summary
**Closes #91** — completes the project-scoping work (#83/#84/#92) so every evolution-dashboard panel reflects the selected project. Threads `project` through the file-based readers and adds a `skill_attribution` project column.

## Changes
- **paths.rs**: `resolve_harness_dir(project)` + `_for(project)` helpers for seesaw/variants/evolved/manifests.
- **seesaw/variants/snapshot**: `load_registry_for(project)`, `VariantPool::load_for(project)`, `build_snapshot_for(project)` (existing no-arg fns delegate to `_for(None)`, preserving all current callers).
- **snapshot** `metrics_summary_for(project)` uses the scoped loader (`load_metrics_scoped_pool`).
- **serve.rs**: 4 arms (`get_seesaw_registry`/`get_variant_pool`/`get_harness_snapshot`/`get_manifests`) pass `project` through.
- **skill_attribution**: composite PK `(skill_name, project)` via idempotent table-rebuild migration (`_harness_meta.skill_attribution_pk_v2`); writer binds `project` with `ON CONFLICT (skill_name, project)`; scoped `load_metrics_scoped_pool` filters `WHERE project = ?`.

## Acceptance Criteria
- AC1 ✅ switching `project` changes seesaw/variants/snapshot/manifests data (readers now project-aware).
- AC2 ✅ skill_attribution migration idempotent + scoped (no more "no such column: project").
- AC3 ✅ `cargo test --lib` 646 passed; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --check` clean.

## Test Plan
- [x] cargo test --lib: 646 passed
- [x] clippy --all-targets -D warnings: clean
- [x] cargo fmt --check: clean
- [ ] CI green