### PR TITLE
refactor(evolve): replace claude -p synthesis with host-agnostic manifest protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,21 +152,27 @@ The pre-holdout scheme (credit every skill on disk each session, derive
 "without" from pre-creation history) was confounded by regression to the mean
 and is gone.
 
-## LLM Skill Synthesis
+## Skill Synthesis (host-agnostic)
 
-Seeded skill bodies are synthesized by a headless `claude -p` call from the
-session's real failure evidence (error snippets per category, counts, detected
-patterns) instead of static templates. Config (`[evolution]`):
+Seeded skills start from static templates. `reflect` then emits a
+**pending-synthesis manifest** (`$HARNESS_DIR/pending_synth.jsonl`) for each
+seeded skill — failure evidence (masked error snippets per category, counts,
+detected patterns) plus the template body. A host agent (claude/codex/agy,
+using its own subagent mechanism with no model specified) reads the manifest,
+synthesizes a better body, and applies it via:
 
-- `llm_synthesis` (default true), `llm_synthesis_cmd` (default `claude`),
-  `llm_synthesis_model` (default `haiku`), `llm_synthesis_timeout_secs`
-  (default 10), `llm_synthesis_max_per_session` (default 1)
+    epic-harness evolve accept-synth --skill <name> [--file <path> | --stdin]
 
-Fallback: any failure (CLI missing, timeout, malformed output) keeps the
-template body — synthesis can improve a skill, never block seeding. Synthesized
-content passes the same validate → Critic → gate path as templates. Recursion
-guard: the child runs with `EPIC_SYNTH_CHILD=1` + `EPIC_HOOK_PROFILE=minimal`.
-Debug builds disable synthesis (test determinism) unless `EPIC_SYNTH_FORCE=1`.
+The CLI validates the body and re-runs the Critic falsifiability gate before
+overwriting the template. Config (`[evolution]`):
+
+- `llm_synthesis` (default true) — gates manifest emission.
+- `llm_synthesis_max_per_session` (default 1) — caps manifests per session.
+
+If no host ever runs `accept-synth`, the template body persists — synthesis can
+only improve a skill, never block seeding. The harness references no CLI binary
+and no model name; the previous synchronous `claude -p` subprocess (which hung
+under slow/remote hosts) is gone.
 
 ## Evolved Skill Injection
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Skill synthesis is now host-agnostic**: `reflect` no longer spawns a
+  synchronous `claude -p --model haiku` subprocess (which could hang or time
+  out under slow/remote hosts). It now emits a pending-synthesis manifest
+  (`$HARNESS_DIR/pending_synth.jsonl`) with masked failure evidence + the
+  template body; any host agent synthesizes a better body out-of-band and
+  submits it via the new `epic-harness evolve accept-synth --skill <name>
+  [--file <path> | --stdin]` CLI, which re-validates and re-runs the Critic
+  gate before applying it. Unconsumed manifests leave the template body in
+  place — synthesis can only improve a skill, never block seeding.
+
+### Removed
+- `[evolution]` config fields `llm_synthesis_cmd`, `llm_synthesis_model`, and
+  `llm_synthesis_timeout_secs` — no longer meaningful now that synthesis runs
+  out-of-process via the manifest protocol above. Existing values for these
+  keys in `config.toml` are silently ignored (no error). `llm_synthesis` and
+  `llm_synthesis_max_per_session` are unchanged and still apply.
+
 ## [0.8.1] — 2026-07-03
 
 Ring 3 rework: the evolution loop now closes in code, measures honestly, and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,7 +239,7 @@ Invalid skills are automatically removed with a log message. This prevents malfo
 1. **Evolved skill quality**: Auto-generated markdown quality scales with failure data volume. Early sessions may produce superficial skills.
 2. **Pattern detection precision**: Matches on same error category + same file. Subtle variations (different line, different root cause) are not distinguishable.
 3. **Metrics horizon**: Only the last 50 sessions are retained. Long-term trends require direct analysis of `evolution.jsonl`.
-4. **Single agent**: The evolution loop assumes a single Claude Code session. Concurrent multi-agent execution may cause observation conflicts.
+4. **Single agent**: The evolution loop assumes a single agent session (host-agnostic — claude/codex/agy). Concurrent multi-agent execution may cause observation conflicts. Skill synthesis is decoupled from the session via the pending-manifest protocol, so it survives across sessions and hosts.
 
 ## Unified Memory Layer — WIP
 

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -99,6 +99,27 @@ Gate (validate: format, dedup, cap of 10)
 Reload (next session resume reports metrics + loads evolved skills)
 ```
 
+## Skill Synthesis (host-agent)
+
+When `epic-harness reflect` seeds a skill, it emits a pending-synthesis manifest
+to `$HARNESS_DIR/pending_synth.jsonl` (failure evidence + template body). To
+synthesize a better body:
+
+1. Read `$HARNESS_DIR/pending_synth.jsonl`; for each record with `status: "pending"`:
+2. Launch a subagent (use your host's subagent mechanism — do not name a specific
+   tool or model) with the manifest's `prompt_guidance` + `evidence`, instructing
+   it to write a markdown skill body with the required sections (`## Process`,
+   `## Anti-Rationalization`, `## Evidence Required`, `## Red Flags`).
+3. Apply the result:
+   ```bash
+   epic-harness evolve accept-synth --skill <name> --file <body.md>
+   ```
+4. The CLI validates the body, runs the Critic gate, overwrites the template
+   skill, and marks the manifest consumed.
+
+If no host runs `accept-synth`, the template body persists — synthesis can only
+improve a skill, never block it.
+
 ## Scoring System
 - **Composite**: `0.5 × tool_success + 0.3 × output_quality + 0.2 × execution_cost`
 - **Failure classification**: 9 categories (type_error, syntax_error, test_fail, lint_fail, build_fail, permission_denied, timeout, not_found, runtime_error)

