### PR TITLE
feat(bench): multi-model A/B smoke runner + project skill

### DIFF
--- a/.agents/skills/bench-ab-smoke/SKILL.md
+++ b/.agents/skills/bench-ab-smoke/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: bench-ab-smoke
+description: "Run the bare-vs-epic A/B smoke benchmark (benchmarks/ab/) safely. Enforces a DRY_RUN-first, one-model-at-a-time execution order to avoid Claude Code headless-call abuse bans."
+---
+
+# bench-ab-smoke — Safe Multi-Model A/B Smoke
+
+## Iron Law
+
+NEVER fire multiple real model calls back-to-back in one shot. Headless
+(`-p` / `--output-format json`) requests issued rapidly and repeatedly are
+exactly the pattern that triggers Claude Code rate-limit / abuse bans. This
+skill exists to make the smoke benchmark safe to run, not just runnable.
+
+## When to Trigger
+
+- Manually, via `/bench-ab-smoke`, when you want to validate the bare-vs-epic
+  plugin toggle on the self-contained `benchmarks/ab/tasks/` fixtures.
+- Before a full SWE-bench Verified main run (issue #94) — this smoke de-risks
+  the mechanics (toggle, capture, grading) at near-zero cost.
+
+## What this measures
+
+For each claudy profile × {bare, epic} arm, on one cheap task:
+
+- `pass1` — mechanical pytest pass/fail (independent grade)
+- `cost_usd`, `num_turns`, `duration_ms`, `input_tokens` — from claude JSON
+- `family` / `model` — resolved from `claudy show <profile>`
+
+The **within-model** bare-vs-epic pair is the controlled A/B (plugin = only
+variable). Cross-model rows are observational (how epic's overhead varies by
+family) — not the main-run controlled variable.
+
+## Safe Execution Order (MANDATORY)
+
+Run these phases **in order**. Do not skip ahead.
+
+### Phase 1 — Validate mechanics, $0 cost
+```bash
+# Always DRY_RUN first: no model calls. Confirms profile resolution,
+# configured/skip logic, file naming, and table generation across N models.
+MODELS="zai native openai" DRY_RUN=1 ./benchmarks/ab/run_smoke.sh \
+  benchmarks/ab/tasks/task1-palindrome 12
+```
+Expect: result JSONs per cell, a combined `comparison.md`, `[skip]` lines for
+not-configured profiles, exit 0. Fix any mechanics issue here — never debug on
+paid calls.
+
+### Phase 2 — Single model, ONE run
+```bash
+# One profile only. This is the only step that spends money (~$0.01–0.03).
+./benchmarks/ab/run_smoke.sh benchmarks/ab/tasks/task1-palindrome 8 zai
+```
+Inspect the result before any further runs. If the gateway returns `529`
+(overloaded) or any `is_error: true`, **STOP** — see "On failure" below.
+
+### Phase 3 — Additional models (optional, one at a time)
+Only after Phase 2 succeeds. Add ONE more model per invocation and review
+between each. Space the invocations out — do not batch:
+```bash
+MODELS="zai native" ./benchmarks/ab/run_smoke.sh benchmarks/ab/tasks/task1-palindrome 8
+```
+Lower `max_turns` (e.g. 8) to bound each cell's cost and latency.
+
+## On failure (529 / gateway error)
+
+A `529` (server overloaded) or any `is_error: true` / `api_error_status` set
+means the gateway is unhealthy. **Do not retry in the same session.** Retrying
+rapidly against a flapping gateway is the highest ban-risk behavior there is.
+
+- Record the failure, stop the run.
+- Resume only in a separate session after the gateway recovers.
+- The runner already captures `is_error` and `api_error_status` in the result
+  JSON — no special handling needed.
+
+## Ban-risk guardrails
+
+- `max_turns` caps agent *actions*, NOT API retry/backoff dwell. A single turn
+  can still dwell ~190s on gateway retries. Low `max_turns` is not a substitute
+  for spacing calls apart.
+- Never loop the runner in a shell `while`/`for` over many profiles/seeds.
+- Prefer the interactive TUI (`claudy <profile>` with no `-p`) for exploratory
+  runs — a human-paced single call is far safer than batched headless ones.
+- A failed cell that spent money but returned no useful output still counts
+  toward your rate budget. Treat 529s as "stop", not "retry".
+
+## Anti-Rationalization
+
+| Excuse | Rebuttal | What to do instead |
+|--------|----------|--------------------|
+| "Running all models at once is faster" | One abuse ban is permanent; the time saved is negligible. | One model per invocation. Review between each. |
+| "I'll just retry on 529" | Retrying against an overloaded gateway maximizes ban risk. | Stop. Resume in a new session when healthy. |
+| "DRY_RUN wastes time, mechanics look fine" | A $0 check that catches a naming/skip bug saves a paid run that overwrites real results. | Always Phase 1 first. |
+| "max_turns=5 makes it safe to spam" | max_turns doesn't bound retry backoff. | Space calls; don't batch. |
+| "The runner already handles errors" | It captures them — it doesn't prevent bans from rapid retries. | You control pacing, not the runner. |
+
+## Evidence Required
+
+Before claiming the smoke "passed", show ALL of:
+
+- [ ] Phase 1 DRY_RUN output: `comparison.md` renders, expected `[skip]` lines present, exit 0
+- [ ] Phase 2 real single-model result: `pass1`, `cost_usd`, `input_tokens` are non-zero and sane (not all 0)
+- [ ] No `is_error: true` / `api_error_status` in the real result line
+- [ ] `result-{profile}-{arm}.json` written per cell; legacy symlinks present in single-profile mode
+
+## Red Flags
+
+- Running `MODELS="a b c d" ./run_smoke.sh` (batched multi-model) without a prior single-model Phase 2
+- Retrying immediately after a `529`
+- Reading `pass1=0, cost=0, input_tokens=0` as "passed" (that's a gateway failure, not a clean fail)
+- Treating `num_turns` as a proxy for call frequency / safety
+- Skipping DRY_RUN because "the code looks right"

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -279,10 +279,12 @@ $RECYCLE.BIN/
 *.crl
 *.pem.txt
 
-.claude/
+.claude/*
+!.claude/skills
 .agents/
 !.agents/
 !.agents/plugins/
+!.agents/skills/
 .collet/
 .harness/
 .cursor/

--- a/benchmarks/ab/README.md
+++ b/benchmarks/ab/README.md
@@ -1,17 +1,26 @@
 # benchmarks/ab — bare-vs-epic A/B smoke (issue #94)
 
-Controlled A/B comparison of loading the **epic-harness plugin**, with model and
-router held fixed. The only variable is whether the plugin is loaded.
+Controlled A/B comparison of loading the **epic-harness plugin**, with the
+**model held fixed within each comparison**. The only within-model variable is
+whether the plugin is loaded.
 
-- **Model/router**: `claudy zai` → GLM-5.2[1m] (Z.AI, anthropic-compatible endpoint)
-- **bare arm**: `claudy zai --bare -p ...` → `claude --bare` skips plugins/hooks/LSP/mcp
-- **epic arm**: `claudy zai -p ...` → normal launch, epic plugin loaded
+- **Profiles**: multi-model via claudy profiles (default `zai`).
+  - `zai` → GLM-5.2[1m] (Z.AI, anthropic-compatible endpoint)
+  - `native` → Claude (family `claude_strict`)
+  - openrouter `or-*`, local `ollama`/`lmstudio`/`llamacpp` when configured
+- **bare arm**: `claudy <profile> --bare -p ...` → `claude --bare` skips plugins/hooks/LSP/mcp
+- **epic arm**: `claudy <profile> -p ...` → normal launch, epic plugin loaded
+
+The bare/epic comparison is valid **within a single model** (plugin = the only
+variable). Cross-model rows in the comparison table are informational — they show
+how epic's overhead and score vary across model families — and are **not** the
+controlled variable of the main run (issue #94).
 
 This is the **smoke test** that de-risks the full SWE-bench Verified main run. It
 validates three things on 1–2 cheap self-contained tasks (Docker-free, mechanical
 pytest grading) before committing to ~$100+ of SWE-bench instances:
 
-1. GLM-5.2[1m] can drive a coding task headless end-to-end.
+1. A model can drive a coding task headless end-to-end.
 2. The bare/epic toggle works (observable via the `input_tokens` overhead delta).
 3. pass@1, cost, turns, and latency are all capturable from claude's JSON output.
 
@@ -19,7 +28,7 @@ pytest grading) before committing to ~$100+ of SWE-bench instances:
 
 ```
 ab/
-├── run_smoke.sh                 # runner — one task, both arms, comparison table
+├── run_smoke.sh                 # runner — N models × {bare,epic}, combined table
 ├── tasks/
 │   ├── task1-palindrome/        # easy: fix a buggy is_palindrome
 │   │   ├── task.md              # prompt handed to the agent
@@ -34,21 +43,46 @@ ab/
 ## Usage
 
 ```bash
-# from the repo root (inside the worktree)
+# single profile (legacy form — 3rd positional arg)
 ./benchmarks/ab/run_smoke.sh benchmarks/ab/tasks/task1-palindrome 12 zai
-./benchmarks/ab/run_smoke.sh benchmarks/ab/tasks/task2-moving-average 15 zai
+
+# multi-model matrix via MODELS env (space- or comma-separated)
+MODELS="zai native ollama" ./benchmarks/ab/run_smoke.sh benchmarks/ab/tasks/task1-palindrome 12
+
+# dry-run: validate the loop mechanics (profile resolution, skip logic,
+# file naming, table generation) with NO model calls — costs $0
+MODELS="zai native openai deepseek" DRY_RUN=1 ./benchmarks/ab/run_smoke.sh benchmarks/ab/tasks/task1-palindrome 12
 ```
 
-Each run writes `result-bare.json`, `result-epic.json`, and `comparison.md` into
-the task directory. Env overrides: `COST_CAP` (default 5.0 USD per arm),
-`RUN_TIMEOUT` (default 600s).
+Precedence: the 3rd positional arg (single profile) wins over `MODELS`. With
+neither set, the default is `zai`.
+
+Each (profile, arm) cell writes `result-{profile}-{arm}.json`. In single-profile
+mode, legacy names `result-bare.json` / `result-epic.json` are created as
+symlinks to the actual result files. A combined `comparison.md` holds every ran
+row. Env overrides: `COST_CAP` (default 5.0 USD per cell), `RUN_TIMEOUT`
+(default 600s), `DRY_RUN` (default 0).
+
+## Profiles
+
+Run `claudy list` to see available profiles and their `configured` /
+`not configured` status. Profiles that are **not configured** are skipped with a
+warning (`[skip] <name> not configured`) and the run continues — it never fails
+the whole matrix on one missing profile.
+
+To configure a profile, run `claudy <name>` and follow the prompts, then exit.
+If `claudy list` is unavailable or unparseable, all listed profiles are assumed
+configured (fail-soft) and real failures surface per-cell.
 
 ## Metrics
 
 | metric | source | meaning |
 |--------|--------|---------|
+| `family` | `claudy show <profile>` `Family:` | provider family (`claude_strict`, `anthropic_compatible_non_claude`, `local`, …) |
+| `model` | `claudy show <profile>` `Model:` | resolved model name (e.g. `glm-5.2[1m]`); `unknown` if the profile has no model set |
+| `profile` | claudy profile used | e.g. `zai`, `native`, `ollama` |
 | `pass1` | independent `pytest` run after the agent | mechanical pass@1 (1 run) |
-| `cost_usd` | `total_cost_usd` from claude JSON | $/instance |
+| `cost_usd` | `total_cost_usd` from claude JSON | $/cell |
 | `num_turns` | `num_turns` | agentic steps |
 | `duration_ms` | `duration_ms` | wall latency (API) |
 | `input_tokens` | `usage.input_tokens` | context overhead proxy (toggle signal) |
@@ -65,3 +99,7 @@ the task directory. Env overrides: `COST_CAP` (default 5.0 USD per arm),
   pulls/builds (`docker-credential-desktop not installed`); use a clean `DOCKER_CONFIG`.
   These smoke tasks use plain `pytest` so no container is needed here.
 - `pass@1` from a single run is a feasibility signal, not a statistic.
+- Cross-model rows are **observational**: different models have different token
+  pricing and capabilities, so epic's cost/latency overhead is not comparable
+  across model families in absolute terms. The controlled A/B lives within each
+  model's bare-vs-epic pair.

--- a/benchmarks/ab/run_smoke.sh
+++ b/benchmarks/ab/run_smoke.sh
@@ -1,25 +1,37 @@
 #!/usr/bin/env bash
 # benchmarks/ab/run_smoke.sh
 #
-# Bare-vs-epic A/B smoke runner for GLM via claudy (epic-harness issue #94).
+# Bare-vs-epic A/B smoke runner for multiple LLM provider profiles via claudy
+# (epic-harness issue #94). Multi-model matrix.
 #
-# Runs one coding task in two configurations against the SAME model+router
-# (claudy <profile> = GLM), with the epic-harness plugin as the only variable:
+# Runs one coding task across a LIST of claudy profiles, in two configurations
+# per profile, with the epic-harness plugin as the only within-model variable:
 #   bare : `claudy <profile> --bare ...`   (claude --bare skips plugins/hooks/LSP/mcp)
 #   epic : `claudy <profile> ...`          (normal launch, epic plugin loaded)
 #
-# Captures per arm: pass@1 (mechanical pytest grade), cost_usd, num_turns,
-# duration_ms, input_tokens. Emits a comparison table + result JSONs.
+# The bare/epic comparison is valid within a single model (plugin = only
+# variable); cross-model rows are informational (how epic's overhead/score
+# varies across model families), NOT the controlled variable of issue #94.
 #
-# Usage:  ./run_smoke.sh <task_dir> [max_turns] [profile]
-# Env:    COST_CAP (default 5.0)  RUN_TIMEOUT (default 600s)
+# Captures per (profile, arm): pass@1 (mechanical pytest grade), cost_usd,
+# num_turns, duration_ms, input_tokens + identity (profile/model/family).
+# Emits per-cell result JSONs + a combined comparison table.
+#
+# Usage:
+#   ./run_smoke.sh <task_dir> [max_turns] [profile]   # single profile (legacy)
+#   MODELS="zai native" ./run_smoke.sh <task_dir> [max_turns]   # multi-model
+# Env:
+#   MODELS      space- or comma-separated profile list (default zai). Ignored if $3 set.
+#   COST_CAP    USD cap per cell (default 5.0)
+#   RUN_TIMEOUT per-cell wall seconds (default 600)
+#   DRY_RUN     1 = skip claudy invocation, synthesize zeroed results (validate loop, $0)
 set -uo pipefail
 
 TASK_DIR="${1:?usage: run_smoke.sh <task_dir> [max_turns] [profile]}"
 MAX_TURNS="${2:-15}"
-PROFILE="${3:-zai}"
 COST_CAP="${COST_CAP:-5.0}"
 RUN_TIMEOUT="${RUN_TIMEOUT:-600}"
+DRY_RUN="${DRY_RUN:-0}"
 
 TASK_NAME="$(basename "$TASK_DIR")"
 PROMPT_FILE="$TASK_DIR/task.md"
@@ -28,16 +40,80 @@ REPO_SRC="$TASK_DIR/repo"
 [ -d "$REPO_SRC" ]    || { echo "ERR: no repo/ in $TASK_DIR" >&2; exit 2; }
 PROMPT="$(cat "$PROMPT_FILE")"
 
-run_arm() {
-  local arm="$1" extra_flag="$2"
-  local work; work="$(mktemp -d -t "ab-${arm}-${TASK_NAME}.XXXX")"
+# --- profile list resolution: $3 (single) > MODELS env > default zai ---
+SINGLE_PROFILE=0
+if [ "${3:-}" != "" ]; then
+  MODELS_LIST=( "$3" )
+  SINGLE_PROFILE=1
+elif [ "${MODELS:-}" != "" ]; then
+  # commas → spaces, then word-split into array
+  IFS=$' \t,' read -r -a MODELS_LIST <<< "$MODELS"
+else
+  MODELS_LIST=( zai )
+fi
+
+command -v jq >/dev/null || { echo "ERR: jq required" >&2; exit 2; }
+
+# --- which profiles are actually configured (claudy list) ---
+# fail-soft: if `claudy list` is unavailable/unparseable, treat all as configured.
+declare -A CONFIGURED
+CLAUDY_LIST="$(claudy list 2>/dev/null || true)"
+if [ -n "$CLAUDY_LIST" ]; then
+  while IFS= read -r _line; do
+    # lines: "  native             configured" / "  openai    not configured"
+    _trimmed="${_line#"${_line%%[![:space:]]*}"}"   # ltrim
+    [ -z "$_trimmed" ] && continue
+    case "$_trimmed" in Available*|"Run:"*) continue ;; esac
+    _p="${_trimmed%%[![:alnum:]_-]*}"                # first token (profile name)
+    # must end with " configured" but NOT "not configured"
+    [ -n "$_p" ] && [[ "$_trimmed" == *" configured" ]] \
+      && [[ "$_trimmed" != *"not configured" ]] && CONFIGURED["$_p"]=1
+  done <<< "$CLAUDY_LIST"
+fi
+CLAUDY_LIST_OK=1
+[ ${#CONFIGURED[@]} -eq 0 ] && CLAUDY_LIST_OK=0   # list failed → assume all configured
+
+# --- resolve model/family per profile via `claudy show` (cached) ---
+declare -A RESOLVED_MODEL RESOLVED_FAMILY
+resolve_profile() {  # $1 = profile
+  local p="$1" info model family
+  if [ -n "${RESOLVED_MODEL[$p]+x}" ]; then return; fi   # cached
+  info="$(claudy show "$p" 2>/dev/null || true)"
+  # claudy show prefixes lines with "INFO ". head -1 avoids sub-model rows.
+  model="$(echo "$info"  | grep -E 'INFO[[:space:]]+Model:'  | head -1 | sed -E 's/.*Model:[[:space:]]*//')"
+  family="$(echo "$info" | grep -E 'INFO[[:space:]]+Family:' | head -1 | sed -E 's/.*Family:[[:space:]]*//')"
+  RESOLVED_MODEL[$p]="${model:-unknown}"
+  RESOLVED_FAMILY[$p]="${family:-unknown}"
+}
+
+run_arm() {  # $1=arm  $2=extra_flag  $3=profile
+  local arm="$1" extra_flag="$2" profile="$3"
+  local model="${RESOLVED_MODEL[$profile]}" family="${RESOLVED_FAMILY[$profile]}"
+  local work; work="$(mktemp -d -t "ab-${profile}-${arm}-${TASK_NAME}.XXXX")"
   cp -R "$REPO_SRC/." "$work/"
   chmod -R u+w "$work"
-  echo "[$TASK_NAME/$arm] workdir=$work" >&2
+  echo "[$TASK_NAME/$profile/$arm] workdir=$work" >&2
 
   # sanity: tests must FAIL before the agent runs (validates the fixture)
   if (cd "$work" && python3 -m pytest -q >/dev/null 2>&1); then
-    echo "[$TASK_NAME/$arm] WARN: tests pass pre-run — fixture is not failing" >&2
+    echo "[$TASK_NAME/$profile/$arm] WARN: tests pass pre-run — fixture is not failing" >&2
+  fi
+
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "[$TASK_NAME/$profile/$arm] dry-run: would run claudy $profile $extra_flag -p <prompt> --max-turns $MAX_TURNS" >&2
+    local pass=0
+    (cd "$work" && python3 -m pytest -q >/dev/null 2>&1) && pass=1
+    jq -n \
+      --arg arm "$arm" --arg task "$TASK_NAME" --arg profile "$profile" \
+      --arg model "$model" --arg family "$family" \
+      --argjson ok true --argjson dry true --argjson pass "$pass" --argjson is_error false \
+      --argjson cost 0 --argjson turns 0 --argjson dur 0 --argjson intokens 0 \
+      --argjson wall 0 --argjson rc 0 --argjson capped 0 --arg work "$work" \
+      '{arm:$arm, task:$task, ok:true, dry_run:$dry, pass1:$pass, is_error:$is_error,
+        cost_usd:$cost, num_turns:$turns, duration_ms:$dur, input_tokens:$intokens,
+        wall_s:$wall, rc:$rc, cost_capped:$capped,
+        profile:$profile, model:$model, family:$family, workdir:$work}'
+    return
   fi
 
   local out="$work/run.stdout" err="$work/run.stderr"
@@ -45,7 +121,7 @@ run_arm() {
   # Launch inside the per-arm workdir so the agent edits the isolated copy,
   # not the shared template. ($out/$err are absolute, stay valid after cd.)
   # shellcheck disable=SC2086  # $extra_flag intentional: "" must vanish, "--bare" must be one arg
-  ( cd "$work" && timeout "$RUN_TIMEOUT" claudy "$PROFILE" $extra_flag -p "$PROMPT" \
+  ( cd "$work" && timeout "$RUN_TIMEOUT" claudy "$profile" $extra_flag -p "$PROMPT" \
       --output-format json --max-turns "$MAX_TURNS" \
       --permission-mode bypassPermissions \
       >"$out" 2>"$err" )
@@ -54,8 +130,11 @@ run_arm() {
 
   local result_line; result_line="$(grep '"type":"result"' "$out" | tail -1 || true)"
   if [ -z "$result_line" ]; then
-    jq -n --arg arm "$arm" --arg task "$TASK_NAME" --argjson wall "$wall" --argjson rc "$rc" --arg work "$work" \
-      '{arm:$arm, task:$task, ok:false, error:"no_result_line", rc:$rc, wall_s:$wall, workdir:$work}'
+    jq -n --arg arm "$arm" --arg task "$TASK_NAME" --arg profile "$profile" \
+      --arg model "$model" --arg family "$family" \
+      --argjson wall "$wall" --argjson rc "$rc" --arg work "$work" \
+      '{arm:$arm, task:$task, ok:false, error:"no_result_line", rc:$rc, wall_s:$wall,
+        profile:$profile, model:$model, family:$family, workdir:$work}'
     cat "$err" | tail -20 | sed 's/^/    stderr: /' >&2
     return
   fi
@@ -74,11 +153,12 @@ run_arm() {
   # cost guard
   local capped=0
   if awk -v c="$cost" -v cap="$COST_CAP" 'BEGIN{exit !(c+0 > cap+0)}'; then
-    capped=1; echo "[$TASK_NAME/$arm] COST CAP EXCEEDED: \$${cost} > \$${COST_CAP}" >&2
+    capped=1; echo "[$TASK_NAME/$profile/$arm] COST CAP EXCEEDED: \$${cost} > \$${COST_CAP}" >&2
   fi
 
   jq -n \
-    --arg arm "$arm" --arg task "$TASK_NAME" \
+    --arg arm "$arm" --arg task "$TASK_NAME" --arg profile "$profile" \
+    --arg model "$model" --arg family "$family" \
     --argjson ok true --argjson pass "$pass" --argjson is_error "$is_error" \
     --argjson cost "$cost" --argjson turns "$turns" \
     --argjson dur "$dur" --argjson intokens "$intokens" \
@@ -86,20 +166,48 @@ run_arm() {
     --arg work "$work" \
     '{arm:$arm, task:$task, ok:true, pass1:$pass, is_error:$is_error,
       cost_usd:$cost, num_turns:$turns, duration_ms:$dur, input_tokens:$intokens,
-      wall_s:$wall, rc:$rc, cost_capped:$capped, workdir:$work}'
+      wall_s:$wall, rc:$rc, cost_capped:$capped,
+      profile:$profile, model:$model, family:$family, workdir:$work}'
 }
 
-echo "=== A/B smoke: $TASK_NAME (profile=$PROFILE max_turns=$MAX_TURNS cost_cap=\$$COST_CAP) ===" >&2
-BARE="$(run_arm bare  "--bare")"
-EPIC="$(run_arm epic  "")"
-echo "$BARE" > "$TASK_DIR/result-bare.json"
-echo "$EPIC" > "$TASK_DIR/result-epic.json"
+echo "=== A/B smoke: $TASK_NAME (models=[${MODELS_LIST[*]}] max_turns=$MAX_TURNS cost_cap=\$$COST_CAP dry=$DRY_RUN) ===" >&2
 
+# --- main loop: profiles × arms. profile outer, arm inner (log adjacency, abort-safe). ---
+RESULTS=()
+RAN_PROFILES=()
+for profile in "${MODELS_LIST[@]}"; do
+  if [ "$CLAUDY_LIST_OK" = "1" ] && [ -z "${CONFIGURED[$profile]:-}" ]; then
+    echo "[skip] $profile not configured (run \`claudy $profile\` then exit to set up)" >&2
+    continue
+  fi
+  resolve_profile "$profile"
+  RAN_PROFILES+=( "$profile" )
+  for arm in bare epic; do
+    if [ "$arm" = "bare" ]; then extra="--bare"; else extra=""; fi
+    result="$(run_arm "$arm" "$extra" "$profile")"
+    echo "$result" > "$TASK_DIR/result-${profile}-${arm}.json"
+    RESULTS+=( "$result" )
+  done
+done
+
+[ ${#RESULTS[@]} -gt 0 ] || { echo "ERR: no profiles ran (all skipped/unconfigured?)" >&2; exit 1; }
+
+# --- legacy filename shims: only in single-profile mode ---
+if [ "$SINGLE_PROFILE" = "1" ] && [ ${#RAN_PROFILES[@]} -eq 1 ]; then
+  sp="${RAN_PROFILES[0]}"
+  ( cd "$TASK_DIR" && ln -sf "result-${sp}-bare.json" "result-bare.json" \
+                       && ln -sf "result-${sp}-epic.json" "result-epic.json" )
+fi
+
+# --- combined comparison table (all ran profiles × arms) ---
+NMODELS=${#RAN_PROFILES[@]}
 {
-  echo "## $TASK_NAME — bare vs epic"
+  echo "## $TASK_NAME — bare vs epic ($NMODELS model$([ "$NMODELS" = "1" ] || echo s))"
   echo ""
-  echo "| arm | pass@1 | cost(\$) | turns | dur(ms) | input_tok | wall(s) | capped |"
-  echo "|-----|--------|---------|-------|---------|-----------|---------|--------|"
-  echo "$BARE" | jq -r '"| bare | \(.pass1) | \(.cost_usd) | \(.num_turns) | \(.duration_ms) | \(.input_tokens) | \(.wall_s) | \(.cost_capped) |"'
-  echo "$EPIC" | jq -r '"| epic | \(.pass1) | \(.cost_usd) | \(.num_turns) | \(.duration_ms) | \(.input_tokens) | \(.wall_s) | \(.cost_capped) |"'
+  echo "| family | model | profile | arm | pass@1 | cost(\$) | turns | dur(ms) | input_tok | wall(s) | capped |"
+  echo "|--------|-------|---------|-----|--------|---------|-------|---------|-----------|---------|--------|"
+  for r in "${RESULTS[@]}"; do
+    echo "$r" | jq -r \
+      '"| \(.family) | \(.model) | \(.profile) | \(.arm) | \(.pass1) | \(.cost_usd) | \(.num_turns) | \(.duration_ms) | \(.input_tokens) | \(.wall_s) | \(.cost_capped) |"'
+  done
 } | tee "$TASK_DIR/comparison.md"


### PR DESCRIPTION
## Summary

Follow-up to #96 (now merged). Extends the bare-vs-epic A/B smoke runner from a single GLM profile to a **multi-model matrix**, and adds a project skill that enforces safe execution order.

## Changes

- `benchmarks/ab/run_smoke.sh` — iterates a `MODELS` list (or single `\` profile) across {bare, epic} arms. Resolves `family`/`model` per profile via `claudy show`; skips not-configured profiles with a warning (never fails the matrix). Emits a combined `comparison.md` with family/model/profile columns, per-cell `result-{profile}-{arm}.json`, legacy `result-bare/epic.json` symlinks in single-profile mode, and a `DRY_RUN` mode to validate loop mechanics with no model calls ($0).
- `benchmarks/ab/README.md` — documents the multi-model matrix, profiles, `MODELS`/`DRY_RUN` env, new identity fields.
- `.agents/skills/bench-ab-smoke/SKILL.md` + `.claude/skills` symlink — **project skill** (not the plugin registry) for developers who clone this repo to benchmark it. Enforces a safe execution order: DRY_RUN first → single model one run → review → additional models one at a time. Explicit ban-risk guardrails for headless (`-p`) rapid repeated calls.
- `.gitignore` — allow `.claude/skills` (symlink) and `.agents/skills/` to be tracked while keeping the rest of `.claude/` ignored.

## Why a project skill, not registry/skills/

`registry/skills/` ships in the plugin to harness *users*. The smoke benchmark is for developers who clone epic-harness to develop/validate it — so it belongs as a local project skill (`.agents/skills/` → `.claude/skills` symlink), not in the distributed plugin.

## Verification

- `bash -n` + `shellcheck -x` clean.
- DRY_RUN single (`zai`): symlink + 2-row table, family parsed correctly.
- DRY_RUN multi (`zai native ollama lmstudio`): 8-row table, families classified (`anthropic_compatible_non_claude` / `claude_strict` / `local`).
- DRY_RUN skip path (`zai openai deepseek gemini`): `[skip]` for not-configured, exit 0.

## Note

Real multi-model results were attempted but the gateway returned `529` (overloaded) for all cells; results are omitted pending gateway recovery. The runner captured `is_error`/`api_error_status` correctly. The project skill encodes the `529 → stop, resume in a new session` rule.

Refs #94.