### PR TITLE
chore(dist): enable homebrew tap auto-publish

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,7 +8,10 @@ cargo-dist-version = "0.31.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = ["shell", "powershell"]
+installers = ["shell", "powershell", "homebrew"]
+# Homebrew tap repository
+tap = "epicsagas/homebrew-tap"
+publish-jobs = ["homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Skip checking whether the specified configuration files are up to date


### PR DESCRIPTION
## Why

The 0.8.2 release shipped binaries but **no Homebrew formula reached `epicsagas/homebrew-tap`**, leaving `brew upgrade` stuck at 0.8.1. Root cause: `dist-workspace.toml`'s `installers` omitted `homebrew`, so cargo-dist never generated/published a formula — even though `release.yml` already had an `update-homebrew` job waiting for one.

## Change

```toml
installers = ["shell", "powershell", "homebrew"]
tap = "epicsagas/homebrew-tap"
publish-jobs = ["homebrew"]
```

Matches the working config already used by `obsidian-forge`.

## Verified

- `cargo dist plan` → `The Homebrew publish job is enabled` ✅
- (cosmetic WARN about `homepage` — field already present in `Cargo.toml`; cargo-dist version skew, non-blocking, same as obsidian-forge)

## Effect

From the next release (0.8.3+) cargo-dist will auto-generate the formula and push it to the tap. The one-off manual formula for 0.8.2 already shipped to the tap (commit `9633e93`), so this PR is purely forward-looking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)