### PR TITLE
fix(evolve): from_db_str Unknown + edit_type test + token_estimate scaffold (#81)

### DIFF
--- a/src/evolve/digester.rs
+++ b/src/evolve/digester.rs
@@ -240,6 +240,10 @@ fn tool_sequence(seg: &[&ObsRecord]) -> Vec<String> {
 }
 
 /// Rough token estimate: ~4 chars per token across action + result + snippet text.
+///
+/// Scaffold (#81 item 3): stored on `TaskDigest.token_estimate` but no
+/// gate/proposal reads it yet. Kept so the field stays populated for future
+/// planner cost-weighting.
 fn estimate_tokens(seg: &[&ObsRecord]) -> usize {
     let chars: usize = seg
         .iter()

--- a/src/shared/evolution.rs
+++ b/src/shared/evolution.rs
@@ -24,6 +24,10 @@ pub enum EditType {
     AddGuardRule,
     /// Modify an existing skill's prompt (auto-tuning).
     ModifyPrompt,
+    /// An unrecognized/legacy DB value. Not a real edit; used so unknown rows
+    /// don't get silently distorted into `AddSkill` and pollute edit-type
+    /// coverage. Excluded from `all()` (never an "untried" edit).
+    Unknown,
 }
 
 impl EditType {
@@ -47,20 +51,25 @@ impl EditType {
             EditType::ModifyConfig => "modify_config",
             EditType::AddGuardRule => "add_guard_rule",
             EditType::ModifyPrompt => "modify_prompt",
+            EditType::Unknown => "unknown",
         }
     }
 
     /// Parse an edit type from its database string representation.
-    /// Falls back to `AddSkill` for unknown/legacy values, which is the
-    /// historically dominant edit type and the safe default.
+    ///
+    /// Unknown/legacy values decode to `Unknown` rather than being silently
+    /// distorted into `AddSkill` (which would mis-count edit-type coverage).
+    /// `Unknown` is excluded from `all()` so it never appears as an "untried"
+    /// edit in the planner.
     pub fn from_db_str(s: &str) -> Self {
         match s {
+            "add_skill" => EditType::AddSkill,
             "modify_skill" => EditType::ModifySkill,
             "add_instinct" => EditType::AddInstinct,
             "modify_config" => EditType::ModifyConfig,
             "add_guard_rule" => EditType::AddGuardRule,
             "modify_prompt" => EditType::ModifyPrompt,
-            _ => EditType::AddSkill,
+            _ => EditType::Unknown,
         }
     }
 }
@@ -324,6 +333,10 @@ pub struct TaskDigest {
     /// Number of previous iterations this task was seen (cross-iteration persistence).
     pub iterations_seen: u32,
     /// Estimated token count of the original trace segment.
+    ///
+    /// Scaffold (#81 item 3): populated by `digester::estimate_tokens` but not
+    /// yet read by any gate/proposal. Retained for future planner
+    /// cost-weighting.
     pub token_estimate: usize,
     /// Number of observations in this segment.
     pub observation_count: u64,
@@ -498,4 +511,29 @@ pub struct SkillVariant {
     pub avg_score: f64,
     /// Patterns that route tasks to this variant.
     pub task_routing: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EditType;
+
+    #[test]
+    fn from_db_str_unknown_is_not_distorted_to_add_skill() {
+        // AC1 (#81 item 1): unknown DB values decode to Unknown, not AddSkill.
+        assert_eq!(EditType::from_db_str("bogus_type"), EditType::Unknown);
+        assert_eq!(EditType::from_db_str(""), EditType::Unknown);
+        // Known values still decode — incl. add_skill, which the old wildcard
+        // arm caught (must stay explicit after the fallback changed).
+        assert_eq!(EditType::from_db_str("add_skill"), EditType::AddSkill);
+        assert_eq!(
+            EditType::from_db_str("modify_prompt"),
+            EditType::ModifyPrompt
+        );
+    }
+
+    #[test]
+    fn unknown_excluded_from_all() {
+        // Unknown must never show up as an "untried" edit in coverage analysis.
+        assert!(!EditType::all().contains(&EditType::Unknown));
+    }
 }

--- a/src/store/evolution.rs
+++ b/src/store/evolution.rs
@@ -212,9 +212,9 @@ mod tests {
     async fn edit_type_roundtrips() {
         // R1: edit_type must persist and read back for every variant.
         let pool = test_pool().await;
-        for ty in crate::shared::evolution::EditType::all() {
+        for (i, ty) in crate::shared::evolution::EditType::all().iter().enumerate() {
             let rec = EvolutionRecord {
-                timestamp: format!("2026-06-16T10:00:0{}Z", ty.as_str().len()),
+                timestamp: format!("2026-06-16T10:00:0{}Z", i),
                 observations: 1,
                 success_rate: 0.5,
                 avg_score: 0.5,


### PR DESCRIPTION
## Summary
**Closes #81** — the 3 residual correctness/quality follow-ups from PR #75 that #77/#78/#79 did not address.

## Changes
- **R1** `EditType::from_db_str` no longer distorts unknown DB values into `AddSkill`: added `EditType::Unknown`, made `"add_skill"` explicit (the old wildcard caught it), and `_ => Unknown`. `Unknown` is excluded from `all()` so it never pollutes edit-type coverage.
- **R2** `edit_type_roundtrips` test timestamp is now index-based (`enumerate`), not `as_str().len()` — structurally unique, survives a future UNIQUE constraint or new variant.
- **R3** `token_estimate` / `estimate_tokens` documented as intentional scaffold (not silently unused) — kept populated for future planner cost-weighting.

## Acceptance Criteria
- AC1 ✅ `from_db_str_unknown_is_not_distorted_to_add_skill` + `unknown_excluded_from_all` (new tests).
- AC2 ✅ round-trip test timestamp is structurally unique (index-based).
- AC3 ✅ `token_estimate`/`estimate_tokens` carry scaffold doc rationale; clippy clean.
- AC4 ✅ `cargo test --lib` 651 passed; clippy clean; fmt clean.

## Test Plan
- [x] cargo test --lib: 651 passed
- [x] clippy --all-targets -D warnings: clean
- [x] cargo fmt --check: clean
- [ ] CI green