--- a/skills/orbit/SKILL.md
+++ b/skills/orbit/SKILL.md
@@ -174,6 +174,14 @@ Run the evolution engine to analyze this session and generate/improve skills.
    ```
    This triggers the Ring 3 loop: observe → analyze → seed evolved skills → update metrics.
 
+   If `$HARNESS_DIR/pending_synth.jsonl` has records with `status: "pending"`,
+   synthesize each — launch one subagent per manifest (use your host's subagent
+   mechanism; do NOT name a model or CLI), then apply the body it produced:
+   ```bash
+   epic-harness evolve accept-synth --skill <name> --file <body.md>
+   ```
+   Unconsumed manifests leave the template skill body in place.
+
 2. **If CI green** (all checks passed): additionally run
    ```bash
    epic-harness reflect --context --days 1

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,27 +113,14 @@ pub struct EvolutionConfig {
     #[serde(default = "default_reward_hacking_cost_rise")]
     pub reward_hacking_cost_rise: f64,
 
-    /// LLM skill synthesis: when true, seeded skill bodies are synthesized by
-    /// a headless `claude -p` call from real failure evidence instead of the
-    /// static templates. Any failure falls back to the template content.
-    /// Disabled in debug builds (test determinism) unless EPIC_SYNTH_FORCE=1.
+    /// Skill synthesis: when true, `reflect` emits pending-synthesis manifests
+    /// (failure evidence + template body) to `pending_synth.jsonl` for a host
+    /// agent to upgrade via `epic-harness evolve accept-synth`. When false,
+    /// skills keep their template bodies. Host-agnostic — no CLI/model pinned.
     #[serde(default = "default_llm_synthesis")]
     pub llm_synthesis: bool,
 
-    /// Command used for LLM synthesis (must accept a prompt on stdin with `-p`).
-    #[serde(default = "default_llm_synthesis_cmd")]
-    pub llm_synthesis_cmd: String,
-
-    /// Model passed to the synthesis command via `--model`. Empty = CLI default.
-    #[serde(default = "default_llm_synthesis_model")]
-    pub llm_synthesis_model: String,
-
-    /// Wall-clock budget for one synthesis call. Keep well under the host's
-    /// SessionEnd hook timeout — reflect runs inside that budget.
-    #[serde(default = "default_llm_synthesis_timeout_secs")]
-    pub llm_synthesis_timeout_secs: u64,
-
-    /// Maximum skills synthesized per reflect round (the rest keep templates).
+    /// Maximum pending-synthesis manifests emitted per reflect round.
     #[serde(default = "default_llm_synthesis_max_per_session")]
     pub llm_synthesis_max_per_session: usize,
 
@@ -248,9 +235,6 @@ impl Default for EvolutionConfig {
             reward_hacking_quality_drop: default_reward_hacking_quality_drop(),
             reward_hacking_cost_rise: default_reward_hacking_cost_rise(),
             llm_synthesis: default_llm_synthesis(),
-            llm_synthesis_cmd: default_llm_synthesis_cmd(),
-            llm_synthesis_model: default_llm_synthesis_model(),
-            llm_synthesis_timeout_secs: default_llm_synthesis_timeout_secs(),
             llm_synthesis_max_per_session: default_llm_synthesis_max_per_session(),
             attribution_eval_sessions: default_attribution_eval_sessions(),
             attribution_holdout_modulus: default_attribution_holdout_modulus(),
@@ -262,18 +246,6 @@ impl Default for EvolutionConfig {
 
 fn default_llm_synthesis() -> bool {
     true
-}
-
-fn default_llm_synthesis_cmd() -> String {
-    "claude".into()
-}
-
-fn default_llm_synthesis_model() -> String {
-    "haiku".into()
-}
-
-fn default_llm_synthesis_timeout_secs() -> u64 {
-    10
 }
 
 fn default_llm_synthesis_max_per_session() -> usize {

--- a/src/evolve/cli.rs
+++ b/src/evolve/cli.rs
@@ -1,0 +1,170 @@
+//! evolve CLI — host-agent skill synthesis handshake.
+//!
+//! `epic-harness evolve accept-synth` is the consume side of the
+//! pending-synthesis manifest protocol (`src/evolve/synthesis.rs`). A host
+//! agent (claude/codex/agy, using its own subagent mechanism with no model
+//! specified) reads a pending manifest, synthesizes a better skill body from
+//! the evidence, and pipes the body here. We validate it, re-run the Critic
+//! falsifiability gate, overwrite the template skill, and mark the manifest
+//! consumed. Host-agnostic: this code never names a CLI or model.
+
+use std::fs;
+use std::io::{IsTerminal, Read};
+
+use crate::evolve::critic::{Critic, CriticVerdict};
+use crate::evolve::edits::EditManifest;
+use crate::evolve::skills::{gate_skills, write_skill_with_meta};
+use crate::evolve::synthesis::{assemble_skill, find_pending, mark_consumed, validate_body};
+use crate::shared::evolution::{EditType, Metrics};
+use crate::shared::helpers::{append_jsonl, hint, read_json};
+use crate::shared::paths::{evolved_dir, manifests_file, metrics_file};
+
+const EXIT_OK: i32 = 0;
+const EXIT_NO_MANIFEST: i32 = 2;
+const EXIT_VALIDATE: i32 = 3;
+const EXIT_DOWNGRADE: i32 = 4;
+const EXIT_CRITIC: i32 = 5;
+const EXIT_IO: i32 = 6;
+const EXIT_USAGE: i32 = 64;
+
+/// Entry point. `args[0]` is `"evolve"`.
+pub fn run(args: &[String]) -> i32 {
+    let sub = args.get(1).map(|s| s.as_str()).unwrap_or("");
+    match sub {
+        "accept-synth" => run_accept_synth(&args[2..]),
+        "" => {
+            eprintln!(
+                "usage: epic-harness evolve accept-synth --skill <name> [--file <path> | --stdin]"
+            );
+            EXIT_USAGE
+        }
+        other => {
+            eprintln!("unknown evolve subcommand: '{other}'");
+            eprintln!("available: accept-synth");
+            EXIT_USAGE
+        }
+    }
+}
+
+fn run_accept_synth(args: &[String]) -> i32 {
+    let skill = match flag(args, "--skill") {
+        Some(s) if !s.is_empty() => s,
+        _ => {
+            eprintln!("missing required --skill <name>");
+            return EXIT_USAGE;
+        }
+    };
+    let file = flag(args, "--file");
+    let stdin_flag = args.iter().any(|a| a == "--stdin");
+
+    if file.is_some() && stdin_flag {
+        eprintln!("pass either --file or --stdin, not both");
+        return EXIT_USAGE;
+    }
+
+    // 1. Read the synthesized body.
+    let raw = if let Some(path) = file {
+        match fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("cannot read '{path}': {e}");
+                return EXIT_IO;
+            }
+        }
+    } else if stdin_flag || !std::io::stdin().is_terminal() {
+        let mut s = String::new();
+        if std::io::stdin().read_to_string(&mut s).is_err() {
+            eprintln!("cannot read body from stdin");
+            return EXIT_IO;
+        }
+        s
+    } else {
+        eprintln!("provide the synthesized body via --file <path> or --stdin");
+        return EXIT_USAGE;
+    };
+
+    // 2. Resolve the pending manifest (join key = skill name).
+    let pending = match find_pending(&skill) {
+        Some(p) => p,
+        None => {
+            eprintln!("no pending-synthesis manifest for skill '{skill}'");
+            return EXIT_NO_MANIFEST;
+        }
+    };
+
+    // 3. Validate the body.
+    let body = match validate_body(&raw) {
+        Some(b) => b,
+        None => {
+            eprintln!(
+                "body rejected: must be 80-6000 chars, no smuggled frontmatter, and contain '## Process' and '## Red Flags'"
+            );
+            return EXIT_VALIDATE;
+        }
+    };
+
+    // 4. Reassemble canonical frontmatter.
+    let assembled = assemble_skill(&skill, &pending.origin, &body);
+
+    // 5. Higher-confidence guard: refuse to downgrade a skill that a later
+    //    reflect re-seeded at higher confidence.
+    let existing_conf = fs::read_to_string(evolved_dir().join(&skill).join("meta.json"))
+        .ok()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+        .and_then(|v| v.get("confidence").and_then(|c| c.as_f64()));
+    if let Some(c) = existing_conf {
+        if c > pending.confidence + 1e-9 {
+            eprintln!(
+                "existing skill '{skill}' has higher confidence ({c:.2} > {:.2}); refusing to downgrade",
+                pending.confidence
+            );
+            return EXIT_DOWNGRADE;
+        }
+    }
+
+    // 6. Critic falsifiability gate — same gate as seed time. reward hacking
+    //    suppresses a claimed score lift.
+    let manifest = EditManifest {
+        edit_type: EditType::AddSkill,
+        target: skill.clone(),
+        intended_effect: format!(
+            "Upgrade evolved skill {skill} with a synthesized body ({})",
+            pending.origin
+        ),
+        predicted_impact: format!(
+            "Lift avg_score_with by reducing {} failures (confidence {:.2})",
+            pending.origin, pending.confidence
+        ),
+    };
+    let metrics: Metrics = read_json(&metrics_file(), Metrics::default());
+    if let CriticVerdict::Reject(reason) = Critic::verify_against_evidence(&manifest, &[], &metrics)
+    {
+        eprintln!("critic rejected: {reason}");
+        return EXIT_CRITIC;
+    }
+
+    // 7. Apply, gate, mark consumed, ledger.
+    write_skill_with_meta(&skill, &assembled, &pending.origin, pending.confidence);
+    gate_skills();
+    mark_consumed(&skill);
+    append_jsonl(&manifests_file(), &manifest);
+    hint(
+        "evolve",
+        &format!("synthesized body accepted for skill '{skill}'"),
+    );
+    EXIT_OK
+}
+
+/// Minimal `--flag value` / `--flag=value` parser (mirrors main.rs).
+fn flag(args: &[String], name: &str) -> Option<String> {
+    let eq = format!("{name}=");
+    args.iter()
+        .find(|a| a.starts_with(&eq))
+        .map(|a| a[eq.len()..].to_string())
+        .or_else(|| {
+            args.iter()
+                .position(|a| a == name)
+                .and_then(|i| args.get(i + 1))
+                .cloned()
+        })
+}

--- a/src/evolve/cli.rs
+++ b/src/evolve/cli.rs
@@ -168,3 +168,106 @@ fn flag(args: &[String], name: &str) -> Option<String> {
                 .cloned()
         })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    // ── flag() parser ──────────────────────────────────────
+
+    #[test]
+    fn flag_reads_space_separated_value() {
+        let a = args(&["--skill", "evo-fix-test-fail"]);
+        assert_eq!(flag(&a, "--skill").as_deref(), Some("evo-fix-test-fail"));
+    }
+
+    #[test]
+    fn flag_reads_equals_separated_value() {
+        let a = args(&["--skill=evo-fix-test-fail"]);
+        assert_eq!(flag(&a, "--skill").as_deref(), Some("evo-fix-test-fail"));
+    }
+
+    #[test]
+    fn flag_missing_returns_none() {
+        let a = args(&["--file", "body.md"]);
+        assert_eq!(flag(&a, "--skill"), None);
+    }
+
+    #[test]
+    fn flag_at_end_with_no_value_returns_none() {
+        let a = args(&["--skill"]);
+        assert_eq!(flag(&a, "--skill"), None);
+    }
+
+    // ── run() dispatch ─────────────────────────────────────
+
+    #[test]
+    fn run_with_no_subcommand_is_usage_error() {
+        assert_eq!(run(&args(&["evolve"])), EXIT_USAGE);
+    }
+
+    #[test]
+    fn run_with_unknown_subcommand_is_usage_error() {
+        assert_eq!(run(&args(&["evolve", "bogus"])), EXIT_USAGE);
+    }
+
+    // ── run_accept_synth: validation branches that never touch
+    //    harness_dir() (a process-global LazyLock, so filesystem-backed
+    //    end-to-end coverage belongs in an integration test, not here) ──
+
+    #[test]
+    fn accept_synth_missing_skill_is_usage_error() {
+        let a = args(&["evolve", "accept-synth", "--file", "body.md"]);
+        assert_eq!(run(&a), EXIT_USAGE);
+    }
+
+    #[test]
+    fn accept_synth_empty_skill_is_usage_error() {
+        let a = args(&["evolve", "accept-synth", "--skill", "", "--stdin"]);
+        assert_eq!(run(&a), EXIT_USAGE);
+    }
+
+    #[test]
+    fn accept_synth_file_and_stdin_together_is_usage_error() {
+        let a = args(&[
+            "evolve",
+            "accept-synth",
+            "--skill",
+            "evo-fix-test-fail",
+            "--file",
+            "body.md",
+            "--stdin",
+        ]);
+        assert_eq!(run(&a), EXIT_USAGE);
+    }
+
+    #[test]
+    fn accept_synth_unreadable_file_is_io_error() {
+        let a = args(&[
+            "evolve",
+            "accept-synth",
+            "--skill",
+            "evo-fix-test-fail",
+            "--file",
+            "/nonexistent/path/does-not-exist-8f3a.md",
+        ]);
+        assert_eq!(run(&a), EXIT_IO);
+    }
+
+    #[test]
+    fn accept_synth_no_source_is_usage_error() {
+        // Neither --file nor --stdin, and stdin is not piped in a `cargo test`
+        // process — falls through to the "provide a source" branch.
+        let a = args(&["evolve", "accept-synth", "--skill", "evo-fix-test-fail"]);
+        // Only assert this when stdin is actually a terminal (interactive);
+        // under a CI runner with redirected stdin this could read from stdin
+        // instead, so skip rather than flake.
+        if std::io::stdin().is_terminal() {
+            assert_eq!(run(&a), EXIT_USAGE);
+        }
+    }
+}

--- a/src/evolve/mod.rs
+++ b/src/evolve/mod.rs
@@ -1,4 +1,5 @@
 pub mod analysis;
+pub mod cli;
 pub mod critic;
 pub mod digester;
 pub mod edits;

--- a/src/evolve/skills.rs
+++ b/src/evolve/skills.rs
@@ -526,15 +526,15 @@ pub fn seed_smart_skills(
     let mut counters = load_promotion_counters();
     let mut plan = plan_skill_edits(analysis, existing, &mut counters);
 
-    // LLM synthesis pass: replace template bodies with skill content
-    // synthesized from this session's real failure evidence. Runs between
-    // the pure planner and the executor so both stay unchanged; synthesized
-    // content passes the same validate/Critic/gate path as templates.
-    let synthesized = crate::evolve::synthesis::upgrade_edits(&mut plan.edits, analysis);
-    if synthesized > 0 {
+    // Synthesis manifest pass: emit pending-synthesis manifests (failure
+    // evidence + template body) for up to N seeded skills. A host agent
+    // upgrades them later via `epic-harness evolve accept-synth`. Runs between
+    // the planner and the executor; skills keep template bodies until upgraded.
+    let emitted = crate::evolve::synthesis::upgrade_edits(&mut plan.edits, analysis);
+    if emitted > 0 {
         hint(
             "reflect",
-            &format!("LLM synthesis: {synthesized} skill(s) synthesized from failure evidence"),
+            &format!("Synthesis: {emitted} pending manifest(s) emitted for host-agent synthesis"),
         );
     }
 

--- a/src/evolve/synthesis.rs
+++ b/src/evolve/synthesis.rs
@@ -1,151 +1,177 @@
-//! LLM-backed skill synthesis (Ring 3, the step templates could never do).
+//! Host-agnostic skill synthesis (Ring 3, the step templates could never do).
 //!
 //! The template builders in `skills.rs` emit the same generic advice for any
-//! failure. This module replaces a planned skill's body with one synthesized
-//! by a headless `claude -p` call from the session's REAL failure evidence
-//! (error snippets, category counts, detected patterns). The synthesized body
-//! flows through the exact same gates as template content: `HarnessEdit::
-//! validate()`, the Critic falsifiability gate, and `gate_skills()`.
+//! failure. This module records a **pending-synthesis manifest** for each
+//! seeded skill, carrying the session's REAL failure evidence (error snippets,
+//! category counts, detected patterns) plus the template body. A host agent
+//! (claude/codex/agy) — using ITS OWN subagent mechanism, with no model
+//! specified — reads the manifest, synthesizes a better body, and hands it back
+//! via `epic-harness evolve accept-synth`, which runs the synthesized body
+//! through the exact same gates as template content: `validate_body`, the
+//! Critic falsifiability gate, and `gate_skills()`.
 //!
-//! Failure of any kind — CLI missing, timeout, empty or malformed output —
-//! falls back to the template content the planner already produced. Synthesis
+//! If no host ever runs `accept-synth`, the template body persists — synthesis
 //! can only improve a skill, never block seeding.
 //!
-//! Recursion guard: the child process runs with `EPIC_SYNTH_CHILD=1` (blocks
-//! nested synthesis) and `EPIC_HOOK_PROFILE=minimal` (skips reflect/polish/
-//! snapshot hooks inside the child session).
+//! Host-agnostic by construction: this module references no CLI binary and no
+//! model name. The previous design spawned a synchronous `claude -p` subprocess
+//! from the SessionEnd `reflect` hook; that hung under slow/remote hosts and
+//! coupled the harness to one CLI. The manifest protocol removes the subprocess
+//! entirely — Rust only reads and writes JSONL.
 
-use std::io::Read;
-use std::io::Write;
-use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
 
 use crate::config::CONFIG;
 use crate::evolve::edits::HarnessEdit;
-use crate::shared::evolution::SessionAnalysis;
-use crate::shared::helpers::hint;
+use crate::shared::evolution::{DetectedPattern, SessionAnalysis};
+use crate::shared::helpers::{append_jsonl, now_iso, read_jsonl_typed};
+use crate::shared::paths::pending_synth_file;
 use crate::shared::sanitize::sanitize_skill_content;
-
-/// Set in the synthesis child's environment; its presence disables synthesis.
-pub const SYNTH_CHILD_ENV: &str = "EPIC_SYNTH_CHILD";
-/// Force-enable synthesis in debug builds (manual testing).
-pub const SYNTH_FORCE_ENV: &str = "EPIC_SYNTH_FORCE";
 
 /// Hard bounds on an accepted synthesized body.
 const BODY_MIN_CHARS: usize = 80;
 const BODY_MAX_CHARS: usize = 6_000;
+/// Bound on accumulated pending manifests so the file never grows unbounded.
+/// Oldest (by `created`) are dropped when exceeded.
+const MAX_PENDING_SYNTH: usize = 30;
 
-/// Whether synthesis may run in this process.
-///
-/// - Never inside a synthesis child (recursion guard).
-/// - Never in debug builds (test determinism) unless EPIC_SYNTH_FORCE=1.
-/// - Otherwise governed by `[evolution] llm_synthesis` (default: on).
+/// Failure evidence packaged for a host agent. All fields are already
+/// secret-masked and sanitized at analysis time (`collect_error_snippets`),
+/// so they are safe to hand to any host.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SynthEvidence {
+    /// Representative error snippets (one per failure category), cap 8.
+    #[serde(default)]
+    pub error_snippets: Vec<String>,
+    /// Failure category → count, highest-count first, cap 8.
+    #[serde(default)]
+    pub failure_category_counts: HashMap<String, u64>,
+    /// Detected failure patterns, cap 4.
+    #[serde(default)]
+    pub failure_patterns: Vec<DetectedPattern>,
+}
+
+/// One pending-synthesis record. Emitted by `reflect`'s `upgrade_edits`,
+/// consumed by `epic-harness evolve accept-synth`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingSynth {
+    pub schema_version: u32,
+    /// Join key — matches `AddSkill.name`.
+    pub skill_name: String,
+    pub origin: String,
+    /// From `AddSkill.confidence`; used by the higher-confidence guard.
+    pub confidence: f64,
+    pub evidence: SynthEvidence,
+    /// Full SKILL.md (frontmatter + body) the planner produced — the fallback
+    /// if no host ever synthesizes.
+    pub template_content: String,
+    /// Host-neutral instructions the synthesizing subagent follows.
+    pub prompt_guidance: String,
+    pub created: String,
+    /// "pending" | "synthesized".
+    #[serde(default = "default_status")]
+    pub status: String,
+    #[serde(default)]
+    pub consumed: Option<String>,
+}
+
+fn default_status() -> String {
+    "pending".to_string()
+}
+
+/// Whether synthesis may run in this process — governed solely by config.
+/// (No subprocess anymore, so no recursion guard or debug-disable is needed;
+/// manifest emission is deterministic and testable.)
 pub fn synthesis_enabled() -> bool {
-    if std::env::var(SYNTH_CHILD_ENV).is_ok() {
-        return false;
-    }
-    if std::env::var(SYNTH_FORCE_ENV).is_ok() {
-        return true;
-    }
-    if cfg!(debug_assertions) {
-        return false;
-    }
     CONFIG.evolution.llm_synthesis
 }
 
-/// Upgrade up to `llm_synthesis_max_per_session` AddSkill edits in-place with
-/// LLM-synthesized bodies. Returns how many were upgraded. Edits keep their
-/// template content when synthesis is unavailable or fails.
+/// Emit a pending-synthesis manifest for up to `llm_synthesis_max_per_session`
+/// AddSkill edits. The edits keep their template `content` unchanged — the
+/// manifest is the upgrade channel, not the seed. Returns how many manifests
+/// were emitted.
 pub fn upgrade_edits(edits: &mut [HarnessEdit], analysis: &SessionAnalysis) -> usize {
     if !synthesis_enabled() {
         return 0;
     }
     let budget = CONFIG.evolution.llm_synthesis_max_per_session;
-    let mut upgraded = 0usize;
+    let path = pending_synth_file();
+    let evidence = extract_evidence(analysis);
+    let mut emitted = 0usize;
     for edit in edits.iter_mut() {
-        if upgraded >= budget {
+        if emitted >= budget {
             break;
         }
         if let HarnessEdit::AddSkill {
             name,
             content,
             origin,
-            ..
+            confidence,
         } = edit
         {
-            match synthesize_skill(name, origin, analysis) {
-                Some(new_content) => {
-                    *content = new_content;
-                    upgraded += 1;
-                }
-                None => hint(
-                    "reflect",
-                    &format!("LLM synthesis failed for '{name}' — keeping template body"),
-                ),
-            }
+            let pending = PendingSynth {
+                schema_version: 1,
+                skill_name: name.clone(),
+                origin: origin.clone(),
+                confidence: *confidence,
+                evidence: evidence.clone(),
+                template_content: content.clone(),
+                prompt_guidance: prompt_guidance(name),
+                created: now_iso(),
+                status: "pending".into(),
+                consumed: None,
+            };
+            append_jsonl(&path, &pending);
+            emitted += 1;
         }
     }
-    upgraded
+    if emitted > 0 {
+        gc_pending(&path);
+    }
+    emitted
 }
 
-/// Synthesize a complete SKILL.md (frontmatter + body) for one skill.
-/// Returns None on any failure; the caller keeps the template content.
-fn synthesize_skill(name: &str, origin: &str, analysis: &SessionAnalysis) -> Option<String> {
-    let prompt = build_prompt(name, analysis);
-    let raw = run_synthesis_command(
-        &prompt,
-        Duration::from_secs(CONFIG.evolution.llm_synthesis_timeout_secs),
-    )?;
-    let body = validate_body(&raw)?;
-    Some(assemble_skill(name, origin, &body))
+/// Pull the bounded evidence a host agent needs out of a session analysis.
+/// Caps mirror the old `build_prompt` so manifests stay compact.
+pub fn extract_evidence(analysis: &SessionAnalysis) -> SynthEvidence {
+    let error_snippets = analysis.error_snippets.iter().take(8).cloned().collect();
+
+    let mut counts: Vec<(&String, &u64)> = analysis.per_error_stats.iter().collect();
+    counts.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
+    let failure_category_counts = counts
+        .into_iter()
+        .take(8)
+        .map(|(k, v)| (k.clone(), *v))
+        .collect();
+
+    let failure_patterns = analysis.failure_patterns.iter().take(4).cloned().collect();
+
+    SynthEvidence {
+        error_snippets,
+        failure_category_counts,
+        failure_patterns,
+    }
 }
 
-/// The synthesis prompt: real evidence in, a bounded skill body out.
-fn build_prompt(name: &str, analysis: &SessionAnalysis) -> String {
-    let mut evidence = String::new();
-
-    if !analysis.error_snippets.is_empty() {
-        evidence.push_str("Error snippets from the session (category, count, latest message):\n");
-        for s in analysis.error_snippets.iter().take(8) {
-            evidence.push_str("- ");
-            evidence.push_str(s);
-            evidence.push('\n');
-        }
-    }
-
-    let mut cats: Vec<_> = analysis.per_error_stats.iter().collect();
-    cats.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
-    if !cats.is_empty() {
-        evidence.push_str("\nFailure category counts:\n");
-        for (cat, count) in cats.iter().take(8) {
-            evidence.push_str(&format!("- {cat}: {count}\n"));
-        }
-    }
-
-    for p in analysis.failure_patterns.iter().take(4) {
-        evidence.push_str(&format!(
-            "\nDetected pattern: {} ({}x) — {}. Files: {}\n",
-            p.pattern_type,
-            p.count,
-            p.description,
-            if p.involved_files.is_empty() {
-                "various".to_string()
-            } else {
-                p.involved_files.join(", ")
-            },
-        ));
-    }
-
+/// Host-neutral synthesis instructions. No CLI or model name — the host uses
+/// its own subagent mechanism.
+pub fn prompt_guidance(name: &str) -> String {
     format!(
-        "You are writing the body of a Claude Code skill named '{name}'. It will be \
-injected into future coding sessions in THIS project to prevent the failures below \
-from recurring.\n\n{evidence}\n\
-Write concrete, project-specific guidance grounded in the errors above — name the \
-actual error messages, files, and commands involved. Generic advice (\"read the \
-error carefully\") is worthless and will be rejected.\n\n\
+        "You are writing the body of an agent skill named '{name}'. It will be \
+injected into future coding sessions in THIS project to prevent the failures \
+recorded in the `evidence` field from recurring.\n\n\
+Using the `evidence` (error snippets, failure category counts, detected \
+patterns) from the accompanying manifest, write concrete, project-specific \
+guidance grounded in those errors — name the actual error messages, files, and \
+commands involved. Generic advice (\"read the error carefully\") is worthless \
+and will be rejected.\n\n\
 Output ONLY markdown body text (no YAML frontmatter, no code fences around the \
 whole output, no preamble) with exactly these sections:\n\
-## Process\n(numbered steps tied to the specific failures above)\n\
+## Process\n(numbered steps tied to the specific failures)\n\
 ## Anti-Rationalization\n(markdown table: Excuse | Rebuttal)\n\
 ## Evidence Required\n(checklist proving the failure class is fixed)\n\
 ## Red Flags\n(bullet list of early warnings specific to these errors)\n\n\
@@ -153,57 +179,59 @@ Hard limit: 60 lines."
     )
 }
 
-/// Run the synthesis command with the prompt on stdin and a wall-clock
-/// deadline. Returns captured stdout on clean exit, None otherwise.
-fn run_synthesis_command(prompt: &str, timeout: Duration) -> Option<String> {
-    let cmd = &CONFIG.evolution.llm_synthesis_cmd;
-    let mut command = Command::new(cmd);
-    command.arg("-p");
-    let model = &CONFIG.evolution.llm_synthesis_model;
-    if !model.is_empty() {
-        command.arg("--model").arg(model);
-    }
-    command
-        .env(SYNTH_CHILD_ENV, "1")
-        .env("EPIC_HOOK_PROFILE", "minimal")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null());
+/// Find the first pending manifest for a skill (the join key).
+pub fn find_pending(skill_name: &str) -> Option<PendingSynth> {
+    read_jsonl_typed::<PendingSynth>(&pending_synth_file())
+        .into_iter()
+        .find(|r| r.status == "pending" && r.skill_name == skill_name)
+}
 
-    let mut child = command.spawn().ok()?;
-    {
-        let mut stdin = child.stdin.take()?;
-        stdin.write_all(prompt.as_bytes()).ok()?;
-        // stdin drops here → EOF, the CLI starts generating.
+/// Mark every pending manifest for a skill as synthesized. Idempotent — a
+/// second call finds no pending record and does nothing.
+pub fn mark_consumed(skill_name: &str) {
+    let path = pending_synth_file();
+    let mut records: Vec<PendingSynth> = read_jsonl_typed(&path);
+    if records.is_empty() {
+        return;
     }
-
-    let deadline = Instant::now() + timeout;
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                if !status.success() {
-                    return None;
-                }
-                break;
-            }
-            Ok(None) => {
-                if Instant::now() >= deadline {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return None;
-                }
-                std::thread::sleep(Duration::from_millis(150));
-            }
-            Err(_) => {
-                let _ = child.kill();
-                return None;
-            }
+    let now = now_iso();
+    let mut changed = false;
+    for r in records.iter_mut() {
+        if r.status == "pending" && r.skill_name == skill_name {
+            r.status = "synthesized".into();
+            r.consumed = Some(now.clone());
+            changed = true;
         }
     }
+    if changed {
+        rewrite_jsonl(&path, &records);
+    }
+}
 
-    let mut out = String::new();
-    child.stdout.take()?.read_to_string(&mut out).ok()?;
-    Some(out)
+/// Drop consumed records and cap pending growth (oldest first by `created`,
+/// which is ISO-8601 so lexical order is chronological).
+fn gc_pending(path: &Path) {
+    let mut records: Vec<PendingSynth> = read_jsonl_typed(path);
+    records.retain(|r| r.status == "pending");
+    if records.len() > MAX_PENDING_SYNTH {
+        records.sort_by(|a, b| b.created.cmp(&a.created));
+        records.truncate(MAX_PENDING_SYNTH);
+    }
+    rewrite_jsonl(path, &records);
+}
+
+fn rewrite_jsonl(path: &Path, records: &[PendingSynth]) {
+    use std::io::Write;
+    let tmp = path.with_extension("jsonl.tmp");
+    let Ok(mut f) = fs::File::create(&tmp) else {
+        return;
+    };
+    for r in records {
+        if let Ok(j) = serde_json::to_string(r) {
+            let _ = writeln!(f, "{j}");
+        }
+    }
+    let _ = fs::rename(&tmp, path);
 }
 
 /// Validate and normalize a synthesized body. Rejects output that is too
@@ -230,11 +258,11 @@ pub(crate) fn validate_body(raw: &str) -> Option<String> {
     Some(sanitize_skill_content(body))
 }
 
-/// Wrap a validated body in canonical frontmatter. The `llm` origin marker
+/// Wrap a validated body in canonical frontmatter. The origin marker
 /// distinguishes synthesized skills in meta.json and the rejected buffer.
-fn assemble_skill(name: &str, origin: &str, body: &str) -> String {
+pub(crate) fn assemble_skill(name: &str, origin: &str, body: &str) -> String {
     sanitize_skill_content(&format!(
-        "---\nname: {name}\ndescription: \"Auto-evolved ({origin}, LLM-synthesized from session failure evidence).\"\n---\n\n# {name}\n\n{body}\n"
+        "---\nname: {name}\ndescription: \"Auto-evolved ({origin}, synthesized from session failure evidence).\"\n---\n\n# {name}\n\n{body}\n"
     ))
 }
 
@@ -250,6 +278,29 @@ mod tests {
 ## Red Flags\n- E0308 mismatched types in store/metrics.rs\n{}",
             " ".repeat(0)
         )
+    }
+
+    fn analysis_with(snippets: usize, patterns: usize) -> SessionAnalysis {
+        let error_snippets = (0..snippets)
+            .map(|i| format!("[cat{i} x9] error message {i}"))
+            .collect();
+        let per_error_stats = (0..snippets).map(|i| (format!("cat{i}"), 9u64)).collect();
+        let failure_patterns = (0..patterns)
+            .map(|i| DetectedPattern {
+                pattern_type: "repeated_same_error".into(),
+                description: format!("desc {i}"),
+                count: i as u64 + 1,
+                involved_files: vec![format!("src/{i}.rs")],
+                suggested_remediation: "fix root cause".into(),
+                implicated_components: vec![],
+            })
+            .collect();
+        SessionAnalysis {
+            error_snippets,
+            per_error_stats,
+            failure_patterns,
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -289,31 +340,42 @@ mod tests {
     fn assemble_produces_canonical_frontmatter() {
         let skill = assemble_skill("evo-fix-test-fail", "high_freq_error", &valid_body());
         assert!(skill.starts_with("---\nname: evo-fix-test-fail\n"));
-        assert!(skill.contains("LLM-synthesized"));
+        assert!(skill.contains("synthesized"));
         assert!(skill.contains("## Process"));
     }
 
     #[test]
-    fn prompt_embeds_evidence() {
-        let analysis = crate::shared::evolution::SessionAnalysis {
-            error_snippets: vec!["[test_fail x4] assertion failed: left == right".into()],
-            per_error_stats: [("test_fail".to_string(), 4u64)].into_iter().collect(),
-            ..Default::default()
-        };
-        let prompt = build_prompt("evo-fix-test-fail", &analysis);
-        assert!(prompt.contains("assertion failed"));
-        assert!(prompt.contains("test_fail: 4"));
-        assert!(prompt.contains("## Process"));
+    fn extract_evidence_caps_snippets_and_patterns() {
+        let analysis = analysis_with(12, 7);
+        let ev = extract_evidence(&analysis);
+        assert_eq!(ev.error_snippets.len(), 8);
+        assert_eq!(ev.failure_patterns.len(), 4);
+        // category counts cap at 8 and are sorted by count desc then name
+        assert_eq!(ev.failure_category_counts.len(), 8);
     }
 
     #[test]
-    fn synthesis_disabled_in_child_env() {
-        // SAFETY: EPIC_SYNTH_CHILD is only touched by this single test, so
-        // the mutation cannot race with other tests.
-        unsafe {
-            std::env::set_var(SYNTH_CHILD_ENV, "1");
-            assert!(!synthesis_enabled());
-            std::env::remove_var(SYNTH_CHILD_ENV);
-        }
+    fn extract_evidence_preserves_category_order() {
+        let analysis = SessionAnalysis {
+            per_error_stats: [("low".to_string(), 1u64), ("high".to_string(), 9u64)]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+        let ev = extract_evidence(&analysis);
+        assert_eq!(ev.failure_category_counts.get("high"), Some(&9));
+        assert_eq!(ev.failure_category_counts.get("low"), Some(&1));
+    }
+
+    #[test]
+    fn prompt_guidance_is_host_neutral() {
+        let g = prompt_guidance("evo-fix-test-fail");
+        // Names the skill and required sections...
+        assert!(g.contains("evo-fix-test-fail"));
+        assert!(g.contains("## Process"));
+        assert!(g.contains("## Red Flags"));
+        // ...but never a host CLI or model.
+        assert!(!g.to_lowercase().contains("claude"));
+        assert!(!g.to_lowercase().contains("haiku"));
     }
 }

--- a/src/evolve/synthesis.rs
+++ b/src/evolve/synthesis.rs
@@ -179,11 +179,17 @@ Hard limit: 60 lines."
     )
 }
 
-/// Find the first pending manifest for a skill (the join key).
+/// Find the most recent pending manifest for a skill (the join key). If
+/// `reflect` ran more than once before `accept-synth` consumed the backlog,
+/// several pending records can accumulate for the same skill — the newest
+/// carries the freshest failure evidence, so it wins. `mark_consumed` still
+/// marks every pending record for the skill as consumed, so older records
+/// never resurface as separate synthesis targets.
 pub fn find_pending(skill_name: &str) -> Option<PendingSynth> {
     read_jsonl_typed::<PendingSynth>(&pending_synth_file())
         .into_iter()
-        .find(|r| r.status == "pending" && r.skill_name == skill_name)
+        .filter(|r| r.status == "pending" && r.skill_name == skill_name)
+        .max_by(|a, b| a.created.cmp(&b.created))
 }
 
 /// Mark every pending manifest for a skill as synthesized. Idempotent — a

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,10 @@ fn main() {
         let code = team::run_org(&args[1..]);
         std::process::exit(code);
     }
+    if subcmd == "evolve" {
+        let code = evolve::cli::run(&args[1..]);
+        std::process::exit(code);
+    }
     if subcmd == "eval" {
         let code = eval::run(&args[2..]);
         std::process::exit(code);
@@ -243,6 +247,12 @@ fn main() {
             eprintln!("    --all-projects       All projects under ~/.harness/projects/");
             eprintln!(
                 "    --source <name>      Extra context source: harness|claude-session|alcove|all (repeatable)\n"
+            );
+            eprintln!("EVOLUTION:");
+            eprintln!("  evolve       Skill synthesis handshake (host-agent)");
+            eprintln!("    accept-synth --skill <name> [--file <path> | --stdin]");
+            eprintln!(
+                "                       Apply a synthesized body to a pending-synth manifest"
             );
             eprintln!("USER SUBCOMMANDS:");
             eprintln!("  eval         Project quality & regression evaluation  (epic eval --init)");

--- a/src/shared/paths.rs
+++ b/src/shared/paths.rs
@@ -195,6 +195,16 @@ pub fn manifests_file() -> PathBuf {
     harness_dir().join("manifests.jsonl")
 }
 
+/// Per-project pending-synthesis manifest log. Each seeded skill eligible for
+/// host-agent synthesis gets one record here; `epic-harness evolve
+/// accept-synth` consumes them. Unconsumed records leave the template skill
+/// body in place — synthesis can only improve a skill, never block seeding.
+/// (Dedicated file: `EditManifest` in `manifests.jsonl` is the falsifiability
+/// ledger and shares no fields with a pending-synthesis record.)
+pub fn pending_synth_file() -> PathBuf {
+    harness_dir().join("pending_synth.jsonl")
+}
+
 /// Resolve the per-project harness dir for a request. Falls back to the
 /// CWD-derived dir when `project` is `None`/empty (preserves existing callers
 /// that don't pass a project). Used by the dashboard read-path to scope


### PR DESCRIPTION
## 배경

orbit Step 7(Evolve)에서 `epic-harness reflect`가 **최대 3분 hang**하거나 타임아웃되는 문제를 해결합니다.

Ring 3 스킬 합성이 SessionEnd `reflect` 훅 안에서 **동기 `claude -p --model haiku` 서브프로세스**를 호출했는데:
- z.ai 환경에서 `claude -p haiku`는 trivial 응답에 13–17초, 합성 길이는 30초+인데 타임아웃이 **10초** → 구조적 실패
- stdout 파이프를 drain하지 않은 채 폴링 → **교착(deadlock)** → reflect hang
- `claude`/`haiku`로 host 고정 → codex/agy 대응 불가

## 변경

합성을 Rust 동기 서브프로세스에서 **host-agnostic 매니페스트 프로토콜**로 전환했습니다.

- **reflect** → `pending_synth.jsonl`에 pending-synthesis 매니페스트(마스킹된 failure evidence + 템플릿 본문) emit (`upgrade_edits` 재작성)
- **호스트 에이전트**(claude/codex/agy)가 **자기 서브에이전트 메커니즘**(모델 미지정)으로 본문 합성 → 새 CLI `epic-harness evolve accept-synth --skill <name> [--file|--stdin]`로 제출
- `accept-synth`는 `validate_body` → Critic 게이트 → `write_skill_with_meta` → `gate_skills` → 매니페스트 consumed 표시 수행
- Rust는 **host CLI/모델 이름 0 참조** (`src/evolve`에서 claude/haiku 0건)
- 미처리 매니페스트는 템플릿 본문 유지 — 합성은 스킬을 개선만 하고 시딩을 블록하지 않음

제거: `llm_synthesis_cmd`/`_model`/`_timeout_secs` config 필드 + claude -p / 재귀가드 코드. 유지: `llm_synthesis`(게이트), `llm_synthesis_max_per_session`.

| 파일 | 변경 |
|------|------|
| `src/evolve/synthesis.rs` | claude -p 제거 → `PendingSynth`/`SynthEvidence` + `extract_evidence`/`prompt_guidance`/`upgrade_edits`/`find_pending`/`mark_consumed` |
| `src/evolve/cli.rs` | **신규** — `accept-synth` 제어흐름 (exit 0/2/3/4/5/6/64) |
| `src/shared/paths.rs` | `pending_synth_file()` |
| `src/main.rs` | `evolve` 서브커맨드 dispatch + 도움말 |
| `src/config.rs` | host 결합 필드 3개 제거 |
| `src/evolve/skills.rs` · `mod.rs` | emit hint + cli 모듈 등록 |
| `skills/evolve/SKILL.md` · `skills/orbit/SKILL.md` | host-neutral 합성 절차 |
| `AGENTS.md` · `docs/architecture.md` | 섹션 재작성 |

## 검증

- `cargo test` — **662 passed, 0 failed** (synthesis 신규 9 + 회귀)
- `cargo clippy --all-targets -- -D warnings` — 깨끗
- `cargo fmt --check` — clean
- `cargo build --release` — 성공
- host-agnostic 정적 확인: `grep claude\|haiku src/evolve/` → **0건**
- end-to-end smoke: `accept-synth` exit 0 + SKILL.md 합성 본문 반영 + 매니페스트 `status=synthesized` + 멱등 재실행 exit 2 (검증 후 정리)

## 별도 PR

SQLite `near "DO"` reflect 노이즈는 **이 PR과 무관**합니다. `ON CONFLICT DO UPDATE` UPSERT는 정상(`init_schema_pool_is_idempotent` 테스트 통과)이고 reflect는 JSONL로 폴백하므로 non-blocking. 별도 PR에서 원인 확정(`sqlite_version()` 로깅) 후 처리합니다.